### PR TITLE
Setting User's Status (Working and Synced with the web client)

### DIFF
--- a/Rocket.Chat.iOS.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.iOS.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		DF113AE91BA6D91000CE6D17 /* MyAccountBarTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF113AE81BA6D91000CE6D17 /* MyAccountBarTabViewController.swift */; };
 		DF2A60E61B8DC6280014548B /* RegisterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2A60E51B8DC6280014548B /* RegisterViewController.swift */; };
 		DF2A60E81B8DCD3A0014548B /* ForgotPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2A60E71B8DCD3A0014548B /* ForgotPasswordViewController.swift */; };
+		DF4928A51BFDCA3400B1F901 /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF4928A41BFDCA3400B1F901 /* DarwinNotifications.swift */; };
 		DF5F92611BAC4304000EA4C3 /* MessagesOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5F92601BAC4304000EA4C3 /* MessagesOptionsViewController.swift */; };
 		DF5F92631BAC4315000EA4C3 /* SoundOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5F92621BAC4315000EA4C3 /* SoundOptionsViewController.swift */; };
 		DF70828E1BED0FF9005B6192 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF70828D1BED0FF9005B6192 /* ChatMessage.swift */; };
@@ -129,6 +130,7 @@
 		DF113AE81BA6D91000CE6D17 /* MyAccountBarTabViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyAccountBarTabViewController.swift; sourceTree = "<group>"; };
 		DF2A60E51B8DC6280014548B /* RegisterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RegisterViewController.swift; path = ../RegisterViewController.swift; sourceTree = "<group>"; };
 		DF2A60E71B8DCD3A0014548B /* ForgotPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForgotPasswordViewController.swift; sourceTree = "<group>"; };
+		DF4928A41BFDCA3400B1F901 /* DarwinNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DarwinNotifications.swift; sourceTree = "<group>"; };
 		DF5F92601BAC4304000EA4C3 /* MessagesOptionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessagesOptionsViewController.swift; sourceTree = "<group>"; };
 		DF5F92621BAC4315000EA4C3 /* SoundOptionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SoundOptionsViewController.swift; sourceTree = "<group>"; };
 		DF70828D1BED0FF9005B6192 /* ChatMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
@@ -289,6 +291,7 @@
 				410CEB161B8B387B00CAFFE9 /* Cells */,
 				410CEB151B8B387500CAFFE9 /* ViewControllers */,
 				DFAB3D9B1B97323700B02020 /* Extensions */,
+				DF4928A41BFDCA3400B1F901 /* DarwinNotifications.swift */,
 				DF7F94C01BCFA67000B52126 /* RoomHistoryManager.swift */,
 				410CEB131B8B386E00CAFFE9 /* AppDelegate.swift */,
 				4FB7E4DB1B70111D00C69777 /* Main.storyboard */,
@@ -594,6 +597,7 @@
 				DF113AE91BA6D91000CE6D17 /* MyAccountBarTabViewController.swift in Sources */,
 				DF7C52C81BCB95C30087B2B4 /* GithubViewController.swift in Sources */,
 				410CEB1C1B8B388300CAFFE9 /* NoDetailsTableViewCell.swift in Sources */,
+				DF4928A51BFDCA3400B1F901 /* DarwinNotifications.swift in Sources */,
 				DF7C52C41BCB957A0087B2B4 /* FacebookViewController.swift in Sources */,
 				DF7C52CA1BCB95DC0087B2B4 /* LinkedInViewController.swift in Sources */,
 				4F18F6851BB3545500048D7E /* BaseViewController.swift in Sources */,

--- a/Rocket.Chat.iOS/AppDelegate.swift
+++ b/Rocket.Chat.iOS/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(application: UIApplication, willFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         
         //Subsribe to Collections
-//        self.meteorClient.addSubscription("activeUsers")
+        self.meteorClient.addSubscription("activeUsers")
 //        self.meteorClient.addSubscription("userData")
         self.meteorClient.addSubscription("subscription")
 

--- a/Rocket.Chat.iOS/AppDelegate.swift
+++ b/Rocket.Chat.iOS/AppDelegate.swift
@@ -10,174 +10,290 @@ import UIKit
 import MMDrawerController
 import ObjectiveDDP
 
+
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-  
-  var window: UIWindow?
-  
-  // Variable to keep the MMDrawerController instance
-  var centerContainer : MMDrawerController?
-  
-//    var meteorClient = initialiseMeteor("pre2", "ws://localhost:4000/websocket");
+    
+    var window: UIWindow?
+    
+    // Variable to keep the MMDrawerController instance
+    var centerContainer : MMDrawerController?
+    
+    //    var meteorClient = initialiseMeteor("pre2", "ws://localhost:4000/websocket");
     var meteorClient = initialiseMeteor("pre2", "https://demo.rocket.chat/websocket");
     
     
+    
     func application(application: UIApplication, willFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
+
+        
+        CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), nil, displayStatusChanged, "com.apple.springboard.lockcomplete", nil, CFNotificationSuspensionBehavior.DeliverImmediately)
         
         //Subsribe to Collections
         self.meteorClient.addSubscription("activeUsers")
-//        self.meteorClient.addSubscription("userData")
+        //        self.meteorClient.addSubscription("userData")
         self.meteorClient.addSubscription("subscription")
-
+        
         return true
     }
-  
-  func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
     
-    let observingOption = NSKeyValueObservingOptions.New
-    meteorClient.addObserver(self, forKeyPath:"websocketReady", options: observingOption, context:nil)
-    
-    
-    
-    NSNotificationCenter.defaultCenter().addObserver(self, selector: "reportConnectionReady", name: MeteorClientConnectionReadyNotification, object: nil)
-    NSNotificationCenter.defaultCenter().addObserver(self, selector: "reportConnection", name: MeteorClientDidConnectNotification, object: nil)
-    NSNotificationCenter.defaultCenter().addObserver(self, selector: "reportDisconnection", name:MeteorClientDidDisconnectNotification, object: nil)
-    
-    return true
-  }
-  
-  func reportConnectionReady() {
-    
-    print("Connection Ready\n")
-    connectWithSessionToken()
-
-  }
-  
-  func reportConnection() {
-    print("================> connected to server!")
-    
-    //Notify current rootview controller
-    let controller = self.window?.rootViewController
-
-    if let controllerType = controller as? LoginViewController {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         
-        controllerType.connectionStatus(true)
+        let observingOption = NSKeyValueObservingOptions.New
+        meteorClient.addObserver(self, forKeyPath:"websocketReady", options: observingOption, context:nil)
+        
+        
+        
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "reportConnectionReady", name: MeteorClientConnectionReadyNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "reportConnection", name: MeteorClientDidConnectNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "reportDisconnection", name:MeteorClientDidDisconnectNotification, object: nil)
+        
+        return true
+    }
 
-    } else if let controllerType = controller as? MMDrawerController {
-        
-        let centerContainerNavController = controllerType.centerViewController as! UINavigationController
-        
-        if let centerContainerOfMMDC = centerContainerNavController.viewControllers[0] as? ViewController {
+    
+    
+    
+    func applicationDidBecomeActive(application: UIApplication) {
+
+
+        if let previousStatus = NSUserDefaults.standardUserDefaults().valueForKey("previousStatus") as? String {
+
+            if previousStatus == "away" {
+                
+                //Do nothing
             
-            centerContainerOfMMDC.connectionStatus(true)
+            } else {
+                
+                
+                self.restorePreviousStatus(previousStatus)
 
-        }
-    }
-  }
-  
-  func reportDisconnection() {
-    print("================> disconnected from server!")
-    
-    //notify current rootview controller
-    let controller = self.window?.rootViewController
+                
+            }
 
-    if let controllerType = controller as? LoginViewController {
-        
-        controllerType.connectionStatus(false)
-        
-    } else if let controllerType = controller as? MMDrawerController {
-        
-        let centerContainerNavController = controllerType.centerViewController as! UINavigationController
-        
-        if let centerContainerOfMMDC = centerContainerNavController.viewControllers[0] as? ViewController {
-            
-            centerContainerOfMMDC.connectionStatus(false)
-
-        }
-    }
-
-    }
-  
-  // MARK: - Connection
-  override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<(Void)>) {
-    
-    if (keyPath == "websocketReady" && meteorClient.websocketReady) {
-      //      connectionStatusText.text = "Connected to Todo Server"
-      //      var image:UIImage = UIImage(named: "green_light.png")!
-      //      connectionStatusLight.image = image
-      print("connected to server!!!")
-
-    }
-  }
-  
-  
-  func connectWithSessionToken() {
-    
-    
-    let defaults = NSUserDefaults.standardUserDefaults()
-    if let sessionToken = defaults.stringForKey("sessionToken") {
-      print("sessionToken: \(sessionToken)")
-      
-      
-      
-      meteorClient.logonWithSessionToken(sessionToken, responseCallback: {(response, error) -> Void in
-        
-        if((error) != nil) {
-            
-          print("error!!! \(error)")
-          return
             
         }
-        print("\(response)\n")
         
-        let appDelegate:AppDelegate = UIApplication.sharedApplication().delegate as! AppDelegate
+    }
+    
+
+    
+    func applicationDidEnterBackground(application: UIApplication) {
         
+        let state:UIApplicationState = UIApplication.sharedApplication().applicationState
         
-        let mainStoryboard: UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
+        if (state == UIApplicationState.Inactive) {
+            
+            print("Sent to background by locking screen")
+            
+        } else if (state == UIApplicationState.Background) {
         
-        
-        //Create and store the center the left and the right views and keep them in variables
-        
-        //center view
-        let centerViewController = mainStoryboard.instantiateViewControllerWithIdentifier("viewController") as! ViewController
-        
-        //left view
-        let leftViewController = mainStoryboard.instantiateViewControllerWithIdentifier("leftView") as! LeftViewController
-        
-        //right view
-        let rightViewController = mainStoryboard.instantiateViewControllerWithIdentifier("rightView") as! RightViewController
-        
-        
-        //Set the left, right and center views as the rootviewcontroller for the navigation controller (one rootviewcontroller at a time)
-        
-        let leftSideNav = UINavigationController(rootViewController: leftViewController)
-        leftSideNav.setNavigationBarHidden(true, animated: false)
-        let centerNav = UINavigationController(rootViewController: centerViewController)
-        let rightNav = UINavigationController(rootViewController: rightViewController)
-        
-        //Create the MMDrawerController and keep it in a variable named center container
-        let centerContainer:MMDrawerController = MMDrawerController(centerViewController: centerNav, leftDrawerViewController: leftSideNav,rightDrawerViewController:rightNav)
-        
-        //Open and Close gestures for the center container
-        
-        centerContainer.openDrawerGestureModeMask = MMOpenDrawerGestureMode.PanningCenterView;
-        centerContainer.closeDrawerGestureModeMask = MMCloseDrawerGestureMode.PanningCenterView;
-        
-        //Setting the width of th right view
-        //centerContainer.setMaximumRightDrawerWidth(appDelegate.window!.frame.width, animated: true, completion: nil)
-        
-        //Set the centerContainer in the appDelegate.swift as the center container
-        appDelegate.centerContainer = centerContainer
-        
-        //Set the rootViewController as the center container
-        appDelegate.window!.rootViewController = appDelegate.centerContainer
-        appDelegate.window!.makeKeyAndVisible()
-      })
-      
-      
+            if(!NSUserDefaults.standardUserDefaults().boolForKey("kDisplayStatusLocked")){
+                
+                print("Sent to background by home button/switching to other app")
+            
+            } else {
+                print("Sent to background by locking screen")
+                
+                //Closing the left view to remove the observer "userChange" because it interferes with restoring the status.
+                //If we don't close it then when setting the status to offline because we locked the device, the app get's notified 
+                //by this observer and the previousStatus(NSUserDefaults)  value is alway set to offline
+                centerContainer?.closeDrawerAnimated(false, completion: nil)
+                
+                self.restorePreviousStatus("away")
+                
+            }
+            
+        }
+    
     }
     
     
-  }
-  
+    func applicationWillEnterForeground(application: UIApplication) {
+
+        NSUserDefaults.standardUserDefaults().setBool(false, forKey: "kDisplayStatusLocked")
+        
+    }
+    
+    
+    func restorePreviousStatus(previousStatus: String) {
+        
+        
+        self.meteorClient.callMethodName("UserPresence:setDefaultStatus", parameters: [previousStatus], responseCallback: { (response, error) -> Void in
+            
+            if error != nil{
+                print("Error: \(error.description)")
+                return
+            }
+            
+            //                    print(response["result"])
+        })
+        
+        
+    }
+    
+    
+    // MARK: - connection
+    
+    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<(Void)>) {
+        
+        if (keyPath == "websocketReady" && meteorClient.websocketReady) {
+            //      connectionStatusText.text = "Connected to Todo Server"
+            //      var image:UIImage = UIImage(named: "green_light.png")!
+            //      connectionStatusLight.image = image
+            print("connected to server!!!")
+            
+        }
+    }
+    
+    
+    func reportConnectionReady() {
+        
+        print("Connection Ready\n")
+        connectWithSessionToken()
+        
+        
+        if(NSUserDefaults.standardUserDefaults().boolForKey("kDisplayStatusLocked")){
+            print("Sent to background by home button/switching to other app")
+        } else {
+            if let previousStatus = NSUserDefaults.standardUserDefaults().valueForKey("previousStatus") as? String {
+                print(previousStatus)
+                self.meteorClient.callMethodName("UserPresence:setDefaultStatus", parameters: [previousStatus], responseCallback: { (response, error) -> Void in
+                    
+                    if error != nil{
+                        print("Error: \(error.description)")
+                        return
+                    }
+                    
+                    //                    print(response["result"])
+                })
+                
+            }
+            
+        }
+        
+    }
+    
+    
+    
+    func reportConnection() {
+        print("================> connected to server!")
+        
+        //Notify current rootview controller
+        let controller = self.window?.rootViewController
+        
+        if let controllerType = controller as? LoginViewController {
+            
+            controllerType.connectionStatus(true)
+            
+        } else if let controllerType = controller as? MMDrawerController {
+            
+            let centerContainerNavController = controllerType.centerViewController as! UINavigationController
+            
+            if let centerContainerOfMMDC = centerContainerNavController.viewControllers[0] as? ViewController {
+                
+                centerContainerOfMMDC.connectionStatus(true)
+                
+            }
+        }
+    }
+    
+    
+    
+    func reportDisconnection() {
+        print("================> disconnected from server!")
+        
+        //notify current rootview controller
+        let controller = self.window?.rootViewController
+        
+        if let controllerType = controller as? LoginViewController {
+            
+            controllerType.connectionStatus(false)
+            
+        } else if let controllerType = controller as? MMDrawerController {
+            
+            let centerContainerNavController = controllerType.centerViewController as! UINavigationController
+            
+            if let centerContainerOfMMDC = centerContainerNavController.viewControllers[0] as? ViewController {
+                
+                centerContainerOfMMDC.connectionStatus(false)
+                
+            }
+        }
+        
+    }
+
+    
+    
+    func connectWithSessionToken() {
+        
+        
+        let defaults = NSUserDefaults.standardUserDefaults()
+        if let sessionToken = defaults.stringForKey("sessionToken") {
+            print("sessionToken: \(sessionToken)")
+            
+            
+            
+            meteorClient.logonWithSessionToken(sessionToken, responseCallback: {(response, error) -> Void in
+                
+                if((error) != nil) {
+                    
+                    print("error!!! \(error)")
+                    return
+                    
+                }
+                print("\(response)\n")
+                
+                let appDelegate:AppDelegate = UIApplication.sharedApplication().delegate as! AppDelegate
+                
+                
+                let mainStoryboard: UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
+                
+                
+                //Create and store the center the left and the right views and keep them in variables
+                
+                //center view
+                let centerViewController = mainStoryboard.instantiateViewControllerWithIdentifier("viewController") as! ViewController
+                
+                //left view
+                let leftViewController = mainStoryboard.instantiateViewControllerWithIdentifier("leftView") as! LeftViewController
+                
+                //right view
+                let rightViewController = mainStoryboard.instantiateViewControllerWithIdentifier("rightView") as! RightViewController
+                
+                
+                //Set the left, right and center views as the rootviewcontroller for the navigation controller (one rootviewcontroller at a time)
+                
+                let leftSideNav = UINavigationController(rootViewController: leftViewController)
+                leftSideNav.setNavigationBarHidden(true, animated: false)
+                let centerNav = UINavigationController(rootViewController: centerViewController)
+                let rightNav = UINavigationController(rootViewController: rightViewController)
+                
+                //Create the MMDrawerController and keep it in a variable named center container
+                let centerContainer:MMDrawerController = MMDrawerController(centerViewController: centerNav, leftDrawerViewController: leftSideNav,rightDrawerViewController:rightNav)
+                
+                //Open and Close gestures for the center container
+                
+                centerContainer.openDrawerGestureModeMask = MMOpenDrawerGestureMode.PanningCenterView;
+                centerContainer.closeDrawerGestureModeMask = MMCloseDrawerGestureMode.PanningCenterView;
+                
+                //Setting the width of th right view
+                //centerContainer.setMaximumRightDrawerWidth(appDelegate.window!.frame.width, animated: true, completion: nil)
+                
+                //Set the centerContainer in the appDelegate.swift as the center container
+                appDelegate.centerContainer = centerContainer
+                
+                //Set the rootViewController as the center container
+                appDelegate.window!.rootViewController = appDelegate.centerContainer
+                appDelegate.window!.makeKeyAndVisible()
+            })
+            
+            
+        }
+        
+        
+    }
+    
+    
+    
 }

--- a/Rocket.Chat.iOS/AppDelegate.swift
+++ b/Rocket.Chat.iOS/AppDelegate.swift
@@ -55,11 +55,48 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   
   func reportConnection() {
     print("================> connected to server!")
+    
+    //Notify current rootview controller
+    let controller = self.window?.rootViewController
+
+    if let controllerType = controller as? LoginViewController {
+        
+        controllerType.connectionStatus(true)
+
+    } else if let controllerType = controller as? MMDrawerController {
+        
+        let centerContainerNavController = controllerType.centerViewController as! UINavigationController
+        
+        if let centerContainerOfMMDC = centerContainerNavController.viewControllers[0] as? ViewController {
+            
+            centerContainerOfMMDC.connectionStatus(true)
+
+        }
+    }
   }
   
   func reportDisconnection() {
     print("================> disconnected from server!")
-  }
+    
+    //notify current rootview controller
+    let controller = self.window?.rootViewController
+
+    if let controllerType = controller as? LoginViewController {
+        
+        controllerType.connectionStatus(false)
+        
+    } else if let controllerType = controller as? MMDrawerController {
+        
+        let centerContainerNavController = controllerType.centerViewController as! UINavigationController
+        
+        if let centerContainerOfMMDC = centerContainerNavController.viewControllers[0] as? ViewController {
+            
+            centerContainerOfMMDC.connectionStatus(false)
+
+        }
+    }
+
+    }
   
   // MARK: - Connection
   override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<(Void)>) {
@@ -142,7 +179,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     
   }
-  
-  
   
 }

--- a/Rocket.Chat.iOS/Base.lproj/LeftMenu.storyboard
+++ b/Rocket.Chat.iOS/Base.lproj/LeftMenu.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
@@ -156,7 +156,7 @@
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="Yellow" translatesAutoresizingMaskIntoConstraints="NO" id="gfG-CM-ESz">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="Green" translatesAutoresizingMaskIntoConstraints="NO" id="gfG-CM-ESz">
                                 <rect key="frame" x="20" y="33" width="15" height="17"/>
                             </imageView>
                         </subviews>

--- a/Rocket.Chat.iOS/Base.lproj/Main.storyboard
+++ b/Rocket.Chat.iOS/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="adJ-xO-Vln">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="adJ-xO-Vln">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>

--- a/Rocket.Chat.iOS/Base.lproj/Main.storyboard
+++ b/Rocket.Chat.iOS/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="adJ-xO-Vln">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="adJ-xO-Vln">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -93,7 +93,7 @@
                                                     <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="15"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ofA-CU-Mw9">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ofA-CU-Mw9">
                                                     <rect key="frame" x="147" y="12" width="34" height="17"/>
                                                     <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="14"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
@@ -140,7 +140,7 @@
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H3y-Oj-f5r">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H3y-Oj-f5r">
                                                     <rect key="frame" x="49" y="6" width="34" height="17"/>
                                                     <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="14"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
@@ -206,16 +206,42 @@
                                     <constraint firstItem="viw-6B-0pw" firstAttribute="leading" secondItem="G3g-gb-Vuc" secondAttribute="leading" constant="24" id="vNd-YI-tMD"/>
                                 </constraints>
                             </view>
+                            <view hidden="YES" alpha="0.89999997615814209" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1ah-tf-R3M">
+                                <rect key="frame" x="0.0" y="64" width="320" height="30"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Trying to connect to the server" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uBk-gO-QCE">
+                                        <rect key="frame" x="55" y="6" width="211" height="18"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="eLJ-qS-vik">
+                                        <rect key="frame" x="27" y="5" width="20" height="20"/>
+                                        <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    </activityIndicatorView>
+                                </subviews>
+                                <color key="backgroundColor" red="1" green="0.89130022269999998" blue="0.0194558552" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstItem="uBk-gO-QCE" firstAttribute="centerX" secondItem="1ah-tf-R3M" secondAttribute="centerX" id="9Za-9f-h2w"/>
+                                    <constraint firstItem="eLJ-qS-vik" firstAttribute="centerY" secondItem="uBk-gO-QCE" secondAttribute="centerY" id="Dzg-IL-fz9"/>
+                                    <constraint firstItem="uBk-gO-QCE" firstAttribute="centerY" secondItem="1ah-tf-R3M" secondAttribute="centerY" id="Evd-sN-pMI"/>
+                                    <constraint firstItem="uBk-gO-QCE" firstAttribute="leading" secondItem="eLJ-qS-vik" secondAttribute="trailing" constant="8" symbolic="YES" id="JPB-66-iZy"/>
+                                    <constraint firstAttribute="height" constant="30" id="PWf-Af-JP2"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="trailingMargin" secondItem="G3g-gb-Vuc" secondAttribute="trailing" constant="-28" id="3To-cJ-80k"/>
                             <constraint firstItem="2Xy-Ja-dRg" firstAttribute="top" secondItem="G3g-gb-Vuc" secondAttribute="bottom" constant="8" id="7cd-OD-IE8"/>
                             <constraint firstAttribute="trailingMargin" secondItem="hUb-s7-0eT" secondAttribute="trailing" constant="-28" id="Hdr-EM-xxR"/>
+                            <constraint firstItem="1ah-tf-R3M" firstAttribute="leading" secondItem="ikq-l2-qYm" secondAttribute="leading" id="MQI-gJ-N4o"/>
+                            <constraint firstItem="1ah-tf-R3M" firstAttribute="centerX" secondItem="hUb-s7-0eT" secondAttribute="centerX" id="NRV-9f-0fI"/>
                             <constraint firstItem="G3g-gb-Vuc" firstAttribute="leading" secondItem="ikq-l2-qYm" secondAttribute="leadingMargin" constant="-28" id="UGi-yP-h4H"/>
                             <constraint firstItem="hUb-s7-0eT" firstAttribute="leading" secondItem="ikq-l2-qYm" secondAttribute="leadingMargin" constant="-28" id="c8k-wA-NbL"/>
                             <constraint firstItem="hUb-s7-0eT" firstAttribute="top" secondItem="QCZ-pr-dNw" secondAttribute="bottom" id="isC-oK-wMS"/>
                             <constraint firstItem="G3g-gb-Vuc" firstAttribute="top" secondItem="hUb-s7-0eT" secondAttribute="bottom" constant="8" id="r4I-6l-Yoi"/>
+                            <constraint firstItem="1ah-tf-R3M" firstAttribute="top" secondItem="hUb-s7-0eT" secondAttribute="top" id="uVp-sH-FAh"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="cQN-uN-CZi">
@@ -231,8 +257,11 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="activityIndicatorInViewController" destination="eLJ-qS-vik" id="mX0-6a-g0W"/>
                         <outlet property="bottomViewBottomConstraint" destination="7cd-OD-IE8" id="fq5-vH-q6f"/>
                         <outlet property="composeMsg" destination="viw-6B-0pw" id="8Ae-Ak-M9e"/>
+                        <outlet property="composeMsgButton" destination="8dJ-SW-7HW" id="vxS-Gp-fHr"/>
+                        <outlet property="customIndicatorViewInViewController" destination="1ah-tf-R3M" id="v0X-Ba-jFh"/>
                         <outlet property="mainTableview" destination="hUb-s7-0eT" id="0rl-la-xoh"/>
                         <outlet property="tableViewTopConstraint" destination="isC-oK-wMS" id="Kmz-fb-lhN"/>
                     </connections>
@@ -285,6 +314,37 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view hidden="YES" alpha="0.90000000000000002" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GOS-Kj-eur">
+                                <rect key="frame" x="-8" y="28" width="336" height="30"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Trying to connect to the server" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BmD-Eb-Er8">
+                                        <rect key="frame" x="63" y="6" width="211" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="211" id="V65-UL-BBb"/>
+                                            <constraint firstAttribute="height" constant="18" id="sBl-tw-WBl"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="Edn-5E-aqP">
+                                        <rect key="frame" x="35" y="5" width="20" height="20"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="20" id="UmH-NE-VqS"/>
+                                            <constraint firstAttribute="width" constant="20" id="tY4-jd-Mxo"/>
+                                        </constraints>
+                                        <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    </activityIndicatorView>
+                                </subviews>
+                                <color key="backgroundColor" red="1" green="0.89130022267518516" blue="0.019455855201255035" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstItem="BmD-Eb-Er8" firstAttribute="leading" secondItem="Edn-5E-aqP" secondAttribute="trailing" constant="8" id="6CQ-mQ-rs1"/>
+                                    <constraint firstItem="BmD-Eb-Er8" firstAttribute="centerX" secondItem="GOS-Kj-eur" secondAttribute="centerX" id="Id8-VH-RbJ"/>
+                                    <constraint firstAttribute="height" constant="30" id="RIR-lj-kiL"/>
+                                    <constraint firstItem="BmD-Eb-Er8" firstAttribute="centerY" secondItem="GOS-Kj-eur" secondAttribute="centerY" id="uzb-ma-99q"/>
+                                    <constraint firstItem="Edn-5E-aqP" firstAttribute="centerY" secondItem="BmD-Eb-Er8" secondAttribute="centerY" id="xu3-zw-wad"/>
+                                </constraints>
+                            </view>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nRT-z4-6HS">
                                 <rect key="frame" x="16" y="149" width="288" height="270"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -382,6 +442,7 @@
                             <constraint firstItem="ghp-Is-tT5" firstAttribute="top" secondItem="3IM-pc-mdw" secondAttribute="bottom" constant="8" symbolic="YES" id="Ao3-hn-Fq0"/>
                             <constraint firstItem="3IM-pc-mdw" firstAttribute="centerX" secondItem="ghp-Is-tT5" secondAttribute="centerX" id="BJQ-1B-HJ5"/>
                             <constraint firstItem="3IM-pc-mdw" firstAttribute="top" secondItem="bSx-Xj-y2l" secondAttribute="bottom" constant="13" id="DYg-Nq-njK"/>
+                            <constraint firstItem="GOS-Kj-eur" firstAttribute="leading" secondItem="oRb-aO-skx" secondAttribute="leadingMargin" constant="-24" id="DYm-ki-gvX"/>
                             <constraint firstItem="ghp-Is-tT5" firstAttribute="leading" secondItem="GIv-Qq-4z9" secondAttribute="leading" id="GvX-ml-dTE"/>
                             <constraint firstItem="GIv-Qq-4z9" firstAttribute="leading" secondItem="cGM-Hl-xXw" secondAttribute="leading" id="HmG-eW-wDE"/>
                             <constraint firstItem="vT7-ho-mxp" firstAttribute="top" secondItem="F2u-zX-id3" secondAttribute="bottom" constant="145" id="I7f-ka-LSr"/>
@@ -394,8 +455,11 @@
                             <constraint firstItem="nRT-z4-6HS" firstAttribute="leading" secondItem="oRb-aO-skx" secondAttribute="leadingMargin" constant="20" id="YD2-80-UqQ"/>
                             <constraint firstItem="vT7-ho-mxp" firstAttribute="leading" secondItem="cGM-Hl-xXw" secondAttribute="leading" id="YYA-Tz-6Dj"/>
                             <constraint firstItem="GIv-Qq-4z9" firstAttribute="top" secondItem="cGM-Hl-xXw" secondAttribute="bottom" constant="19" id="ciL-mx-wgR"/>
+                            <constraint firstItem="GOS-Kj-eur" firstAttribute="top" secondItem="F2u-zX-id3" secondAttribute="bottom" constant="8" id="cz6-SL-C02"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="GOS-Kj-eur" secondAttribute="trailing" constant="-24" id="dY8-8C-xW3"/>
                             <constraint firstItem="GIv-Qq-4z9" firstAttribute="centerX" secondItem="nRT-z4-6HS" secondAttribute="centerX" id="eqx-V2-ShB"/>
                             <constraint firstItem="bSx-Xj-y2l" firstAttribute="centerX" secondItem="3IM-pc-mdw" secondAttribute="centerX" id="gdY-zS-dMy"/>
+                            <constraint firstItem="GOS-Kj-eur" firstAttribute="centerX" secondItem="oRb-aO-skx" secondAttribute="centerX" id="kWp-Jh-I2F"/>
                             <constraint firstItem="vT7-ho-mxp" firstAttribute="top" secondItem="IjP-fK-PyE" secondAttribute="bottom" constant="24" id="kox-3R-xR5"/>
                             <constraint firstItem="bSx-Xj-y2l" firstAttribute="top" secondItem="GIv-Qq-4z9" secondAttribute="bottom" constant="18" id="l50-Yk-otb"/>
                             <constraint firstItem="GIv-Qq-4z9" firstAttribute="trailing" secondItem="cGM-Hl-xXw" secondAttribute="trailing" id="pse-N5-8L3"/>
@@ -410,6 +474,8 @@
                     </view>
                     <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <connections>
+                        <outlet property="activityIndicatorInLoginViewController" destination="Edn-5E-aqP" id="dTk-kv-FEJ"/>
+                        <outlet property="customIndicatorViewInLoginViewController" destination="GOS-Kj-eur" id="jyR-G6-uUZ"/>
                         <outlet property="passwordTextField" destination="GIv-Qq-4z9" id="Dda-VS-54a"/>
                         <outlet property="userNameTextField" destination="cGM-Hl-xXw" id="Qyy-iw-hgE"/>
                     </connections>

--- a/Rocket.Chat.iOS/DarwinNotifications.swift
+++ b/Rocket.Chat.iOS/DarwinNotifications.swift
@@ -1,0 +1,19 @@
+//
+//  DarwinNotifications.swift
+//  Rocket.Chat.iOS
+//
+//  Created by Kornelakis Michael on 11/19/15.
+//  Copyright © 2015 Rocket.Chat. All rights reserved.
+//
+
+import Foundation
+
+func displayStatusChanged(center: CFNotificationCenter!, _: UnsafeMutablePointer<Void>, name: CFString!, _: UnsafePointer<Void>, userInfo: CFDictionary!){
+    
+    if (name == "com.apple.springboard.lockcomplete") {
+        
+        NSUserDefaults.standardUserDefaults().setBool(true, forKey: "kDisplayStatusLocked")
+        
+    }
+    
+}

--- a/Rocket.Chat.iOS/ViewControllers/AccountBarViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/AccountBarViewController.swift
@@ -24,12 +24,13 @@ class AccountBarViewController: UIViewController {
     var delegate:SwitchAccountViewDelegate! = nil
     
     var meteor:MeteorClient!
+    var ad:AppDelegate?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let ad = UIApplication.sharedApplication().delegate as! AppDelegate
-        meteor = ad.meteorClient
+        self.ad = UIApplication.sharedApplication().delegate as! AppDelegate
+        meteor = self.ad!.meteorClient
         
     }
     

--- a/Rocket.Chat.iOS/ViewControllers/AccountBarViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/AccountBarViewController.swift
@@ -29,7 +29,7 @@ class AccountBarViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.ad = UIApplication.sharedApplication().delegate as! AppDelegate
+        self.ad = UIApplication.sharedApplication().delegate as? AppDelegate
         meteor = self.ad!.meteorClient
         
     }
@@ -90,7 +90,7 @@ class AccountBarViewController: UIViewController {
             default:
                 self.statusIcon.image = UIImage(named: "Green")
         }
-        
+        NSUserDefaults.standardUserDefaults().setValue(currentStatus, forKey: "previousStatus")
     }
     
     

--- a/Rocket.Chat.iOS/ViewControllers/AccountBarViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/AccountBarViewController.swift
@@ -10,80 +10,111 @@ import UIKit
 import ObjectiveDDP
 
 class AccountBarViewController: UIViewController {
-  
-  // MARK: Properties
-  @IBOutlet weak var detailsButton: UIButton!
-  @IBOutlet weak var usernameLabel: UILabel!
-  @IBOutlet weak var avatarIcon: UIImageView!
-  @IBOutlet weak var statusIcon: UIImageView!
+    
+    // MARK: Properties
+    @IBOutlet weak var detailsButton: UIButton!
+    @IBOutlet weak var usernameLabel: UILabel!
+    @IBOutlet weak var avatarIcon: UIImageView!
+    @IBOutlet weak var statusIcon: UIImageView!
     
     
-  /** this will tell you what the state was before the touch event */
-  var accountOptionsWereOpen = false
-  
-  var delegate:SwitchAccountViewDelegate! = nil
+    /** this will tell you what the state was before the touch event */
+    var accountOptionsWereOpen = false
     
-  var meteor:MeteorClient!
+    var delegate:SwitchAccountViewDelegate! = nil
     
-  override func viewDidLoad() {
-    super.viewDidLoad()
+    var meteor:MeteorClient!
     
-    //Get the username and
-    let ad = UIApplication.sharedApplication().delegate as! AppDelegate
-    meteor = ad.meteorClient
-    let users = meteor.collections["users"] as! M13MutableOrderedDictionary
-    
-    let obj = users.objectAtIndex(0)
-    print(obj["_id"])
-    
-    self.usernameLabel.text = obj["username"] as? String
-    
-  }
-  
-  override func didReceiveMemoryWarning() {
-    super.didReceiveMemoryWarning()
-    // Dispose of any resources that can be recreated.
-  }
-  
-  
-  
-  // MARK: - Navigation
-  
-  //MARK: Navigation
-  
-  override func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?) {
-    
-      //rotate icon 180
-      let rotateAnimation = CABasicAnimation(keyPath: "transform.rotation")
-      rotateAnimation.fromValue = 0.0
-      rotateAnimation.toValue = CGFloat(M_PI * 1.0)
-      rotateAnimation.duration = 0.2
-      
-      //handle the callback in the animationDidStop below
-      rotateAnimation.delegate = self
-      detailsButton.layer.addAnimation(rotateAnimation, forKey: nil)
-    
-  }
-  
-  
-  override func animationDidStop(anim: CAAnimation, finished flag: Bool){
-    
-    if (detailsButton.imageView?.image == UIImage(named: "Arrow-Up")) {
-      detailsButton.imageView?.image = UIImage(named: "Arrow-Down")
-    } else {
-      detailsButton.imageView?.image = UIImage(named: "Arrow-Up")
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let ad = UIApplication.sharedApplication().delegate as! AppDelegate
+        meteor = ad.meteorClient
+        
     }
-    if ((delegate) != nil){ // let delegate know about event
-	    delegate!.didClickOnAccountBar(accountOptionsWereOpen)
-  	  accountOptionsWereOpen = !accountOptionsWereOpen
+    
+    
+    override func viewWillAppear(animated: Bool) {
+        
+        let userNameAndStatus = self.getUsernameAndStatus()
+        
+        self.usernameLabel.text = userNameAndStatus.0
+        
+        switch userNameAndStatus.1 {
+            
+            case "online":
+                self.statusIcon.image = UIImage(named: "Green")
+            
+            case "away":
+                self.statusIcon.image = UIImage(named: "Yellow")
+            
+            case "busy":
+                self.statusIcon.image = UIImage(named: "Red")
+            
+            case "offline":
+                self.statusIcon.image = UIImage(named: "Grey")
+            
+            default:
+                self.statusIcon.image = UIImage(named: "Green")
+        }
+        
     }
-  }
-  
+    
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+    
+    func getUsernameAndStatus()-> (String, String) {
+        
+        let users = self.meteor.collections["users"]! as! M13MutableOrderedDictionary
+        
+        let userName = users[self.meteor.userId]["username"] as? String
+        
+        let userStatus = users[self.meteor.userId]["status"] as? String ?? "offline"
+
+        return (userName!, userStatus)
+    }
+    
+    
+    // MARK: - Navigation
+    
+    //MARK: Navigation
+    
+    override func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?) {
+        
+        //rotate icon 180
+        let rotateAnimation = CABasicAnimation(keyPath: "transform.rotation")
+        rotateAnimation.fromValue = 0.0
+        rotateAnimation.toValue = CGFloat(M_PI * 1.0)
+        rotateAnimation.duration = 0.2
+        
+        //handle the callback in the animationDidStop below
+        rotateAnimation.delegate = self
+        detailsButton.layer.addAnimation(rotateAnimation, forKey: nil)
+        
+    }
+    
+    
+    override func animationDidStop(anim: CAAnimation, finished flag: Bool){
+        
+        if (detailsButton.imageView?.image == UIImage(named: "Arrow-Up")) {
+            detailsButton.imageView?.image = UIImage(named: "Arrow-Down")
+        } else {
+            detailsButton.imageView?.image = UIImage(named: "Arrow-Up")
+        }
+        if ((delegate) != nil){ // let delegate know about event
+            delegate!.didClickOnAccountBar(accountOptionsWereOpen)
+            accountOptionsWereOpen = !accountOptionsWereOpen
+        }
+    }
+    
 }
 
 
 /** This protocol is used for handling events from the AccountBar. */
 protocol SwitchAccountViewDelegate {
-  func didClickOnAccountBar(accountOptionsWereOpen: Bool)
+    func didClickOnAccountBar(accountOptionsWereOpen: Bool)
 }
 

--- a/Rocket.Chat.iOS/ViewControllers/AccountBarViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/AccountBarViewController.swift
@@ -36,28 +36,20 @@ class AccountBarViewController: UIViewController {
     
     override func viewWillAppear(animated: Bool) {
         
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "userChange:", name: "users_changed", object: nil)
+        
         let userNameAndStatus = self.getUsernameAndStatus()
         
         self.usernameLabel.text = userNameAndStatus.0
         
-        switch userNameAndStatus.1 {
-            
-            case "online":
-                self.statusIcon.image = UIImage(named: "Green")
-            
-            case "away":
-                self.statusIcon.image = UIImage(named: "Yellow")
-            
-            case "busy":
-                self.statusIcon.image = UIImage(named: "Red")
-            
-            case "offline":
-                self.statusIcon.image = UIImage(named: "Grey")
-            
-            default:
-                self.statusIcon.image = UIImage(named: "Green")
-        }
+        self.changeStatusIcon(userNameAndStatus.1)
         
+    }
+    
+    override func viewWillDisappear(animated: Bool) {
+        
+        NSNotificationCenter.defaultCenter().removeObserver(self, name: "users_changed", object: nil)
+    
     }
     
     override func didReceiveMemoryWarning() {
@@ -77,6 +69,41 @@ class AccountBarViewController: UIViewController {
         return (userName!, userStatus)
     }
     
+    
+    func changeStatusIcon(currentStatus: String) {
+        
+        switch currentStatus {
+            
+            case "online":
+                self.statusIcon.image = UIImage(named: "Green")
+                
+            case "away":
+                self.statusIcon.image = UIImage(named: "Yellow")
+                
+            case "busy":
+                self.statusIcon.image = UIImage(named: "Red")
+                
+            case "offline":
+                self.statusIcon.image = UIImage(named: "Grey")
+                
+            default:
+                self.statusIcon.image = UIImage(named: "Green")
+        }
+        
+    }
+    
+    
+    func userChange(notification:NSNotification){
+        
+        if notification.userInfo!["_id"] as? String == self.meteor.userId {
+            
+            let status = notification.userInfo!["status"] as? String ?? "offline"
+            
+            self.changeStatusIcon(status)
+            
+        }
+        
+    }
     
     // MARK: - Navigation
     

--- a/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
@@ -62,59 +62,71 @@ class AccountOptionsTableViewController: UITableViewController {
     //Here is what happens when the user select's an option from account options
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
     
-        
+        //User's Status
+        if (indexPath.section == 0){
+            //Get the username and
+            
+            switch indexPath.row {
+                
+            case 0:
+                print("online")
+                self.meteor.callMethodName("UserPresence:setDefaultStatus", parameters: ["online"], responseCallback: { (response, error) -> Void in
+                    
+                    if error != nil{
+                        print("Error: \(error.description)")
+                        return
+                    }
+                    
+//                    print(response["result"])
+                    self.chooseOptionAndSetViews("ChatNav",color: "Green")
+                })
+            case 1:
+                print("Away")
+                self.meteor.callMethodName("UserPresence:setDefaultStatus", parameters: ["away"], responseCallback: { (response, error) -> Void in
+                    
+                    if error != nil{
+                        print("Error: \(error.description)")
+                        return
+                    }
+                    
+//                    print(response["result"])
+                    self.chooseOptionAndSetViews("ChatNav",color: "Yellow")
+                })
+            case 2:
+                print("Busy")
+                self.meteor.callMethodName("UserPresence:setDefaultStatus", parameters: ["busy"], responseCallback: { (response, error) -> Void in
+                    
+                    if error != nil{
+                        print("Error: \(error.description)")
+                        return
+                    }
+                    
+//                    print(response["result"])
+                    self.chooseOptionAndSetViews("ChatNav",color: "Red")
+                })
+            case 3:
+                print("Invisible")
+                
+                self.meteor.callMethodName("UserPresence:setDefaultStatus", parameters: ["offline"], responseCallback: { (response, error) -> Void in
+                    
+                    if error != nil{
+                        print("Error: \(error.description)")
+                        return
+                    }
+                    
+//                    print(response["result"])
+                    self.chooseOptionAndSetViews("ChatNav",color:"Grey")
+                })
+            default:
+                print("default")
+            }
+            
+        }
         //If user selects MySettings
-        if (indexPath.section == 1 && indexPath.row == 0) {
+        else if (indexPath.section == 1 && indexPath.row == 0) {
          
-            //get the appDelegate
-            let appdelegate:AppDelegate = UIApplication.sharedApplication().delegate as! AppDelegate
-            
-            
-            //Create MySettingsViewController instance
-            let mySettingsVC = storyboard?.instantiateViewControllerWithIdentifier("mySettings") as! MySettingsViewController
-            
-            //Set it as rootViewController in the navigation controller
-            let centerNewNav = UINavigationController(rootViewController: mySettingsVC)
-            
-            
-            //Set the settings controller as the center view controller in the MMDrawer
-            appdelegate.centerContainer?.setCenterViewController(centerNewNav, withCloseAnimation: false, completion: nil)
-            
-            //Close the drawer
-            appdelegate.centerContainer?.closeDrawerAnimated(true, completion: nil)
-            
-            
-            //Get the AccountBar's tab controller
-            let MyAccountTabBarController = tabBarController?.parentViewController?.childViewControllers[0] as! MyAccountBarTabViewController
-            
+            self.chooseOptionAndSetViews("Settings", color: nil)
 
-            //Set the account bar view
-            MyAccountTabBarController.selectedViewController = MyAccountTabBarController.viewControllers![1]
-            
-            
-            
-            /******** Prepare the account bar for when we exit settings ********/
-            
-            //Get the accountBarView
-            let accountBarView = MyAccountTabBarController.viewControllers![MyAccountTabBarController.findIndexOfAccountBar()] as! AccountBarViewController
-            
-            //Set accountOptionWereOpen to false so when we get back from settings the account bar will work right
-            accountBarView.accountOptionsWereOpen = false
-            
-            //Rotate the arrow down
-            accountBarView.detailsButton?.imageView?.image = UIImage(named: "Arrow-Down")
-            
-            /************/
-            
-            
-            
-            //get LeftMenu's tab bar controller
-            let leftMenuTabBarController = tabBarController as! LeftMenuTabBarViewController
-            
-            //Set the left menu's view
-            tabBarController?.selectedViewController = tabBarController?.viewControllers![leftMenuTabBarController.findIndexOfMySettings()]
-            
-            
         }
     
         else if (indexPath.section == 1 && indexPath.row == 1) {

--- a/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
@@ -79,6 +79,8 @@ class AccountOptionsTableViewController: UITableViewController {
                     
 //                    print(response["result"])
                     self.chooseOptionAndSetViews("ChatNav",color: "Green")
+                    NSUserDefaults.standardUserDefaults().setValue("online", forKey: "previousStatus")
+
                 })
             case 1:
                 print("Away")
@@ -91,6 +93,8 @@ class AccountOptionsTableViewController: UITableViewController {
                     
 //                    print(response["result"])
                     self.chooseOptionAndSetViews("ChatNav",color: "Yellow")
+                    NSUserDefaults.standardUserDefaults().setValue("away", forKey: "previousStatus")
+
                 })
             case 2:
                 print("Busy")
@@ -103,6 +107,7 @@ class AccountOptionsTableViewController: UITableViewController {
                     
 //                    print(response["result"])
                     self.chooseOptionAndSetViews("ChatNav",color: "Red")
+                    NSUserDefaults.standardUserDefaults().setValue("busy", forKey: "previousStatus")
                 })
             case 3:
                 print("Invisible")
@@ -116,6 +121,8 @@ class AccountOptionsTableViewController: UITableViewController {
                     
 //                    print(response["result"])
                     self.chooseOptionAndSetViews("ChatNav",color:"Grey")
+                    NSUserDefaults.standardUserDefaults().setValue("offline", forKey: "previousStatus")
+
                 })
             default:
                 print("default")

--- a/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
@@ -8,12 +8,18 @@
 
 import UIKit
 import MMDrawerController
+import ObjectiveDDP
 
 class AccountOptionsTableViewController: UITableViewController {
     
+    var meteor = MeteorClient!()
+    var ad:AppDelegate?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        self.ad = UIApplication.sharedApplication().delegate as? AppDelegate
+        self.meteor = self.ad!.meteorClient
 
         // Uncomment the following line to preserve selection between presentations
         // self.clearsSelectionOnViewWillAppear = false

--- a/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
@@ -126,28 +126,80 @@ class AccountOptionsTableViewController: UITableViewController {
     
             if (meteor.connected){
                 
-//                meteor.callMethodName("leaveRoom", parameters: ["GENERAL"], responseCallback: { (response, error) -> Void in
-//                    
-//                    if error != nil {
-//                        print(error.description)
-//                    }else{
-//                        print(response)
-//                    }
-//                    
-//                })
-                
                 meteor.logout()
                 print("Logged out")
                 ad.window?.rootViewController = loginVC
+            
             } else {
+            
                 let alert = UIAlertController(title: "Error", message: "Connection is lost", preferredStyle: UIAlertControllerStyle.Alert)
                 let cancel = UIAlertAction(title: "Cancel", style: UIAlertActionStyle.Cancel, handler: nil)
                 alert.addAction(cancel)
                 self.presentViewController(alert, animated: true, completion: nil)
+            
             }
             
         }
     
 
+    }
+    
+    
+    /* 
+    This func is to handle left menu's view when user chooses an option.
+    Also when user chooses a status the statusIcon changes color and
+    the arrow turns down
+    */
+    func chooseOptionAndSetViews(viewToAppear:String,color:String?) {
+        
+        //Get the AccountBar's tab controller
+        let MyAccountTabBarController = tabBarController?.parentViewController?.childViewControllers[0] as! MyAccountBarTabViewController
+        
+        /******** Prepare the account bar for when we exit settings ********/
+         
+         //Get the accountBarView
+        let accountBarView = MyAccountTabBarController.viewControllers![MyAccountTabBarController.findIndexOfAccountBar()] as! AccountBarViewController
+        
+        //Set accountOptionWereOpen to false so when we get back from settings the account bar will work right
+        accountBarView.accountOptionsWereOpen = false
+        
+        //Rotate the arrow down
+        accountBarView.detailsButton?.imageView?.image = UIImage(named: "Arrow-Down")
+        
+        if color != nil {
+            accountBarView.statusIcon.image = UIImage(named: color!)
+        }
+        /************/
+         
+         //get LeftMenu's tab bar controller
+        let leftMenuTabBarController = tabBarController as! LeftMenuTabBarViewController
+        
+        
+        switch viewToAppear{
+            
+            case "ChatNav":
+                //Set the left menu's view
+                tabBarController?.selectedViewController = tabBarController?.viewControllers![leftMenuTabBarController.findIndexOfChatNav()]
+                
+            case "Settings":
+                //Create MySettingsViewController instance
+                let mySettingsVC = storyboard?.instantiateViewControllerWithIdentifier("mySettings") as! MySettingsViewController
+                
+                //Set it as rootViewController in the navigation controller
+                let centerNewNav = UINavigationController(rootViewController: mySettingsVC)
+                
+                
+                //Set the settings controller as the center view controller in the MMDrawer
+                self.ad!.centerContainer?.setCenterViewController(centerNewNav, withCloseAnimation: false, completion: nil)
+                
+                //Close the drawer
+                self.ad!.centerContainer?.closeDrawerAnimated(true, completion: nil)
+                tabBarController?.selectedViewController = tabBarController?.viewControllers![leftMenuTabBarController.findIndexOfMySettings()]
+            
+            default:
+                tabBarController?.selectedViewController = tabBarController?.viewControllers![leftMenuTabBarController.findIndexOfMySettings()]
+        
+        }
+        
     }
 }

--- a/Rocket.Chat.iOS/ViewControllers/Auth/LoginViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/Auth/LoginViewController.swift
@@ -12,219 +12,236 @@ import ObjectiveDDP
 
 class LoginViewController: AuthViewController, UIPopoverPresentationControllerDelegate {
   
-  @IBOutlet var userNameTextField: UITextField!
-  @IBOutlet var passwordTextField: UITextField!
-  
-  
-  
-  //variable to get the logged in user
-  var meteor: MeteorClient!
-  
-  override func viewWillAppear(animated: Bool) {
-    super.viewWillAppear(animated)
+    @IBOutlet var userNameTextField: UITextField!
+    @IBOutlet var passwordTextField: UITextField!
+    @IBOutlet var customIndicatorViewInLoginViewController: UIView!
+    @IBOutlet var activityIndicatorInLoginViewController: UIActivityIndicatorView!
     
     
-    let ad = UIApplication.sharedApplication().delegate as! AppDelegate
-    meteor = ad.meteorClient
+    //variable to get the logged in user
+    var meteor: MeteorClient!
     
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        
+        let ad = UIApplication.sharedApplication().delegate as! AppDelegate
+        meteor = ad.meteorClient
+        
+        
+        //We have to see how to do the login
+        
+        //    let defaults = NSUserDefaults.standardUserDefaults()
+        //    if let sessionToken = defaults.stringForKey("sessionToken") {
+        //        print("sessionToken: \(sessionToken)")
+        //
+        //
+        //
+        //        meteor.logonWithSessionToken(sessionToken, responseCallback: {(response, error) -> Void in
+        //
+        //            if((error) != nil) {
+        //                print("error!!! \(error)")
+        //                return
+        //            }
+        //            print(response)
+        //        })
+        //        
+        //        // TODO: check if session token exists and try to login with that.
+        //        
+        //    }
+        
+        
+        
+    }
+  
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        //set password textfield to secure entry textfield
+        passwordTextField.secureTextEntry = true
+        
+        //Add listener for the textinput for when input changes
+        userNameTextField.addTarget(self, action: "textFieldDidChange", forControlEvents: UIControlEvents.EditingChanged)
+        passwordTextField.addTarget(self, action: "textFieldDidChange", forControlEvents: UIControlEvents.EditingChanged)
+        
+        //Prefill text inputs to make login easier for developing
+        //        userNameTextField.text = "info@rocket.chat"
+        //        passwordTextField.text = "123qwe"
+    }
+    
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+  
+  
+    //Function to return popovers as modals to all devices.
+    func adaptivePresentationStyleForPresentationController(controller: UIPresentationController) -> UIModalPresentationStyle {
+        
+        return .None
+        
+    }
+    
+    
+    //Login action
+    @IBAction func loginButtonTapped(sender: AnyObject) {
+        
+        
+        validateFields()
+        
+        
+        loginToServer(userNameTextField.text!, pass: passwordTextField.text!)
+        
+        
+    }
+    
+    func loginToServer(userName: String, pass: String) {
+        if (!meteor.websocketReady) {
+            let notConnectedAlert = UIAlertView(title: "Connection Error", message: "Can't find the Rocket.Chat server, try again", delegate: nil, cancelButtonTitle: "OK")
+            notConnectedAlert.show()
+            return
+        }
+        
+        meteor.logonWithUsernameOrEmail(userName, password: pass) {(response, error) -> Void in
+            
+            if((error) != nil) {
+                self.handleFailedAuth(error)
+                return
+            }
+            self.handleSuccessfulAuth(response)
+        }
+    }
+    
+    func handleSuccessfulAuth(response: NSDictionary) {
+        
+        
+        let result = response["result"] as? NSDictionary
+        if (result == nil) {
+            let err = NSError(domain: "Rocket.chat", code: 500, userInfo: ["msg": "empty result"])
+            self.handleFailedAuth(err)
+            return
+        }
+        
+        
+        
+        if (getTokenAndSaveUser(userNameTextField.text!, response: response)){
+            createMainMMDrawer()
+        }
+    }
+    
+    func handleFailedAuth(error: NSError) {
+        //create an alert
+        let alert = UIAlertView(title: "Warning!", message: "Check your username / password combination", delegate: self, cancelButtonTitle: "Dismiss")
+        
+        //empty textfields
+        userNameTextField.text = ""
+        passwordTextField.text = ""
+        
+        
+        //show the alert
+        alert.show()
+        
+        //userNameTextField gets the focus
+        userNameTextField.becomeFirstResponder()
+    }
+    
+    func validateFields(){
+        //Check if username is empty
+        
+        if(userNameTextField.text == nil || userNameTextField.text!.isEmpty){
+            
+            //if empty change username textfield border color to red
+            userNameTextField.layer.borderColor = UIColor.redColor().CGColor
+            userNameTextField.layer.borderWidth = 1.0
+            
+            let popoverVC = storyboard?.instantiateViewControllerWithIdentifier("loginPopover")
+            popoverVC!.modalPresentationStyle = .Popover
+            popoverVC!.preferredContentSize = CGSizeMake(250, 50)
+            
+            
+            if let popoverController = popoverVC!.popoverPresentationController {
+                
+                //Specify the anchor location
+                popoverController.sourceView = userNameTextField
+                popoverController.sourceRect = userNameTextField.bounds
+                
+                //Popover above the textfield
+                popoverController.permittedArrowDirections = .Down
+                popoverController.delegate = self
+            }
+            
+            //Show the popover
+            presentViewController(popoverVC!, animated: true, completion: nil)
+            
+        }else if(passwordTextField.text == nil || passwordTextField.text!.isEmpty){
+            
+            //if empty change password textfield border color to red
+            passwordTextField.layer.borderColor = UIColor.redColor().CGColor
+            passwordTextField.layer.borderWidth = 1.0
+            
+            let popoverVC = storyboard?.instantiateViewControllerWithIdentifier("loginPopover")
+            popoverVC!.modalPresentationStyle = .Popover
+            popoverVC?.preferredContentSize = CGSizeMake(250, 50)
+            
+            if let popoverController = popoverVC!.popoverPresentationController {
+                
+                //Specify the anchor location
+                popoverController.sourceView = passwordTextField
+                popoverController.sourceRect = passwordTextField.bounds
+                
+                //Popover above the textfield
+                popoverController.permittedArrowDirections = .Down
+                popoverController.delegate = self
+                
+                //Show the popover
+                presentViewController(popoverVC!, animated: true, completion: nil)
+                
+            }
+            
+        }
+    }
+  
+  
+  
+    func textFieldDidChange() {
+        
+        //Reset textField's border color and width
+        userNameTextField.layer.borderColor = UIColor.blackColor().CGColor
+        userNameTextField.layer.borderWidth = 0.0
+        passwordTextField.layer.borderColor = UIColor.blackColor().CGColor
+        passwordTextField.layer.borderWidth = 0.0
+        
+    }
+    
+    //Dismissing the keyboard
+    @IBAction func dismissKeyboard(sender: AnyObject) {
+        
+        self.resignFirstResponder()
+    }
+    
+    //Dismissing the keyboard when user taps outside
+    override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
+        
+        self.view.endEditing(true)
+        
+    }
+    
+    func connectionStatus(live:Bool) {
+        
+        if (live){
+            
+            self.customIndicatorViewInLoginViewController.hidden = true
+            self.activityIndicatorInLoginViewController.stopAnimating()
+            
+        }else {
+            
+            self.customIndicatorViewInLoginViewController.hidden = false
+            self.activityIndicatorInLoginViewController.startAnimating()
+            
+        }
 
-//We have to see how to do the login
-    
-//    let defaults = NSUserDefaults.standardUserDefaults()
-//    if let sessionToken = defaults.stringForKey("sessionToken") {
-//        print("sessionToken: \(sessionToken)")
-//        
-//        
-//        
-//        meteor.logonWithSessionToken(sessionToken, responseCallback: {(response, error) -> Void in
-//            
-//            if((error) != nil) {
-//                print("error!!! \(error)")
-//                return
-//            }
-//            print(response)
-//        })
-//        
-//        // TODO: check if session token exists and try to login with that.
-//        
-//    }
-    
-    
-    
-  }
-  
-  
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    
-    //set password textfield to secure entry textfield
-    passwordTextField.secureTextEntry = true
-    
-    //Add listener for the textinput for when input changes
-    userNameTextField.addTarget(self, action: "textFieldDidChange", forControlEvents: UIControlEvents.EditingChanged)
-    passwordTextField.addTarget(self, action: "textFieldDidChange", forControlEvents: UIControlEvents.EditingChanged)
-    
-    //Prefill text inputs to make login easier for developing
-    //        userNameTextField.text = "info@rocket.chat"
-    //        passwordTextField.text = "123qwe"
-   }
-  
-  override func didReceiveMemoryWarning() {
-    super.didReceiveMemoryWarning()
-    // Dispose of any resources that can be recreated.
-  }
-  
-  
-  //Function to return popovers as modals to all devices.
-  func adaptivePresentationStyleForPresentationController(controller: UIPresentationController) -> UIModalPresentationStyle {
-    
-    return .None
-    
-  }
-  
-  
-  //Login action
-  @IBAction func loginButtonTapped(sender: AnyObject) {
-    
-    
-    validateFields()
-    
-    
-    loginToServer(userNameTextField.text!, pass: passwordTextField.text!)
-    
-    
-  }
-  
-  func loginToServer(userName: String, pass: String) {
-    if (!meteor.websocketReady) {
-      let notConnectedAlert = UIAlertView(title: "Connection Error", message: "Can't find the Rocket.Chat server, try again", delegate: nil, cancelButtonTitle: "OK")
-      notConnectedAlert.show()
-      return
+        
     }
     
-    meteor.logonWithUsernameOrEmail(userName, password: pass) {(response, error) -> Void in
-      
-      if((error) != nil) {
-        self.handleFailedAuth(error)
-        return
-      }
-      self.handleSuccessfulAuth(response)
-    }
-  }
-  
-  func handleSuccessfulAuth(response: NSDictionary) {
-    
-    
-    let result = response["result"] as? NSDictionary
-    if (result == nil) {
-      let err = NSError(domain: "Rocket.chat", code: 500, userInfo: ["msg": "empty result"])
-      self.handleFailedAuth(err)
-      return
-    }
-   
-    
-    
-    if (getTokenAndSaveUser(userNameTextField.text!, response: response)){
-     	createMainMMDrawer()
-    }
-  }
-  
-  func handleFailedAuth(error: NSError) {
-    //create an alert
-    let alert = UIAlertView(title: "Warning!", message: "Check your username / password combination", delegate: self, cancelButtonTitle: "Dismiss")
-    
-    //empty textfields
-    userNameTextField.text = ""
-    passwordTextField.text = ""
-    
-    
-    //show the alert
-    alert.show()
-    
-    //userNameTextField gets the focus
-    userNameTextField.becomeFirstResponder()
-  }
-  
-  func validateFields(){
-    //Check if username is empty
-    
-    if(userNameTextField.text == nil || userNameTextField.text!.isEmpty){
-      
-      //if empty change username textfield border color to red
-      userNameTextField.layer.borderColor = UIColor.redColor().CGColor
-      userNameTextField.layer.borderWidth = 1.0
-      
-      let popoverVC = storyboard?.instantiateViewControllerWithIdentifier("loginPopover")
-      popoverVC!.modalPresentationStyle = .Popover
-      popoverVC!.preferredContentSize = CGSizeMake(250, 50)
-      
-      
-      if let popoverController = popoverVC!.popoverPresentationController {
-        
-        //Specify the anchor location
-        popoverController.sourceView = userNameTextField
-        popoverController.sourceRect = userNameTextField.bounds
-        
-        //Popover above the textfield
-        popoverController.permittedArrowDirections = .Down
-        popoverController.delegate = self
-      }
-      
-      //Show the popover
-      presentViewController(popoverVC!, animated: true, completion: nil)
-      
-    }else if(passwordTextField.text == nil || passwordTextField.text!.isEmpty){
-      
-      //if empty change password textfield border color to red
-      passwordTextField.layer.borderColor = UIColor.redColor().CGColor
-      passwordTextField.layer.borderWidth = 1.0
-      
-      let popoverVC = storyboard?.instantiateViewControllerWithIdentifier("loginPopover")
-      popoverVC!.modalPresentationStyle = .Popover
-      popoverVC?.preferredContentSize = CGSizeMake(250, 50)
-      
-      if let popoverController = popoverVC!.popoverPresentationController {
-        
-        //Specify the anchor location
-        popoverController.sourceView = passwordTextField
-        popoverController.sourceRect = passwordTextField.bounds
-        
-        //Popover above the textfield
-        popoverController.permittedArrowDirections = .Down
-        popoverController.delegate = self
-        
-        //Show the popover
-        presentViewController(popoverVC!, animated: true, completion: nil)
-        
-      }
-      
-    }
-  }
-  
-  
-  
-  func textFieldDidChange() {
-    
-    //Reset textField's border color and width
-    userNameTextField.layer.borderColor = UIColor.blackColor().CGColor
-    userNameTextField.layer.borderWidth = 0.0
-    passwordTextField.layer.borderColor = UIColor.blackColor().CGColor
-    passwordTextField.layer.borderWidth = 0.0
-    
-  }
-  
-  //Dismissing the keyboard
-  @IBAction func dismissKeyboard(sender: AnyObject) {
-    
-    self.resignFirstResponder()
-  }
-  
-  //Dismissing the keyboard when user taps outside
-  override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
-    
-    self.view.endEditing(true)
-    
-  }
-  
-  
 }

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -19,6 +19,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     
     @IBOutlet var mainTableview: UITableView!
     @IBOutlet var composeMsg: UITextView!
+    @IBOutlet var composeMsgButton: UIButton!
     
     // indexPath to find the bottom of the tableview
     var bottomIndexPath:NSIndexPath = NSIndexPath()
@@ -32,6 +33,10 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     
     //Array to keep each chatMessage
     var chatMessageData = [ChatMessage]()
+    
+    
+    @IBOutlet var activityIndicatorInViewController: UIActivityIndicatorView!
+    @IBOutlet var customIndicatorViewInViewController: UIView!
     
     
     override func viewWillAppear(animated: Bool) {
@@ -151,7 +156,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         composeMsg.layer.borderColor = UIColor.blackColor().CGColor
         composeMsg.layer.borderWidth = 0.5
         composeMsg.layer.cornerRadius = 10
-
+        
         dateFormatter.dateFormat = "HH:mm"
     }
     
@@ -378,7 +383,6 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     //Function to close the keyboard when send button is pressed
     @IBAction func sendMsg(sender: AnyObject) {
         
-        
         if (composeMsg.text != ""){
             
             var messageObject = NSDictionary()
@@ -542,6 +546,30 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             
         }
         
+        
+    }
+    
+    func connectionStatus(live:Bool) {
+
+        if (live){
+            
+            self.customIndicatorViewInViewController.hidden = true
+            self.activityIndicatorInViewController.stopAnimating()
+            self.composeMsg.userInteractionEnabled = false
+            self.composeMsg.backgroundColor = UIColor.whiteColor()
+            self.composeMsgButton.userInteractionEnabled = true
+            self.composeMsgButton.enabled = true
+            
+        }else {
+            
+            self.customIndicatorViewInViewController.hidden = false
+            self.activityIndicatorInViewController.startAnimating()
+            self.composeMsg.userInteractionEnabled = false
+            self.composeMsg.backgroundColor = UIColor.lightGrayColor()
+            self.composeMsgButton.userInteractionEnabled = false
+            self.composeMsgButton.enabled = false
+        }
+
         
     }
     

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -45,7 +45,6 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         let ad = UIApplication.sharedApplication().delegate as! AppDelegate
         meteor = ad.meteorClient
         
-        
         //Subscribe to rocketchat_message collection for the GENERAL channel
         self.meteor.addSubscription("messages", withParameters: ["GENERAL"])
 
@@ -79,7 +78,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                 
             } else {
                 
-                print(response!["result"]!)
+//                print(response!["result"]!)
                 
                 //JSON Handling
                 let result = JSON(response)
@@ -98,7 +97,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                     let timestampInMilliseconds = timestampInDouble[0] / 1000
                     
                     let  cM = ChatMessage(user_id: subJson["u","_id"].string!, username: subJson["u","username"].string!, msg: subJson["msg"].string!, msgType: type, ts: timestampInMilliseconds)
-                    
+        
                     
                     self.chatMessageData.append(cM)
 
@@ -106,7 +105,6 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                 
                 
                 self.chatMessageData = self.chatMessageData.reverse()
-                
                 
                 
                 //Reload data and scroll to the bottom of the tableview


### PR DESCRIPTION
This is so the user can set his status. What I 've done is this:
User can choose his status from the left menu. When the user press home or switches to another app the status remains the same. But when the user locks the device the status is set to away. When he unlocks, the status is set back to the previous status.If he puts the app to the background and then locks the device the the status stays the same. Also when the status is changed from the web client the app get's notified and the status is synced to the device. I added an observer to AccountBarViewController but I noticed that it gets plenty notifications so every time we close the left menu the observer is removed to keep network traffic low. It's being added every time we open the left menu. If it's needed later it won't be removed at all.

Please feel free to review and if anyone thinks this is not the way the status should be handled on locking the device please let me know! :) :) :)

P.s. > I would prefer this to be confirmed after my previous pr has been confirmed first. I don't think there would be any merge conflict anyway but just to be sure....