### PR TITLE
Room selection in left menu and changed the subscription to stream-messages

### DIFF
--- a/Rocket.Chat.iOS.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.iOS.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		4F18F6871BB4103A00048D7E /* UsernameRegistrationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F18F6861BB4103A00048D7E /* UsernameRegistrationViewController.swift */; };
 		4F28B1571B903B6D0033D8D1 /* LeftMenu.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F28B1551B903B6D0033D8D1 /* LeftMenu.storyboard */; };
 		4F28B1591B90FF230033D8D1 /* AccountBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F28B1581B90FF230033D8D1 /* AccountBarViewController.swift */; };
-		4F28B1601B9101720033D8D1 /* FavoritesTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F28B15B1B9101720033D8D1 /* FavoritesTableViewCell.swift */; };
+		4F28B1601B9101720033D8D1 /* HistoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F28B15B1B9101720033D8D1 /* HistoryTableViewCell.swift */; };
 		4F28B1611B9101720033D8D1 /* DirectMessagesTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F28B15C1B9101720033D8D1 /* DirectMessagesTableViewCell.swift */; };
 		4F28B1621B9101720033D8D1 /* PrivateGroupsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F28B15D1B9101720033D8D1 /* PrivateGroupsTableViewCell.swift */; };
 		4F28B1631B9101720033D8D1 /* ChannelsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F28B15E1B9101720033D8D1 /* ChannelsTableViewCell.swift */; };
@@ -37,6 +37,7 @@
 		A5A3A9721B93CBEE00CFE8FB /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A5A3A9741B93CBEE00CFE8FB /* Localizable.strings */; };
 		DF113AE51BA6D87B00CE6D17 /* MyAccountBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF113AE41BA6D87B00CE6D17 /* MyAccountBarViewController.swift */; };
 		DF113AE91BA6D91000CE6D17 /* MyAccountBarTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF113AE81BA6D91000CE6D17 /* MyAccountBarTabViewController.swift */; };
+		DF19164C1C010F2B0055D107 /* Room.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF19164B1C010F2B0055D107 /* Room.swift */; };
 		DF2A60E61B8DC6280014548B /* RegisterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2A60E51B8DC6280014548B /* RegisterViewController.swift */; };
 		DF2A60E81B8DCD3A0014548B /* ForgotPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2A60E71B8DCD3A0014548B /* ForgotPasswordViewController.swift */; };
 		DF4928A51BFDCA3400B1F901 /* DarwinNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF4928A41BFDCA3400B1F901 /* DarwinNotifications.swift */; };
@@ -105,7 +106,7 @@
 		4F18F6861BB4103A00048D7E /* UsernameRegistrationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UsernameRegistrationViewController.swift; path = ../../UsernameRegistrationViewController.swift; sourceTree = "<group>"; };
 		4F28B1561B903B6D0033D8D1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LeftMenu.storyboard; sourceTree = "<group>"; };
 		4F28B1581B90FF230033D8D1 /* AccountBarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AccountBarViewController.swift; path = ViewControllers/AccountBarViewController.swift; sourceTree = "<group>"; };
-		4F28B15B1B9101720033D8D1 /* FavoritesTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesTableViewCell.swift; sourceTree = "<group>"; };
+		4F28B15B1B9101720033D8D1 /* HistoryTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryTableViewCell.swift; sourceTree = "<group>"; };
 		4F28B15C1B9101720033D8D1 /* DirectMessagesTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectMessagesTableViewCell.swift; sourceTree = "<group>"; };
 		4F28B15D1B9101720033D8D1 /* PrivateGroupsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateGroupsTableViewCell.swift; sourceTree = "<group>"; };
 		4F28B15E1B9101720033D8D1 /* ChannelsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelsTableViewCell.swift; sourceTree = "<group>"; };
@@ -128,6 +129,7 @@
 		A5A3A9751B93CBFC00CFE8FB /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DF113AE41BA6D87B00CE6D17 /* MyAccountBarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyAccountBarViewController.swift; sourceTree = "<group>"; };
 		DF113AE81BA6D91000CE6D17 /* MyAccountBarTabViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyAccountBarTabViewController.swift; sourceTree = "<group>"; };
+		DF19164B1C010F2B0055D107 /* Room.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Room.swift; sourceTree = "<group>"; };
 		DF2A60E51B8DC6280014548B /* RegisterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RegisterViewController.swift; path = ../RegisterViewController.swift; sourceTree = "<group>"; };
 		DF2A60E71B8DCD3A0014548B /* ForgotPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForgotPasswordViewController.swift; sourceTree = "<group>"; };
 		DF4928A41BFDCA3400B1F901 /* DarwinNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DarwinNotifications.swift; sourceTree = "<group>"; };
@@ -228,7 +230,7 @@
 		410CEB161B8B387B00CAFFE9 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
-				4F28B15B1B9101720033D8D1 /* FavoritesTableViewCell.swift */,
+				4F28B15B1B9101720033D8D1 /* HistoryTableViewCell.swift */,
 				4F28B15C1B9101720033D8D1 /* DirectMessagesTableViewCell.swift */,
 				4F28B15D1B9101720033D8D1 /* PrivateGroupsTableViewCell.swift */,
 				4F28B15E1B9101720033D8D1 /* ChannelsTableViewCell.swift */,
@@ -327,6 +329,7 @@
 			isa = PBXGroup;
 			children = (
 				DF70828D1BED0FF9005B6192 /* ChatMessage.swift */,
+				DF19164B1C010F2B0055D107 /* Room.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -583,6 +586,7 @@
 				DF7CD46C1BA585B6004B55E9 /* SettingsMenuViewController.swift in Sources */,
 				4F28B1631B9101720033D8D1 /* ChannelsTableViewCell.swift in Sources */,
 				410CEB141B8B386E00CAFFE9 /* AppDelegate.swift in Sources */,
+				DF19164C1C010F2B0055D107 /* Room.swift in Sources */,
 				410CEB1B1B8B388300CAFFE9 /* MainTableViewCell.swift in Sources */,
 				DF5F92631BAC4315000EA4C3 /* SoundOptionsViewController.swift in Sources */,
 				DF7F94C11BCFA67000B52126 /* RoomHistoryManager.swift in Sources */,
@@ -610,7 +614,7 @@
 				4F28B1591B90FF230033D8D1 /* AccountBarViewController.swift in Sources */,
 				DF7C52C21BCB95530087B2B4 /* ChooseFileViewController.swift in Sources */,
 				4F28B1651B93514E0033D8D1 /* AccountOptionsTableViewController.swift in Sources */,
-				4F28B1601B9101720033D8D1 /* FavoritesTableViewCell.swift in Sources */,
+				4F28B1601B9101720033D8D1 /* HistoryTableViewCell.swift in Sources */,
 				4F18F6871BB4103A00048D7E /* UsernameRegistrationViewController.swift in Sources */,
 				410CEB231B8B388F00CAFFE9 /* RightViewController.swift in Sources */,
 				4F28B1671B936C6C0033D8D1 /* LeftMenuTabBarViewController.swift in Sources */,
@@ -733,7 +737,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -773,7 +777,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
@@ -795,7 +799,7 @@
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
 				INFOPLIST_FILE = Rocket.Chat.iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "chat.rocket.Rocket-Chat-iOS";
@@ -820,7 +824,7 @@
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
 				INFOPLIST_FILE = Rocket.Chat.iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "chat.rocket.Rocket-Chat-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Rocket.Chat.iOS/AppDelegate.swift
+++ b/Rocket.Chat.iOS/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.meteorClient.addSubscription("activeUsers")
         //        self.meteorClient.addSubscription("userData")
         self.meteorClient.addSubscription("subscription")
-        
+        self.meteorClient.addSubscription("rocketchat_subscription")
         return true
     }
     
@@ -112,7 +112,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillEnterForeground(application: UIApplication) {
 
         NSUserDefaults.standardUserDefaults().setBool(false, forKey: "kDisplayStatusLocked")
-        
+
     }
     
     
@@ -148,7 +148,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     
     func reportConnectionReady() {
-        
+
         print("Connection Ready\n")
         connectWithSessionToken()
         
@@ -203,6 +203,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func reportDisconnection() {
         print("================> disconnected from server!")
         
+        
         //notify current rootview controller
         let controller = self.window?.rootViewController
         
@@ -243,6 +244,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     
                 }
                 print("\(response)\n")
+                
+                NSUserDefaults.standardUserDefaults().setBool(true, forKey: "connectedWithSessionToken")
                 
                 let appDelegate:AppDelegate = UIApplication.sharedApplication().delegate as! AppDelegate
                 

--- a/Rocket.Chat.iOS/Base.lproj/LaunchScreen.storyboard
+++ b/Rocket.Chat.iOS/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8187.4" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8151.3"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
     <scenes>
         <!--View Controller-->

--- a/Rocket.Chat.iOS/Base.lproj/LeftMenu.storyboard
+++ b/Rocket.Chat.iOS/Base.lproj/LeftMenu.storyboard
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -259,7 +258,7 @@
                         <sections>
                             <tableViewSection headerTitle="Status" id="ARU-id-X4b" userLabel="Status">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="favoritesCell" id="B4G-uR-27I" userLabel="OnlineCell" customClass="FavoritesTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="historyCell" id="B4G-uR-27I" userLabel="OnlineCell" customClass="HistoryTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="B4G-uR-27I" id="n1a-UP-Zx0">
@@ -290,7 +289,7 @@
                                             <outlet property="nameLabel" destination="fBj-cQ-OOH" id="hc7-51-rnT"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="favoritesCell" id="Dm6-6G-uZE" userLabel="AwayCell" customClass="FavoritesTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="historyCell" id="Dm6-6G-uZE" userLabel="AwayCell" customClass="HistoryTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="72" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Dm6-6G-uZE" id="tmF-K1-p9o">
@@ -323,7 +322,7 @@
                                             <outlet property="nameLabel" destination="qSH-UG-nmE" id="3O3-0J-7aC"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="favoritesCell" id="Vlu-ml-Caq" userLabel="BusyCell" customClass="FavoritesTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="historyCell" id="Vlu-ml-Caq" userLabel="BusyCell" customClass="HistoryTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="116" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Vlu-ml-Caq" id="nwa-3P-qGw">
@@ -356,7 +355,7 @@
                                             <outlet property="nameLabel" destination="jbv-ZA-Pku" id="F3r-Jn-t9r"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="favoritesCell" id="ipY-m6-T2K" userLabel="InvisibleCell" customClass="FavoritesTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="historyCell" id="ipY-m6-T2K" userLabel="InvisibleCell" customClass="HistoryTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="160" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ipY-m6-T2K" id="2zd-6G-vud">
@@ -393,7 +392,7 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Options" id="iYe-pn-z1y" userLabel="Options">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="favoritesCell" id="Dh1-1s-5lg" userLabel="SettingsCell" customClass="FavoritesTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="historyCell" id="Dh1-1s-5lg" userLabel="SettingsCell" customClass="HistoryTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="232" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Dh1-1s-5lg" id="RLt-d7-UWs">
@@ -424,7 +423,7 @@
                                             <outlet property="nameLabel" destination="KJX-i1-Ef2" id="Ebp-fy-UL9"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="favoritesCell" id="i4I-MC-acb" userLabel="SettingsCell" customClass="FavoritesTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="historyCell" id="i4I-MC-acb" userLabel="SettingsCell" customClass="HistoryTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="276" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="i4I-MC-acb" id="SXM-4u-RoX">
@@ -601,7 +600,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.01176470588" green="0.26274509800000001" blue="0.41568627450000001" alpha="1" colorSpace="calibratedRGB"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="favoritesCell" id="QgN-K3-dzw" customClass="FavoritesTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="channelsCell" id="QgN-K3-dzw" customClass="ChannelsTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="50" width="320" height="32"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QgN-K3-dzw" id="pAf-W3-Xz8">
@@ -614,7 +613,7 @@
                                             <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="s" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iNs-Md-WAz">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iNs-Md-WAz">
                                             <rect key="frame" x="8" y="-2" width="24" height="33"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="24" id="bPc-nn-prS"/>
@@ -640,24 +639,24 @@
                                     <outlet property="statusLabel" destination="iNs-Md-WAz" id="mlS-1x-8il"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="channelsCell" id="MYV-8Q-fXD" customClass="ChannelsTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="dmCell" id="MYV-8Q-fXD" customClass="DirectMessagesTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="82" width="320" height="32"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="MYV-8Q-fXD" id="OR5-Ti-skW">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="31"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="s" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dQd-Gq-fHy">
-                                            <rect key="frame" x="8" y="0.0" width="24" height="31"/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" constant="24" id="WEz-Cg-MQf"/>
-                                            </constraints>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label..." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Jz-gK-Dff">
+                                            <rect key="frame" x="31" y="0.0" width="269" height="31"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label..." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Jz-gK-Dff">
-                                            <rect key="frame" x="31" y="0.0" width="269" height="31"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dQd-Gq-fHy">
+                                            <rect key="frame" x="8" y="0.0" width="24" height="31"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="24" id="WEz-Cg-MQf"/>
+                                            </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
@@ -679,7 +678,7 @@
                                     <outlet property="statusLabel" destination="dQd-Gq-fHy" id="pLf-Fx-BMO"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="dmCell" id="HeS-hV-i2I" customClass="DirectMessagesTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="groupsCell" id="HeS-hV-i2I" customClass="PrivateGroupsTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="114" width="320" height="32"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="HeS-hV-i2I" id="qAy-W9-uru">
@@ -692,7 +691,7 @@
                                             <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="s" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3gW-a9-xB2">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3gW-a9-xB2">
                                             <rect key="frame" x="8" y="0.0" width="24" height="31"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="24" id="Kqi-z7-J1e"/>
@@ -718,22 +717,13 @@
                                     <outlet property="statusLabel" destination="3gW-a9-xB2" id="Tsf-H9-qc5"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="groupsCell" id="k6P-FJ-ssG" customClass="PrivateGroupsTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="historyCell" id="k6P-FJ-ssG" customClass="HistoryTableViewCell" customModule="Rocket_Chat_iOS" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="146" width="320" height="32"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="k6P-FJ-ssG" id="gUh-JN-pgB">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="31"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="s" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vX5-am-dbw">
-                                            <rect key="frame" x="8" y="0.0" width="24" height="31"/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" constant="24" id="a3K-UY-4G2"/>
-                                            </constraints>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label..." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ekv-MU-CXr">
                                             <rect key="frame" x="31" y="0.0" width="269" height="31"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -742,19 +732,15 @@
                                         </label>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="Ekv-MU-CXr" firstAttribute="leading" secondItem="gUh-JN-pgB" secondAttribute="leadingMargin" constant="23" id="1om-YN-9E6"/>
-                                        <constraint firstItem="Ekv-MU-CXr" firstAttribute="top" secondItem="gUh-JN-pgB" secondAttribute="top" id="2iE-ZD-0gf"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="Ekv-MU-CXr" secondAttribute="trailing" constant="12" id="Fix-L7-an2"/>
-                                        <constraint firstItem="vX5-am-dbw" firstAttribute="firstBaseline" secondItem="Ekv-MU-CXr" secondAttribute="firstBaseline" id="PE5-z3-nWa"/>
-                                        <constraint firstAttribute="bottom" secondItem="vX5-am-dbw" secondAttribute="bottom" id="Pdz-MZ-Z8s"/>
-                                        <constraint firstAttribute="leadingMargin" secondItem="vX5-am-dbw" secondAttribute="leading" id="iKZ-9p-dOQ"/>
-                                        <constraint firstItem="vX5-am-dbw" firstAttribute="baseline" secondItem="Ekv-MU-CXr" secondAttribute="baseline" id="wlx-Af-Ze5"/>
+                                        <constraint firstItem="Ekv-MU-CXr" firstAttribute="top" secondItem="gUh-JN-pgB" secondAttribute="top" id="2d1-3D-9BA"/>
+                                        <constraint firstItem="Ekv-MU-CXr" firstAttribute="leading" secondItem="gUh-JN-pgB" secondAttribute="leadingMargin" constant="23" id="F3t-QN-6Iu"/>
+                                        <constraint firstAttribute="bottom" secondItem="Ekv-MU-CXr" secondAttribute="bottom" id="SKw-4q-WqF"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="Ekv-MU-CXr" secondAttribute="trailing" constant="12" id="bwn-q3-b2G"/>
                                     </constraints>
                                 </tableViewCellContentView>
                                 <color key="backgroundColor" red="0.015686274510000001" green="0.26274509800000001" blue="0.41568627450000001" alpha="1" colorSpace="calibratedRGB"/>
                                 <connections>
                                     <outlet property="nameLabel" destination="Ekv-MU-CXr" id="Gjg-vi-B7a"/>
-                                    <outlet property="statusLabel" destination="vX5-am-dbw" id="QYF-hV-TtA"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>

--- a/Rocket.Chat.iOS/Base.lproj/LeftMenu.storyboard
+++ b/Rocket.Chat.iOS/Base.lproj/LeftMenu.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1509" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>

--- a/Rocket.Chat.iOS/Base.lproj/Main.storyboard
+++ b/Rocket.Chat.iOS/Base.lproj/Main.storyboard
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="adJ-xO-Vln">
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
@@ -19,7 +18,7 @@
         </mutableArray>
     </customFonts>
     <scenes>
-        <!--View Controller-->
+        <!--Title-->
         <scene sceneID="ZB7-k7-jxU">
             <objects>
                 <viewController storyboardIdentifier="viewController" automaticallyAdjustsScrollViewInsets="NO" id="uTd-Gh-naL" customClass="ViewController" customModule="Rocket_Chat_iOS" customModuleProvider="target" sceneMemberID="viewController">
@@ -75,7 +74,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="344" height="79"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="V7E-uh-7ni">
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="V7E-uh-7ni">
                                                     <rect key="frame" x="23" y="10" width="60" height="60"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="60" id="8jQ-VM-XGa"/>
@@ -244,7 +243,7 @@
                             <constraint firstItem="1ah-tf-R3M" firstAttribute="top" secondItem="hUb-s7-0eT" secondAttribute="top" id="uVp-sH-FAh"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="cQN-uN-CZi">
+                    <navigationItem key="navigationItem" title="Title" id="cQN-uN-CZi">
                         <barButtonItem key="leftBarButtonItem" title="Menu" id="KNH-mw-WAW">
                             <connections>
                                 <action selector="leftNavTapped:" destination="uTd-Gh-naL" id="hny-Zb-7Oq"/>

--- a/Rocket.Chat.iOS/Base.lproj/Right.storyboard
+++ b/Rocket.Chat.iOS/Base.lproj/Right.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
     <scenes>
         <!--Right View Controller-->

--- a/Rocket.Chat.iOS/Base.lproj/Right.storyboard
+++ b/Rocket.Chat.iOS/Base.lproj/Right.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1509" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <scenes>
         <!--Right View Controller-->

--- a/Rocket.Chat.iOS/ChatMessage.swift
+++ b/Rocket.Chat.iOS/ChatMessage.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class ChatMessage {
 
+    var rid = String()
     var userId = String()
     var username = String()
     var message = String()
@@ -18,22 +19,21 @@ class ChatMessage {
     
     
     
-    init(user_id: String, username: String, msg: String, msgType: String, ts: Double){
+    init(rid: String ,user_id: String, username: String, msg: String, msgType: String, ts: Double?){
 
+        self.rid = rid
         self.userId = user_id
         self.username = username
         self.message = msg
         self.messageType = msgType
-        self.timestamp = ts
+        self.timestamp = ts!
         
     }
     
     convenience init() {
-        self.init(user_id: String(), username: String(), msg: String(), msgType: String(), ts: Double())
+        self.init(rid: String(), user_id: String(), username: String(), msg: String(), msgType: String(), ts: Double())
     }
     
-    
-
     
 }
 

--- a/Rocket.Chat.iOS/DarwinNotifications.swift
+++ b/Rocket.Chat.iOS/DarwinNotifications.swift
@@ -13,7 +13,7 @@ func displayStatusChanged(center: CFNotificationCenter!, _: UnsafeMutablePointer
     if (name == "com.apple.springboard.lockcomplete") {
         
         NSUserDefaults.standardUserDefaults().setBool(true, forKey: "kDisplayStatusLocked")
-        
+
     }
     
 }

--- a/Rocket.Chat.iOS/HistoryTableViewCell.swift
+++ b/Rocket.Chat.iOS/HistoryTableViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  FavoritesTableViewCell.swift
+//  HistoryTableViewCell.swift
 //  Rocket.Chat.iOS
 //
 //  Created by giorgos on 8/24/15.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class FavoritesTableViewCell: UITableViewCell {
+class HistoryTableViewCell: UITableViewCell {
   
   // MARK: Properties
   @IBOutlet weak var statusLabel: UILabel!

--- a/Rocket.Chat.iOS/Room.swift
+++ b/Rocket.Chat.iOS/Room.swift
@@ -1,0 +1,47 @@
+//
+//  Room.swift
+//  Rocket.Chat.iOS
+//
+//  Created by Kornelakis Michael on 11/21/15.
+//  Copyright © 2015 Rocket.Chat. All rights reserved.
+//
+
+import UIKit
+
+class Room {
+    
+    var _id = String()
+    var unread = Int()
+    var t = String()
+    var open = Bool()
+    var ts = Double()
+    var rid = String()
+    var ls = Double()
+    var alert = Bool()
+    var name = String()
+    
+    
+    init(_id: String ,unread: Int, t: String, open: Bool, ts: Double?, rid: String, ls: Double?, alert: Bool, name: String){
+    
+        self._id = _id
+        self.unread = unread
+        self.t = t
+        self.open = open
+        if ts != nil {
+           self.ts = ts!
+        }
+        self.rid = rid
+        if ls != nil {
+            self.ls = ls!
+        }
+        self.alert = alert
+        self.name = name
+        
+    }
+    
+    convenience init() {
+        self.init(_id: String(), unread: Int(), t: String(), open: Bool(), ts: Double(), rid: String(), ls: Double(), alert: Bool(), name: String())
+    }
+    
+    
+}

--- a/Rocket.Chat.iOS/Room.swift
+++ b/Rocket.Chat.iOS/Room.swift
@@ -10,15 +10,15 @@ import UIKit
 
 class Room {
     
-    var _id = String()
-    var unread = Int()
-    var t = String()
-    var open = Bool()
-    var ts = Double()
-    var rid = String()
-    var ls = Double()
-    var alert = Bool()
-    var name = String()
+    var _id:String
+    var unread:Int
+    var t:String
+    var open:Bool
+    var ts:Double
+    var rid:String
+    var ls:Double
+    var alert:Bool
+    var name:String
     
     
     init(_id: String ,unread: Int, t: String, open: Bool, ts: Double?, rid: String, ls: Double?, alert: Bool, name: String){
@@ -29,10 +29,14 @@ class Room {
         self.open = open
         if ts != nil {
            self.ts = ts!
+        }else {
+            self.ts = Double()
         }
         self.rid = rid
         if ls != nil {
             self.ls = ls!
+        }else {
+            self.ls = Double()
         }
         self.alert = alert
         self.name = name

--- a/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
@@ -146,6 +146,7 @@ class AccountOptionsTableViewController: UITableViewController {
             if (meteor.connected){
                 
                 meteor.logout()
+                NSUserDefaults.standardUserDefaults().setBool(false, forKey: "connectedWithSessionToken")
                 print("Logged out")
                 ad.window?.rootViewController = loginVC
             

--- a/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
@@ -14,6 +14,7 @@ class AccountOptionsTableViewController: UITableViewController {
     
     var meteor = MeteorClient!()
     var ad:AppDelegate?
+    var viewController:ViewController!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,6 +22,9 @@ class AccountOptionsTableViewController: UITableViewController {
         self.ad = UIApplication.sharedApplication().delegate as? AppDelegate
         self.meteor = self.ad!.meteorClient
 
+        let navC = self.ad?.centerContainer?.centerViewController as! UINavigationController
+        self.viewController = navC.viewControllers.first as! ViewController
+        
         // Uncomment the following line to preserve selection between presentations
         // self.clearsSelectionOnViewWillAppear = false
 
@@ -128,6 +132,8 @@ class AccountOptionsTableViewController: UITableViewController {
                 print("default")
             }
             
+            checkIfWeAreOnSettingsAndSetCenterContainer()
+        
         }
         //If user selects MySettings
         else if (indexPath.section == 1 && indexPath.row == 0) {
@@ -195,6 +201,9 @@ class AccountOptionsTableViewController: UITableViewController {
         let leftMenuTabBarController = tabBarController as! LeftMenuTabBarViewController
         
         
+        sendCenterContainerToChatNavWhenSettingsSelected()
+        
+        
         switch viewToAppear{
             
             case "ChatNav":
@@ -202,6 +211,7 @@ class AccountOptionsTableViewController: UITableViewController {
                 tabBarController?.selectedViewController = tabBarController?.viewControllers![leftMenuTabBarController.findIndexOfChatNav()]
                 
             case "Settings":
+                
                 //Create MySettingsViewController instance
                 let mySettingsVC = storyboard?.instantiateViewControllerWithIdentifier("mySettings") as! MySettingsViewController
                 
@@ -219,6 +229,38 @@ class AccountOptionsTableViewController: UITableViewController {
             default:
                 tabBarController?.selectedViewController = tabBarController?.viewControllers![leftMenuTabBarController.findIndexOfMySettings()]
         
+        }
+        
+    }
+    
+    
+    func checkIfWeAreOnSettingsAndSetCenterContainer() {
+        let navC = self.ad?.centerContainer?.centerViewController as! UINavigationController
+        
+        if (navC.viewControllers.first!.isKindOfClass(MySettingsViewController) == true) {
+            print("Settings are the center")
+            let centerNewNav = UINavigationController(rootViewController: self.viewController!)
+            self.ad!.centerContainer?.setCenterViewController(centerNewNav, withCloseAnimation: false, completion: nil)
+            self.ad!.centerContainer?.closeDrawerAnimated(true, completion: nil)
+        }
+        
+    }
+    
+    
+    
+    func sendCenterContainerToChatNavWhenSettingsSelected() {
+        
+        //get LeftMenu's tab bar controller
+        let leftMenuTabBarController = tabBarController as! LeftMenuTabBarViewController
+        
+        //Send the current center ViewController instance to ChatsNavTableViewController so we can return to it
+        let chatsNavTableViewController = tabBarController?.viewControllers![leftMenuTabBarController.findIndexOfChatNav()] as! ChatsNavTableViewController
+        let navC = self.ad?.centerContainer?.centerViewController as? UINavigationController
+        
+        if ((navC?.viewControllers.first?.isKindOfClass(ViewController)) == true) {
+            
+            chatsNavTableViewController.currentCenterVCWhenSettingsSelected = navC?.viewControllers.first as? ViewController
+            
         }
         
     }

--- a/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/AccountOptionsTableViewController.swift
@@ -235,10 +235,18 @@ class AccountOptionsTableViewController: UITableViewController {
     
     
     func checkIfWeAreOnSettingsAndSetCenterContainer() {
+        
         let navC = self.ad?.centerContainer?.centerViewController as! UINavigationController
         
-        if (navC.viewControllers.first!.isKindOfClass(MySettingsViewController) == true) {
-            print("Settings are the center")
+//        if (navC.viewControllers.first!.isKindOfClass(MySettingsViewController) == true) {
+//            print("Settings were the center")
+//            let centerNewNav = UINavigationController(rootViewController: self.viewController!)
+//            self.ad!.centerContainer?.setCenterViewController(centerNewNav, withCloseAnimation: false, completion: nil)
+//            self.ad!.centerContainer?.closeDrawerAnimated(true, completion: nil)
+//        }
+        
+        if (navC.viewControllers.first!.isKindOfClass(ViewController) != true) {
+            print("Channel was not the center")
             let centerNewNav = UINavigationController(rootViewController: self.viewController!)
             self.ad!.centerContainer?.setCenterViewController(centerNewNav, withCloseAnimation: false, completion: nil)
             self.ad!.centerContainer?.closeDrawerAnimated(true, completion: nil)

--- a/Rocket.Chat.iOS/ViewControllers/Auth/AuthViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/Auth/AuthViewController.swift
@@ -85,7 +85,6 @@ class AuthViewController: UIViewController {
     let centerContainer:MMDrawerController = MMDrawerController(centerViewController: centerNav, leftDrawerViewController: leftSideNav,rightDrawerViewController:rightNav)
     
     //Open and Close gestures for the center container
-    
     centerContainer.openDrawerGestureModeMask = MMOpenDrawerGestureMode.PanningCenterView;
     centerContainer.closeDrawerGestureModeMask = MMCloseDrawerGestureMode.PanningCenterView;
     
@@ -98,6 +97,6 @@ class AuthViewController: UIViewController {
     //Set the rootViewController as the center container
     appDelegate.window!.rootViewController = appDelegate.centerContainer
     appDelegate.window!.makeKeyAndVisible()
-
+    
   }
 }

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -32,11 +32,6 @@ class ChatsNavTableViewController: UITableViewController {
 
   }
   // MARK: - Table view data source
-  
-  override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
-    return 4
-  }
-  
   override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return 1
   }
@@ -98,6 +93,11 @@ class ChatsNavTableViewController: UITableViewController {
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
+    }
+    
+    
+    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return 4
     }
     
     

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -173,24 +173,30 @@ enum LeftMenuCellIds: String {
 
 /** The section IDs and names for the Left Menu UITableView */
 enum LeftMenuHeaders: Int {
-  
-  case Favorites = 0
-  case Channels
-  case DirectMessages
-  case PrivateGroups
-  
-  func toString()-> String {
-    switch self{
-    case .Favorites:
-      return "Favorites"
-    case .Channels:
-      return "Channels"
-    case .DirectMessages:
-      return "Direct Messages"
-    case .PrivateGroups:
-      return "Private Groups"
+    
+    case Channels = 0
+    case DirectMessages
+    case PrivateGroups
+    case History
+    
+    func toString()-> String {
+        switch self{
+        case .Channels:
+            return "Channels"
+        case .DirectMessages:
+            return "Direct Messages"
+        case .PrivateGroups:
+            return "Private Groups"
+        case .History:
+            return "History"
+        }
+        
     }
     
-  }
-  
+}
+
+
+/** This protocol is used for handling events from the AccountBar. */
+protocol SwitchRoomDelegate {
+    func didSelectRoom(rid: String, roomName: String)
 }

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -31,16 +31,6 @@ class ChatsNavTableViewController: UITableViewController {
     tableView.separatorColor = UIColor.clearColor()
 
   }
-  // MARK: - Table view data source
-  override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return 1
-  }
-  
-  override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-    
-    return LeftMenuHeaders(rawValue: section)?.toString()
-  }
-  
   override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
     
     // Table view cells are reused and should be dequeued using a cell identifier.
@@ -98,6 +88,49 @@ class ChatsNavTableViewController: UITableViewController {
     
     override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
         return 4
+    }
+    
+    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        
+        switch LeftMenuHeaders(rawValue: section)!.rawValue{
+            
+        case LeftMenuHeaders.Channels.rawValue:
+            
+            if self.channelsData.count == 0 {
+                return 1
+            }else {
+                return self.channelsData.count
+            }
+            
+        case LeftMenuHeaders.DirectMessages.rawValue:
+            
+            if self.directMessagesData.count == 0 {
+                return 1
+            }else {
+                return self.directMessagesData.count
+            }
+        case LeftMenuHeaders.PrivateGroups.rawValue:
+            
+            if self.privateGroupsData.count == 0 {
+                return 1
+            }else {
+                return self.privateGroupsData.count
+            }
+            
+        default:
+            
+            return 1
+            
+        }
+        
+        
+    }
+    
+    
+    
+    override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        
+        return LeftMenuHeaders(rawValue: section)?.toString()
     }
     
     

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -78,15 +78,6 @@ class ChatsNavTableViewController: UITableViewController {
     
     return cell!
   }
-  
-  override func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
-
-    // for some reason, the background color on ipads does not respect the storyboard value.
-    cell.backgroundColor = UIColor(red: 4, green: 67, blue: 106, alpha: 0)
-
-    //TODO: replace this with hex value once we merge with @kormic's branch
-  }
-  
   func drawFavoritesCell(currentCell: FavoritesTableViewCell, currentTableView: UITableView, currentIndexPath: NSIndexPath){
     //TODO
     currentCell.nameLabel?.text = "Favorites \(currentIndexPath.section) Row \(currentIndexPath.row)"
@@ -158,6 +149,15 @@ class ChatsNavTableViewController: UITableViewController {
   }
   */
   
+    
+    override func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
+        
+        // for some reason, the background color on ipads does not respect the storyboard value.
+        cell.backgroundColor = UIColor(red: 4, green: 67, blue: 106, alpha: 0)
+        
+        //TODO: replace this with hex value once we merge with @kormic's branch
+    }
+    
 }
 
 /** The cell ids used in the UITableView in order to identify the different prototype cells. */

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -162,13 +162,13 @@ class ChatsNavTableViewController: UITableViewController {
 
 /** The cell ids used in the UITableView in order to identify the different prototype cells. */
 enum LeftMenuCellIds: String {
-  case Favorites = "favoritesCell"
-  case Channels = "channelsCell"
-  case DirectMessages = "dmCell"
-  case PrivateGroups = "groupsCell"
-  
-  static let allValues = [Favorites, Channels, DirectMessages, PrivateGroups]
-
+    case Channels = "channelsCell"
+    case DirectMessages = "dmCell"
+    case PrivateGroups = "groupsCell"
+    case History = "historyCell"
+    
+    static let allValues = [Channels, DirectMessages, PrivateGroups, History]
+    
 }
 
 /** The section IDs and names for the Left Menu UITableView */

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -106,6 +106,7 @@ class ChatsNavTableViewController: UITableViewController {
             
             if self.channelsData[i]._id == incomingRoom["_id"].string! {
                 self.channelsData.removeAtIndex(i)
+                roomRemovedNotification()
                 break
             }
             
@@ -115,6 +116,7 @@ class ChatsNavTableViewController: UITableViewController {
             
             if self.directMessagesData[i]._id == incomingRoom["_id"].string! {
                 self.directMessagesData.removeAtIndex(i)
+                roomRemovedNotification()
                 break
             }
             
@@ -124,6 +126,7 @@ class ChatsNavTableViewController: UITableViewController {
             
             if self.privateGroupsData[i]._id == incomingRoom["_id"].string! {
                 self.privateGroupsData.removeAtIndex(i)
+                roomRemovedNotification()
                 break
             }
             
@@ -321,6 +324,24 @@ class ChatsNavTableViewController: UITableViewController {
             self.ad!.centerContainer?.setCenterViewController(centerNewNav, withCloseAnimation: false, completion: nil)
         }
         
+    }
+    
+    func roomRemovedNotification() {
+    
+        let alert = UIAlertController(title: "Room Removed", message: "This room has been removed", preferredStyle: UIAlertControllerStyle.Alert)
+        let ok = UIAlertAction(title: "OK", style: .Default) { _ in
+            
+            let currentVC = self.ad?.centerContainer?.centerViewController as! UINavigationController
+            let vc = currentVC.viewControllers.first as! ViewController
+
+            vc.composeMsg.userInteractionEnabled = false
+            vc.composeMsg.backgroundColor = UIColor.lightGrayColor()
+            vc.composeMsgButton.userInteractionEnabled = false
+            vc.composeMsgButton.enabled = false
+        }
+        alert.addAction(ok)
+        self.presentViewController(alert, animated: true, completion: nil)
+    
     }
     
 }

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -98,6 +98,40 @@ class ChatsNavTableViewController: UITableViewController {
         
     }
     
+    func roomRemoved(notification: NSNotification) {
+        
+        let incomingRoom = JSON(notification.userInfo!)
+        
+        for (var i = 0; i < self.channelsData.count ; i++){
+            
+            if self.channelsData[i]._id == incomingRoom["_id"].string! {
+                self.channelsData.removeAtIndex(i)
+                break
+            }
+            
+        }
+        
+        for (var i = 0; i < self.directMessagesData.count ; i++){
+            
+            if self.directMessagesData[i]._id == incomingRoom["_id"].string! {
+                self.directMessagesData.removeAtIndex(i)
+                break
+            }
+            
+        }
+        
+        for (var i = 0; i < self.privateGroupsData.count ; i++){
+            
+            if self.privateGroupsData[i]._id == incomingRoom["_id"].string! {
+                self.privateGroupsData.removeAtIndex(i)
+                break
+            }
+            
+        }
+        
+        self.tableView.reloadData()
+    }
+    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -315,8 +315,8 @@ class ChatsNavTableViewController: UITableViewController {
     
     
     func checkIfWeAreOnSettingsAndSetCenterContainer(navController: UINavigationController) {
-        
-        if ((navController.viewControllers.first?.isKindOfClass(MySettingsViewController)) == true) {
+        print("Check if we are on settings")
+        if ((navController.viewControllers.first?.isKindOfClass(ViewController)) != true) {
             let centerNewNav = UINavigationController(rootViewController: self.currentCenterVCWhenSettingsSelected!)
             self.ad!.centerContainer?.setCenterViewController(centerNewNav, withCloseAnimation: false, completion: nil)
         }

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -31,12 +31,6 @@ class ChatsNavTableViewController: UITableViewController {
     tableView.separatorColor = UIColor.clearColor()
 
   }
-  
-  override func didReceiveMemoryWarning() {
-    super.didReceiveMemoryWarning()
-    // Dispose of any resources that can be recreated.
-  }
-  
   // MARK: - Table view data source
   
   override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
@@ -100,6 +94,12 @@ class ChatsNavTableViewController: UITableViewController {
     currentCell.statusLabel?.text = "g"
     currentCell.nameLabel?.text = "Groups \(currentIndexPath.section) Row \(currentIndexPath.row)"
   }
+    
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
     
     override func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
         

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -7,6 +7,8 @@
 //
 
 import UIKit
+import ObjectiveDDP
+import SwiftyJSON
 
 class ChatsNavTableViewController: UITableViewController {
   
@@ -15,6 +17,12 @@ class ChatsNavTableViewController: UITableViewController {
     
     // Uncomment the following line to preserve selection between presentations
     // self.clearsSelectionOnViewWillAppear = false
+    var meteor:MeteorClient?
+    var channelsData = [Room]()
+    var directMessagesData = [Room]()
+    var privateGroupsData = [Room]()
+    var ad:AppDelegate?
+    var delegate:SwitchRoomDelegate?
     
     // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
     // self.navigationItem.rightBarButtonItem = self.editButtonItem()

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -143,6 +143,45 @@ class ChatsNavTableViewController: UITableViewController {
         return LeftMenuHeaders(rawValue: section)?.toString()
     }
     
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        
+        // Table view cells are reused and should be dequeued using a cell identifier.
+        
+        var cell: UITableViewCell?
+        
+        if indexPath.section == LeftMenuHeaders.Channels.rawValue {
+            
+            let mycell = tableView.dequeueReusableCellWithIdentifier(LeftMenuCellIds.Channels.rawValue, forIndexPath: indexPath) as! ChannelsTableViewCell
+            drawChannelsCell(mycell, currentTableView: tableView, currentIndexPath: indexPath)
+            
+            cell = mycell
+            
+        }else if indexPath.section == LeftMenuHeaders.DirectMessages.rawValue {
+            
+            let mycell = tableView.dequeueReusableCellWithIdentifier(LeftMenuCellIds.DirectMessages.rawValue, forIndexPath: indexPath) as! DirectMessagesTableViewCell
+            drawMessagesCell(mycell, currentTableView: tableView, currentIndexPath: indexPath)
+            
+            cell = mycell
+            
+        }else if indexPath.section == LeftMenuHeaders.PrivateGroups.rawValue {
+            
+            let mycell = tableView.dequeueReusableCellWithIdentifier(LeftMenuCellIds.PrivateGroups.rawValue, forIndexPath: indexPath) as! PrivateGroupsTableViewCell
+            drawGroupsCell(mycell, currentTableView: tableView, currentIndexPath: indexPath)
+            
+            cell = mycell
+            
+        }else if indexPath.section == LeftMenuHeaders.History.rawValue {
+            
+            let mycell = tableView.dequeueReusableCellWithIdentifier(LeftMenuCellIds.History.rawValue, forIndexPath: indexPath) as! HistoryTableViewCell
+            drawHistoryCell(mycell, currentTableView: tableView, currentIndexPath: indexPath)
+            
+            cell = mycell
+            
+        }
+        
+        return cell!
+        
+    }
     
     override func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
         
@@ -152,7 +191,78 @@ class ChatsNavTableViewController: UITableViewController {
         //TODO: replace this with hex value once we merge with @kormic's branch
     }
     
+    func drawChannelsCell(currentCell: ChannelsTableViewCell, currentTableView: UITableView, currentIndexPath: NSIndexPath){
+        
+        
+        if self.channelsData.count == 0 {
+            currentCell.nameLabel?.text = "You haven't joined any rooms yet"
+        }else {
+            currentCell.statusLabel?.text = "#"
+            currentCell.nameLabel?.text = "\(self.channelsData[currentIndexPath.row].name)"
+        }
+    }
+    
+    func drawMessagesCell(currentCell: DirectMessagesTableViewCell, currentTableView: UITableView, currentIndexPath: NSIndexPath){
+        
+        if self.directMessagesData.count == 0 {
+            currentCell.nameLabel?.text = "You haven't started any conversations yet"
+        }else {
+            currentCell.statusLabel?.text = "@"
+            currentCell.nameLabel?.text = "\(self.directMessagesData[currentIndexPath.row].name)"
+        }
+    }
+    
+    func drawGroupsCell(currentCell: PrivateGroupsTableViewCell, currentTableView: UITableView, currentIndexPath: NSIndexPath){
+        
+        if self.privateGroupsData.count == 0 {
+            //            currentCell.nameLabel.font = UIFont.italicSystemFontOfSize(15)
+            //            currentCell.nameLabel.textColor = UIColor.rocketSecondaryFontColor()
+            currentCell.nameLabel?.text = "You have no private groups yet"
+        }else {
+            currentCell.statusLabel?.text = "g"
+            currentCell.nameLabel?.text = "\(self.privateGroupsData[currentIndexPath.row].name)"
+        }
+        
+    }
+    
+    func drawHistoryCell(currentCell: HistoryTableViewCell, currentTableView: UITableView, currentIndexPath: NSIndexPath){
+        
+        currentCell.nameLabel.hidden = true
+        currentCell.userInteractionEnabled = false
+        //        currentCell.nameLabel?.text = "History \(currentIndexPath.section) Row \(currentIndexPath.row)"
+    }
+    
+    
+    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        
+        
+        if indexPath.section == LeftMenuHeaders.Channels.rawValue {
+            
+            if ((delegate) != nil){ // let delegate know about event
+                delegate!.didSelectRoom(self.channelsData[indexPath.row].rid, roomName: self.channelsData[indexPath.row].name)
+            }
+            
+        }else if indexPath.section == LeftMenuHeaders.DirectMessages.rawValue {
+            
+            if ((delegate) != nil){ // let delegate know about event
+                delegate!.didSelectRoom(self.directMessagesData[indexPath.row].rid, roomName: self.directMessagesData[indexPath.row].name)
+            }
+            
+        }else if indexPath.section == LeftMenuHeaders.PrivateGroups.rawValue {
+            
+            if ((delegate) != nil){ // let delegate know about event
+                delegate!.didSelectRoom(self.privateGroupsData[indexPath.row].rid, roomName: self.privateGroupsData[indexPath.row].name)
+            }
+            
+        }else if indexPath.section == LeftMenuHeaders.History.rawValue {
+            print("History")
+        }
+        
+        self.ad?.centerContainer?.closeDrawerAnimated(true, completion: nil)
+    }
+    
 }
+
 
 /** The cell ids used in the UITableView in order to identify the different prototype cells. */
 enum LeftMenuCellIds: String {

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -18,7 +18,7 @@ class ChatsNavTableViewController: UITableViewController {
     var privateGroupsData = [Room]()
     var ad:AppDelegate?
     var delegate:SwitchRoomDelegate?
-    
+    var currentCenterVCWhenSettingsSelected:ViewController?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -235,20 +235,28 @@ class ChatsNavTableViewController: UITableViewController {
     
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         
-        
+        let currentVC = self.ad?.centerContainer?.centerViewController as! UINavigationController
+
         if indexPath.section == LeftMenuHeaders.Channels.rawValue {
+
+            checkIfWeAreOnSettingsAndSetCenterContainer(currentVC)
             
             if ((delegate) != nil){ // let delegate know about event
+                print("selectroom")
                 delegate!.didSelectRoom(self.channelsData[indexPath.row].rid, roomName: self.channelsData[indexPath.row].name)
             }
             
         }else if indexPath.section == LeftMenuHeaders.DirectMessages.rawValue {
+
+            checkIfWeAreOnSettingsAndSetCenterContainer(currentVC)
             
             if ((delegate) != nil){ // let delegate know about event
                 delegate!.didSelectRoom(self.directMessagesData[indexPath.row].rid, roomName: self.directMessagesData[indexPath.row].name)
             }
             
         }else if indexPath.section == LeftMenuHeaders.PrivateGroups.rawValue {
+
+            checkIfWeAreOnSettingsAndSetCenterContainer(currentVC)
             
             if ((delegate) != nil){ // let delegate know about event
                 delegate!.didSelectRoom(self.privateGroupsData[indexPath.row].rid, roomName: self.privateGroupsData[indexPath.row].name)
@@ -261,7 +269,21 @@ class ChatsNavTableViewController: UITableViewController {
         self.ad?.centerContainer?.closeDrawerAnimated(true, completion: nil)
     }
     
+    
+    
+    func checkIfWeAreOnSettingsAndSetCenterContainer(navController: UINavigationController) {
+        
+        if ((navController.viewControllers.first?.isKindOfClass(MySettingsViewController)) == true) {
+            let centerNewNav = UINavigationController(rootViewController: self.currentCenterVCWhenSettingsSelected!)
+            self.ad!.centerContainer?.setCenterViewController(centerNewNav, withCloseAnimation: false, completion: nil)
+        }
+        
+    }
+    
 }
+
+
+
 
 
 /** The cell ids used in the UITableView in order to identify the different prototype cells. */

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -12,32 +12,41 @@ import SwiftyJSON
 
 class ChatsNavTableViewController: UITableViewController {
     
-    var meteor:MeteorClient?
+    var meteor:MeteorClient!
     var channelsData = [Room]()
     var directMessagesData = [Room]()
     var privateGroupsData = [Room]()
-    var ad:AppDelegate?
+    var ad:AppDelegate!
     var delegate:SwitchRoomDelegate?
     var currentCenterVCWhenSettingsSelected:ViewController?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        ad = UIApplication.sharedApplication().delegate as? AppDelegate
-        self.meteor = self.ad?.meteorClient
+        ad = UIApplication.sharedApplication().delegate as! AppDelegate
+        self.meteor = self.ad.meteorClient
         
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "roomAdded:", name: "rocketchat_subscription_added", object: nil)
-        
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "roomRemoved:", name: "rocketchat_subscription_removed", object: nil)
+
         if !NSUserDefaults.standardUserDefaults().boolForKey("connectedWithSessionToken") {
             
-            let rocketchat_subscription = self.meteor?.collections["rocketchat_subscription"] as? M13MutableOrderedDictionary
+            let rocketchat_subscription = self.meteor.collections["rocketchat_subscription"] as! M13MutableOrderedDictionary
             print(rocketchat_subscription)
             
-            for var i:UInt = 0 ; i < (rocketchat_subscription?.count()) ; i++ {
+            for var i:UInt = 0 ; i < (rocketchat_subscription.count()) ; i++ {
                 
-                print(rocketchat_subscription?.objectAtIndex(i)!)
+                print(rocketchat_subscription.objectAtIndex(i)!)
                 
-                let room = Room(_id: (rocketchat_subscription?.objectAtIndex(i)!["_id"])! as! String, unread: (rocketchat_subscription?.objectAtIndex(i)!["unread"])! as! Int, t: (rocketchat_subscription?.objectAtIndex(i)!["t"])! as! String, open: (rocketchat_subscription?.objectAtIndex(i)!["open"])! as! Bool, ts: (rocketchat_subscription?.objectAtIndex(i)!["ts"])! as? Double, rid: (rocketchat_subscription?.objectAtIndex(i)!["rid"])! as! String, ls: (rocketchat_subscription?.objectAtIndex(i)!["ls"])! as? Double, alert: (rocketchat_subscription?.objectAtIndex(i)!["alert"])! as! Bool, name: (rocketchat_subscription?.objectAtIndex(i)!["name"])! as! String)
+                let room = Room(_id: (rocketchat_subscription.objectAtIndex(i)!["_id"])! as! String,
+                    unread: (rocketchat_subscription.objectAtIndex(i)!["unread"])! as! Int,
+                    t: (rocketchat_subscription.objectAtIndex(i)!["t"])! as! String,
+                    open: (rocketchat_subscription.objectAtIndex(i)!["open"])! as! Bool,
+                    ts: (rocketchat_subscription.objectAtIndex(i)!["ts"])! as? Double,
+                    rid: (rocketchat_subscription.objectAtIndex(i)!["rid"])! as! String,
+                    ls: (rocketchat_subscription.objectAtIndex(i)!["ls"])! as? Double,
+                    alert: (rocketchat_subscription.objectAtIndex(i)!["alert"])! as! Bool,
+                    name: (rocketchat_subscription.objectAtIndex(i)!["name"])! as! String)
                 
                 if (room.t == "c"){
                     self.channelsData.append(room)

--- a/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ChatsNavTableViewController.swift
@@ -100,55 +100,6 @@ class ChatsNavTableViewController: UITableViewController {
     currentCell.statusLabel?.text = "g"
     currentCell.nameLabel?.text = "Groups \(currentIndexPath.section) Row \(currentIndexPath.row)"
   }
-
-
-
-  
-  /*
-  // Override to support conditional editing of the table view.
-  override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-  // Return false if you do not want the specified item to be editable.
-  return true
-  }
-  */
-  
-  /*
-  // Override to support editing the table view.
-  override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
-  if editingStyle == .Delete {
-  // Delete the row from the data source
-  tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Fade)
-  } else if editingStyle == .Insert {
-  // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
-  }
-  }
-  */
-  
-  /*
-  // Override to support rearranging the table view.
-  override func tableView(tableView: UITableView, moveRowAtIndexPath fromIndexPath: NSIndexPath, toIndexPath: NSIndexPath) {
-  
-  }
-  */
-  
-  /*
-  // Override to support conditional rearranging of the table view.
-  override func tableView(tableView: UITableView, canMoveRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-  // Return false if you do not want the item to be re-orderable.
-  return true
-  }
-  */
-  
-  /*
-  // MARK: - Navigation
-  
-  // In a storyboard-based application, you will often want to do a little preparation before navigation
-  override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-  // Get the new view controller using segue.destinationViewController.
-  // Pass the selected object to the new view controller.
-  }
-  */
-  
     
     override func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
         

--- a/Rocket.Chat.iOS/ViewControllers/LeftViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/LeftViewController.swift
@@ -8,62 +8,72 @@
 
 import UIKit
 
-class LeftViewController: UIViewController, SwitchAccountViewDelegate {
-
-  @IBOutlet weak var accountTopView: UIView!
-  @IBOutlet weak var leftMainContainer: UIView!
-  
+class LeftViewController: UIViewController, SwitchAccountViewDelegate, SwitchRoomDelegate {
+    
+    @IBOutlet weak var accountTopView: UIView!
+    @IBOutlet weak var leftMainContainer: UIView!
+    
+    var viewController: ViewController?
     var accountTabBarContainer : MyAccountBarTabViewController?
     var tabBarContainer : LeftMenuTabBarViewController?
-  
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         // Do any additional setup after loading the view.
         self.view.backgroundColor = UIColor.rocketBlueColor()
-
+        
     }
-
+    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
     
-
-  override func prefersStatusBarHidden() -> Bool {
-    switch UIDevice.currentDevice().orientation{
-    case .Portrait, .PortraitUpsideDown:
-			return false
-    case .LandscapeLeft, .LandscapeRight:
-    	return true
-    default:
-      return false
-    }
-
-  }
-  
-
-  // MARK: - Navigation
-  
-  // In a storyboard-based application, you will often want to do a little preparation before navigation
-  override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
     
-    //set self as the delegate in the account bar that will handle the event coming up from there.
-    if segue.identifier == "embedAccountBar"{
-      accountTabBarContainer = segue.destinationViewController as? MyAccountBarTabViewController
-        let accountBarTabView = accountTabBarContainer?.viewControllers![0] as! AccountBarViewController
-        accountBarTabView.delegate = self
-    } else if segue.identifier == "embedChatNav"{
-      tabBarContainer = segue.destinationViewController as? LeftMenuTabBarViewController
+    override func prefersStatusBarHidden() -> Bool {
+        switch UIDevice.currentDevice().orientation{
+        case .Portrait, .PortraitUpsideDown:
+            return false
+        case .LandscapeLeft, .LandscapeRight:
+            return true
+        default:
+            return false
+        }
+        
     }
-  }
-  
-  // MARK: SwitchAccountViewDelegate
-  func didClickOnAccountBar(accountOptionsWereOpen: Bool){
-		// not much to do here, simply let the tab bar container know about the event, so it can swap the selected view.
-    if (tabBarContainer != nil){
-      tabBarContainer?.didClickOnAccountBar(accountOptionsWereOpen)
+    
+    
+    // MARK: - Navigation
+    
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+        
+        //set self as the delegate in the account bar that will handle the event coming up from there.
+        if segue.identifier == "embedAccountBar"{
+            accountTabBarContainer = segue.destinationViewController as? MyAccountBarTabViewController
+            let accountBarTabView = accountTabBarContainer?.viewControllers![0] as! AccountBarViewController
+            accountBarTabView.delegate = self
+        } else if segue.identifier == "embedChatNav"{
+            tabBarContainer = segue.destinationViewController as? LeftMenuTabBarViewController
+            let chatsNavTableView = tabBarContainer?.viewControllers![0] as! ChatsNavTableViewController
+            chatsNavTableView.delegate = self
+        }
     }
-  }
-
+    
+    // MARK: SwitchAccountViewDelegate
+    func didClickOnAccountBar(accountOptionsWereOpen: Bool){
+        // not much to do here, simply let the tab bar container know about the event, so it can swap the selected view.
+        if (tabBarContainer != nil){
+            tabBarContainer?.didClickOnAccountBar(accountOptionsWereOpen)
+        }
+    }
+    
+    // MARK: SwitchRoomViewDelegate
+    func didSelectRoom(rid: String, roomName: String) {
+        // not much to do here, simply let the view controller know about the event, so it can swap the rooms.
+        viewController!.didSelectRoom(rid, roomName: roomName)
+        
+    }
+    
 }

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -668,7 +668,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             
             self.customIndicatorViewInViewController.hidden = true
             self.activityIndicatorInViewController.stopAnimating()
-            self.composeMsg.userInteractionEnabled = false
+            self.composeMsg.userInteractionEnabled = true
             self.composeMsg.backgroundColor = UIColor.whiteColor()
             self.composeMsgButton.userInteractionEnabled = true
             self.composeMsgButton.enabled = true
@@ -695,6 +695,14 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         self.lastJoinedRoom = NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRid") as? String
         self.title = "#\(NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRoomName")!)"
         
+        if self.composeMsgButton.enabled == false {
+
+            self.composeMsg.userInteractionEnabled = true
+            self.composeMsg.backgroundColor = UIColor.whiteColor()
+            self.composeMsgButton.userInteractionEnabled = true
+            self.composeMsgButton.enabled = true
+            
+        }
         
         if self.chatMessageData[lastJoinedRoom!] == nil {
             

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -189,7 +189,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         //Get visible cells indexes
         let visible = mainTableview.indexPathsForVisibleRows
         //Set bottomIndexpath to last visible cell's index
-        bottomIndexPath = NSIndexPath(forRow: visible!.last!.row, inSection: 0)
+        self.bottomIndexPath = NSIndexPath(forRow: visible!.last!.row, inSection: 0)
         
         
         
@@ -201,9 +201,9 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         
         
         //Check if the next and previous user are the same to see what kind of cell we will create
-        if(indexPath.row > 0){
+        if(indexPath.row > 1){
             
-            if(self.chatMessageData[indexPath.row].userId == self.chatMessageData[indexPath.row - 1].userId){
+            if(self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].userId == self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 2].userId){
             
                 sameUser = true
                 
@@ -231,7 +231,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         
         
         
-        //If Same User - return a full detailed cell
+        //If Same User - return a no detailed cell
         if (sameUser) {
             
             var noDetailsCell:NoDetailsTableViewCell? = mainTableview.dequeueReusableCellWithIdentifier("noDetailsCell", forIndexPath: indexPath) as? NoDetailsTableViewCell
@@ -243,13 +243,13 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             }
             
             //Set hidden timestamp
-            noDetailsCell!.hiddenTimeStamp.text = "\(dateFormatter.stringFromDate(NSDate(timeIntervalSince1970: (self.chatMessageData[indexPath.row].timestamp))))"
+            noDetailsCell!.hiddenTimeStamp.text = "\(dateFormatter.stringFromDate(NSDate(timeIntervalSince1970: (self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].timestamp))))"
             noDetailsCell!.hiddenTimeStamp.hidden = true
             noDetailsCell!.hiddenTimeStamp.textColor = UIColor.rocketTimestampColor()
             
             
             //If message is removed
-            if(self.chatMessageData[indexPath.row].messageType == "rm") {
+            if(self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].messageType == "rm") {
                 
                 
                 //Set text to noDetailsMessage label
@@ -289,13 +289,13 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             }
             
             fullDetailsCell!.avatarImg.image = UIImage(named: "Default-Avatar")
-            fullDetailsCell!.usernameLabel.text = self.chatMessageData[indexPath.row].username
+            fullDetailsCell!.usernameLabel.text = self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].username
             
             //Set color to #444444
             fullDetailsCell!.usernameLabel.textColor = UIColor.rocketMainFontColor()
             
             //Set the timestamp
-            fullDetailsCell!.timeLabel.text = "\(dateFormatter.stringFromDate(NSDate(timeIntervalSince1970: (self.chatMessageData[indexPath.row].timestamp))))"
+            fullDetailsCell!.timeLabel.text = "\(dateFormatter.stringFromDate(NSDate(timeIntervalSince1970: (self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].timestamp))))"
             fullDetailsCell!.timeLabel.textColor = UIColor.rocketTimestampColor()
             fullDetailsCell!.messageLabel.text = "has joined the channel"
             fullDetailsCell?.messageLabel.font = UIFont.italicSystemFontOfSize(15)
@@ -304,9 +304,9 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             return fullDetailsCell!
             
         }
-        //If different user - return a non detailed cell
+        //If different user - return a full detailed cell
         else {
-        
+            
             var fullDetailsCell:MainTableViewCell? = mainTableview.dequeueReusableCellWithIdentifier("fullDetailsCell", forIndexPath: indexPath) as? MainTableViewCell
             
             
@@ -317,18 +317,18 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             }
             
             fullDetailsCell!.avatarImg.image = UIImage(named: "Default-Avatar")
-            fullDetailsCell!.usernameLabel.text = self.chatMessageData[indexPath.row].username
+            fullDetailsCell!.usernameLabel.text = self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].username
             
             //Set color to #444444
             fullDetailsCell!.usernameLabel.textColor = UIColor.rocketMainFontColor()
             
-            //Set the timestamp
-            fullDetailsCell!.timeLabel.text = "\(dateFormatter.stringFromDate(NSDate(timeIntervalSince1970: (self.chatMessageData[indexPath.row].timestamp))))"
-            fullDetailsCell!.timeLabel.textColor = UIColor.rocketTimestampColor()
-            
             
             //If message is removed
-            if(self.chatMessageData[indexPath.row].messageType == "rm"){
+            if(self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].messageType == "rm"){
+                
+                //Set the timestamp
+                fullDetailsCell!.timeLabel.text = "\(dateFormatter.stringFromDate(NSDate(timeIntervalSince1970: (self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].timestamp))))"
+                fullDetailsCell!.timeLabel.textColor = UIColor.rocketTimestampColor()
                 
                 //Set the message text
                 fullDetailsCell!.messageLabel.text = "message removed"

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -261,11 +261,22 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                 
                 return noDetailsCell!
             
-            }else{
+            }else if (self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].messageType == "uj"){
                 
                 //Set text to noDetailsMessage label
-                noDetailsCell!.noDetailsMessage.text = self.chatMessageData[indexPath.row].message
-                noDetailsCell?.noDetailsMessage.font = UIFont(name: "Roboto-Regular.ttf", size: 15)
+                noDetailsCell!.noDetailsMessage.text = "has joined the channel"
+                noDetailsCell?.noDetailsMessage.font = UIFont.italicSystemFontOfSize(15)
+                
+                //Set color to #444444
+                noDetailsCell!.noDetailsMessage.textColor = UIColor.rocketSecondaryFontColor()
+                
+                return noDetailsCell!
+                
+            }else if (self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].messageType == "room_changed_privacy"){
+                
+                //Set text to noDetailsMessage label
+                noDetailsCell!.noDetailsMessage.text = "room type has changed to \(self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].message) by \(self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].username)"
+                noDetailsCell?.noDetailsMessage.font = UIFont.italicSystemFontOfSize(15)
                 
                 //Set color to #444444
                 noDetailsCell!.noDetailsMessage.textColor = UIColor.rocketSecondaryFontColor()
@@ -273,11 +284,54 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                 return noDetailsCell!
                 
             }
+            else{
+                
+                if (self.tmpChatMessage?.messageType == "tmp") {
+                    
+                    if (indexPath.row == self.chatMessageData[self.lastJoinedRoom!]?.count) {
+                        
+                        //Set text to noDetailsMessage label
+                        noDetailsCell!.noDetailsMessage.text = self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].message
+                        noDetailsCell?.noDetailsMessage.font = UIFont(name: "Roboto-Regular.ttf", size: 15)
+                        
+                        //Set color to #444444
+                        noDetailsCell!.noDetailsMessage.textColor = UIColor.rocketRedColor()
+                        
+                        return noDetailsCell!
+                        
+                    }else {
+                        
+                        //Set text to noDetailsMessage label
+                        noDetailsCell!.noDetailsMessage.text = self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].message
+                        noDetailsCell?.noDetailsMessage.font = UIFont(name: "Roboto-Regular.ttf", size: 15)
+                        
+                        //Set color to #444444
+                        noDetailsCell!.noDetailsMessage.textColor = UIColor.rocketSecondaryFontColor()
+                        
+                        return noDetailsCell!
+                        
+                    }
+                    
+                }else {
+                
+                    //Set text to noDetailsMessage label
+                    noDetailsCell!.noDetailsMessage.text = self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].message
+                    noDetailsCell?.noDetailsMessage.font = UIFont(name: "Roboto-Regular.ttf", size: 15)
+                    
+                    //Set color to #444444
+                    noDetailsCell!.noDetailsMessage.textColor = UIColor.rocketSecondaryFontColor()
+                    
+                    return noDetailsCell!
+                
+                }
+                
+                
+            }
             
             
         }
         //If different user and joined the channel - return a full detailed cell
-        else if (!sameUser && self.chatMessageData[indexPath.row].messageType == "uj"){
+        else if (!sameUser && self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].messageType == "uj"){
             
             var fullDetailsCell:MainTableViewCell? = mainTableview.dequeueReusableCellWithIdentifier("fullDetailsCell", forIndexPath: indexPath) as? MainTableViewCell
             
@@ -338,15 +392,79 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                 return fullDetailsCell!
                 
                 
-            }
-            else {
+            } else if (self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].messageType == "uj") {
+                
+                //Set the timestamp
+                fullDetailsCell!.timeLabel.text = "\(dateFormatter.stringFromDate(NSDate(timeIntervalSince1970: (self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].timestamp))))"
+                fullDetailsCell!.timeLabel.textColor = UIColor.rocketTimestampColor()
                 
                 //Set the message text
-                fullDetailsCell!.messageLabel.text = self.chatMessageData[indexPath.row].message
-                fullDetailsCell?.messageLabel.font = UIFont(name: "Roboto-Regular.ttf", size: 15)
+                fullDetailsCell!.messageLabel.text = "has joined the channel"
+                fullDetailsCell?.messageLabel.font = UIFont.italicSystemFontOfSize(15)
                 fullDetailsCell!.messageLabel.textColor = UIColor.rocketSecondaryFontColor()
                 
                 return fullDetailsCell!
+                
+            } else if (self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].messageType == "room_changed_privacy") {
+                
+                //Set the timestamp
+                fullDetailsCell!.timeLabel.text = "\(dateFormatter.stringFromDate(NSDate(timeIntervalSince1970: (self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].timestamp))))"
+                fullDetailsCell!.timeLabel.textColor = UIColor.rocketTimestampColor()
+                
+                //Set the message text
+                fullDetailsCell!.messageLabel.text = "room type has changed to \(self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].message) by \(self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].username)"
+                fullDetailsCell?.messageLabel.font = UIFont.italicSystemFontOfSize(15)
+                fullDetailsCell!.messageLabel.textColor = UIColor.rocketSecondaryFontColor()
+                
+                return fullDetailsCell!
+                
+            } else {
+                
+                if (self.tmpChatMessage?.messageType == "tmp") {
+                    
+                    if (indexPath.row == self.chatMessageData[self.lastJoinedRoom!]!.count) {
+                        
+                        //Hide the timestamp
+                        fullDetailsCell!.timeLabel.text = ""
+                        
+                        //Set the message text
+                        fullDetailsCell!.messageLabel.text = self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].message
+                        fullDetailsCell?.messageLabel.font = UIFont(name: "Roboto-Regular.ttf", size: 15)
+                        fullDetailsCell!.messageLabel.textColor = UIColor.rocketRedColor()
+                        
+                        return fullDetailsCell!
+                        
+                    }else {
+                        
+                        //Set the timestamp
+                        fullDetailsCell!.timeLabel.text = "\(dateFormatter.stringFromDate(NSDate(timeIntervalSince1970: (self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].timestamp))))"
+                        fullDetailsCell!.timeLabel.textColor = UIColor.rocketTimestampColor()
+                        
+                        //Set the message text
+                        fullDetailsCell!.messageLabel.text = self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].message
+                        fullDetailsCell?.messageLabel.font = UIFont(name: "Roboto-Regular.ttf", size: 15)
+                        fullDetailsCell!.messageLabel.textColor = UIColor.rocketSecondaryFontColor()
+                        
+                        return fullDetailsCell!
+                        
+                    }
+                    
+                    
+                }else {
+                    
+                    //Set the timestamp
+                    fullDetailsCell!.timeLabel.text = "\(dateFormatter.stringFromDate(NSDate(timeIntervalSince1970: (self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].timestamp))))"
+                    fullDetailsCell!.timeLabel.textColor = UIColor.rocketTimestampColor()
+                    
+                    //Set the message text
+                    fullDetailsCell!.messageLabel.text = self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].message
+                    fullDetailsCell?.messageLabel.font = UIFont(name: "Roboto-Regular.ttf", size: 15)
+                    fullDetailsCell!.messageLabel.textColor = UIColor.rocketSecondaryFontColor()
+                    
+                    return fullDetailsCell!
+                    
+                }
+                
             }
             
         }

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -623,22 +623,22 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             //Reloading data and if we are at the bottom scroll the view to the last row
             self.mainTableview.reloadData()
             
-            if let lastVisibleCells = self.mainTableview.visibleCells.last {
-            
-                let lastVisibleCellsIndexPath = NSIndexPath(forRow: self.mainTableview.indexPathForCell(lastVisibleCells)!.row, inSection: 0)
-            
-                self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
-                
-                if (lastVisibleCellsIndexPath.row >= bottomIndexPath.row - 1) {
-                    print("scroll to bottom")
-                    self.mainTableview.scrollToRowAtIndexPath(self.bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
+                if let lastVisibleCells = self.mainTableview.visibleCells.last {
+                    
+                    let lastVisibleCellsIndexPath = NSIndexPath(forRow: self.mainTableview.indexPathForCell(lastVisibleCells)!.row, inSection: 0)
+                    
+                    self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
+                    
+                    if (lastVisibleCellsIndexPath.row >= bottomIndexPath.row - 1) {
+                        print("scroll to bottom")
+                        self.mainTableview.scrollToRowAtIndexPath(self.bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
+                    }
+                    
+                } else {
+                    print("empty room")
+                    self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
+                    
                 }
-                
-            } else {
-                print("empty room")
-                self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
-                
-            }
             }
         }
         
@@ -680,17 +680,18 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
 
 
         if self.chatMessageData[lastJoinedRoom!] == nil {
-            
+
             loadHistory(self.lastJoinedRoom!, numberOfMessages: 50)
             
         }else {
 
             self.mainTableview.reloadData()
-            //If iOS 8 scrolling doesn't work properly.
-            self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
             
-            //Uncomment this if you want to scroll at the bottom even when selecting the current channel
-            self.mainTableview.scrollToRowAtIndexPath(self.bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
+                //If iOS 8 scrolling doesn't work properly.
+                self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
+                
+                //Uncomment this if you want to scroll at the bottom even when selecting the current channel
+                self.mainTableview.scrollToRowAtIndexPath(self.bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
 
         }
         

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -560,31 +560,34 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     //Function to toggle message's timestamp
     func showHiddenTimestamp(gesture: UITapGestureRecognizer) {
         
-        //get the index path of the cell where the user double tapped on
-        let tableCellRow = mainTableview.indexPathForRowAtPoint(gesture.locationInView(mainTableview))!
-        
-        //Get the cell
-        if  let tableCell = mainTableview.cellForRowAtIndexPath(tableCellRow) as? NoDetailsTableViewCell {
+        //If double tapping happens inside the tableview
+        if mainTableview.indexPathForRowAtPoint(gesture.locationInView(mainTableview)) != nil {
             
-            //Toggle timestamp
+            //get the index path of the cell where the user double tapped on
+            let tableCellRow = mainTableview.indexPathForRowAtPoint(gesture.locationInView(mainTableview))!
             
-            if !tableCell.hiddenTimeStamp.hidden {
+            //Get the cell
+            if  let tableCell = mainTableview.cellForRowAtIndexPath(tableCellRow) as? NoDetailsTableViewCell {
                 
-                tableCell.hiddenTimeStamp.hidden = true
+                //Toggle timestamp
                 
-            }else {
-                
-                tableCell.hiddenTimeStamp.hidden = false
-                
+                if !tableCell.hiddenTimeStamp.hidden {
+                    
+                    tableCell.hiddenTimeStamp.hidden = true
+                    
+                }else {
+                    
+                    tableCell.hiddenTimeStamp.hidden = false
+                    
+                }
             }
         }
-        
     }
     
     //Function to add the incoming messages
     func didReceiveUpdate(notification: NSNotification) {
         
-        
+
         if let args = notification.userInfo!["args"] {
         
             let msg = JSON(args[1]!)

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -27,6 +27,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     var dateFormatter = NSDateFormatter()
     
     var meteor: MeteorClient!
+    var ad:AppDelegate!
     
     //JSON to keep the response
     var chatMessages:JSON = []
@@ -92,8 +93,8 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         self.title = "#\(self.lastJoinedRoomName!)"
         
         //After login join general room
-        let ad = UIApplication.sharedApplication().delegate as! AppDelegate
-        meteor = ad.meteorClient
+        self.ad = UIApplication.sharedApplication().delegate as! AppDelegate
+        meteor = self.ad.meteorClient
         
         //Subscribe to rocketchat_message collection for the GENERAL channel
         self.meteor.addSubscription("stream-messages")
@@ -115,7 +116,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                 print("Error:\(error.description)")
                 return
             }else{
-                
+                print(response)
                 //Add observer to handle incoming messages
                 NSNotificationCenter.defaultCenter().addObserver(self, selector: "didReceiveUpdate:", name: "stream-messages_added", object: nil)
                 
@@ -716,6 +717,12 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             if error != nil {
                 
                 print("Error:\(error.description)")
+                let alert = UIAlertController(title: "Invalid Room", message: "Invalid Room", preferredStyle: UIAlertControllerStyle.Alert)
+                let action = UIAlertAction(title: "OK", style: UIAlertActionStyle.Default){ _ in
+                    self.ad.centerContainer?.openDrawerSide(MMDrawerSide.Left, animated: true, completion: nil)
+                }
+                alert.addAction(action)
+                self.presentViewController(alert, animated: true, completion: nil)
                 return
                 
             } else {

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -772,9 +772,10 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             if error != nil {
                 
                 print("Error:\(error.description)")
-                let alert = UIAlertController(title: "Invalid Room", message: "Invalid Room", preferredStyle: UIAlertControllerStyle.Alert)
+                let alert = UIAlertController(title: "Invalid Room", message: "This room is invalid. You will be redirected to the general channel", preferredStyle: UIAlertControllerStyle.Alert)
                 let action = UIAlertAction(title: "OK", style: UIAlertActionStyle.Default){ _ in
-                    self.ad.centerContainer?.openDrawerSide(MMDrawerSide.Left, animated: true, completion: nil)
+//                    self.ad.centerContainer?.openDrawerSide(MMDrawerSide.Left, animated: true, completion: nil)
+                    self.didSelectRoom("GENERAL", roomName: "general")
                 }
                 alert.addAction(action)
                 self.presentViewController(alert, animated: true, completion: nil)

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -622,11 +622,11 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                 
                 self.lastSeenTimeStamp = Double(msg["ts"]["$date"].number! as NSNumber)
 
-            }
             
-            //Reloading data and if we are at the bottom scroll the view to the last row
-            self.mainTableview.reloadData()
             
+                //Reloading data and if we are at the bottom scroll the view to the last row
+                self.mainTableview.reloadData()
+                
                 if let lastVisibleCells = self.mainTableview.visibleCells.last {
                     
                     let lastVisibleCellsIndexPath = NSIndexPath(forRow: self.mainTableview.indexPathForCell(lastVisibleCells)!.row, inSection: 0)
@@ -639,9 +639,11 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                     }
                     
                 } else {
-                    print("empty room")
-                    self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
+                    //When we are in an empty room and a we have an incoming message to another room we have joined
+                    print("No need to scroll")
+                    self.bottomIndexPath = NSIndexPath(forRow: 0, inSection: 0)
                     
+                }
                 }
             }
         }

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -472,15 +472,25 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     }
     
     
-    
+
     //Function to close the keyboard when send button is pressed
     @IBAction func sendMsg(sender: AnyObject) {
-        
+
         if (composeMsg.text != ""){
+            
+            self.tmpChatMessage = ChatMessage(rid: self.lastJoinedRoom!, user_id: self.meteor.userId, username: "komic", msg: composeMsg.text, msgType: "tmp", ts: NSDate().timeIntervalSince1970 * 1000.0)
+            
+            self.chatMessageData[self.lastJoinedRoom!]?.append(self.tmpChatMessage!)
+            
+            self.mainTableview.reloadData()
+            
+            //If iOS 8 scrolling doesn't work properly.
+            self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
+            self.mainTableview.scrollToRowAtIndexPath(self.bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
             
             var messageObject = NSDictionary()
             messageObject = [
-                "rid":"GENERAL",
+                "rid":self.lastJoinedRoom!,
                 "msg":composeMsg.text!
             ]
             
@@ -498,49 +508,6 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             
         }
 
-        
-
-        
-//        //If there is text
-//        if composeMsg.text != "" {
-//            //create current message
-////            let currentMsg:Message = Message(id: "", text: composeMsg.text, tstamp: NSDate(timeInterval: randomTime(), sinceDate: NSDate()), user: currentUser!)
-//          let currentMsg:Message = Message(id: "", text: composeMsg.text, tstamp: NSDate(timeInterval: randomTime(), sinceDate: NSDate()), user: User?)	// FIXME!
-//            //add it to the messages array
-//            mArray1 += [currentMsg]
-//            
-//            
-//            //update the messages array of the chatroom
-//            cR1?.messages = mArray1
-//            
-//            //reset the text input
-//            composeMsg.text = ""
-//            
-//            //dismiss keyboard - Uncomment the next line if you want keyboard to hide when you send a message
-//            //dismissKeyboard()
-//            
-//            //reload the tableview data
-//            mainTableview.reloadData()
-//            
-//            
-//            //get the bottom index - THIS NEEDS TO BE REMOVED -
-//            //bottomIndexPath = NSIndexPath(forRow: cR1!.messages.count-1, inSection: 0)
-//            
-//            //If we are the bottom
-//            if (bottomIndexPath.row == cR1!.messages.count - 1) {
-//            //scroll to bottom
-//                mainTableview.scrollToRowAtIndexPath(bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
-//                //calling it twice because something is wrong with scrolling the tableview to the bottom in iOS 9
-//                mainTableview.scrollToRowAtIndexPath(bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
-//            }
-//            
-//        }
-//        //If text is empty
-//        else{
-//        
-//            //dismiss keyboard
-//            dismissKeyboard()
-//        }
     }
     
     

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -59,18 +59,18 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         //Create double tap gesture
         let doubleTapGesture = UITapGestureRecognizer(target: self, action: Selector("showHiddenTimestamp:"))
         doubleTapGesture.numberOfTapsRequired = 2
-
+        
         //Add gestures on tableview
         mainTableview.addGestureRecognizer(tapGesture)
         mainTableview.addGestureRecognizer(doubleTapGesture)
-
+        
         
         //Remove lines between cells
         mainTableview.separatorStyle = UITableViewCellSeparatorStyle.None
         
         mainTableview.rowHeight = UITableViewAutomaticDimension
         mainTableview.estimatedRowHeight = 75
- 
+        
         //Set border to composeMsg textarea
         composeMsg.layer.borderColor = UIColor.blackColor().CGColor
         composeMsg.layer.borderWidth = 0.5
@@ -134,7 +134,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         
         
     }
-        
+    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
@@ -172,8 +172,8 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     func numberOfSectionsInTableView(tableView: UITableView) -> Int {
         return 1 // Just for now?
     }
-      
-
+    
+    
     
     //Number of table rows
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -182,7 +182,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         let numOfRows = self.chatMessageData[self.lastJoinedRoom!] != nil ? self.chatMessageData[self.lastJoinedRoom!]!.count + 1 : 0
         
         return numOfRows
-      
+        
     }
     
     //Populating data
@@ -207,7 +207,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         if(indexPath.row > 1){
             
             if(self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].userId == self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 2].userId){
-            
+                
                 sameUser = true
                 
             }
@@ -263,7 +263,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                 noDetailsCell!.noDetailsMessage.textColor = UIColor.rocketSecondaryFontColor()
                 
                 return noDetailsCell!
-            
+                
             }else if (self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].messageType == "uj"){
                 
                 //Set text to noDetailsMessage label
@@ -316,7 +316,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                     }
                     
                 }else {
-                
+                    
                     //Set text to noDetailsMessage label
                     noDetailsCell!.noDetailsMessage.text = self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].message
                     noDetailsCell?.noDetailsMessage.font = UIFont(name: "Roboto-Regular.ttf", size: 15)
@@ -325,7 +325,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                     noDetailsCell!.noDetailsMessage.textColor = UIColor.rocketSecondaryFontColor()
                     
                     return noDetailsCell!
-                
+                    
                 }
                 
                 
@@ -333,7 +333,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             
             
         }
-        //If different user and joined the channel - return a full detailed cell
+            //If different user and joined the channel - return a full detailed cell
         else if (!sameUser && self.chatMessageData[self.lastJoinedRoom!]![indexPath.row - 1].messageType == "uj"){
             
             var fullDetailsCell:MainTableViewCell? = mainTableview.dequeueReusableCellWithIdentifier("fullDetailsCell", forIndexPath: indexPath) as? MainTableViewCell
@@ -361,7 +361,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             return fullDetailsCell!
             
         }
-        //If different user - return a full detailed cell
+            //If different user - return a full detailed cell
         else {
             
             var fullDetailsCell:MainTableViewCell? = mainTableview.dequeueReusableCellWithIdentifier("fullDetailsCell", forIndexPath: indexPath) as? MainTableViewCell
@@ -475,10 +475,10 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     }
     
     
-
+    
     //Function to close the keyboard when send button is pressed
     @IBAction func sendMsg(sender: AnyObject) {
-
+        
         if (composeMsg.text != ""){
             
             self.tmpChatMessage = ChatMessage(rid: self.lastJoinedRoom!, user_id: self.meteor.userId, username: "komic", msg: composeMsg.text, msgType: "tmp", ts: NSDate().timeIntervalSince1970 * 1000.0)
@@ -513,7 +513,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             })
             
         }
-
+        
     }
     
     
@@ -587,12 +587,12 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     //Function to add the incoming messages
     func didReceiveUpdate(notification: NSNotification) {
         
-
-        if let args = notification.userInfo!["args"] {
         
+        if let args = notification.userInfo!["args"] {
+            
             let msg = JSON(args[1]!)
-//            print(msg)
-
+            //            print(msg)
+            
             if self.tmpChatMessage?.messageType == "tmp"{
                 
                 self.tmpChatMessage?.messageType = ""
@@ -601,52 +601,52 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             }
             
             if self.lastSeenTimeStamp != Double(msg["ts"]["$date"].number! as NSNumber) {
-            
-            
-
-            
-            if msg["rid"].string == NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRid") as? String {
-                var type = ""
-                if let t = msg["t"].string{
-                    type = t
-                }
                 
-                let timestamp = [msg["ts"]["$date"].number! as NSNumber]
-                let timestampInDouble = timestamp as! [Double]
-                let timestampInMilliseconds = timestampInDouble[0] / 1000
                 
-                let incomingMsg = ChatMessage(rid: msg["rid"].string!,user_id: msg["u"]["_id"].string!, username: msg["u"]["username"].string!, msg: msg["msg"].string!, msgType: type, ts: timestampInMilliseconds)
                 
-                if self.chatMessageData[self.lastJoinedRoom!] != nil{
-                self.chatMessageData[self.lastJoinedRoom!]!.append(incomingMsg)
-                } else {
-                    self.chatMessageData[self.lastJoinedRoom!] = [incomingMsg]
-                }
                 
-                self.lastSeenTimeStamp = Double(msg["ts"]["$date"].number! as NSNumber)
-
-            
-            
-                //Reloading data and if we are at the bottom scroll the view to the last row
-                self.mainTableview.reloadData()
-                
-                if let lastVisibleCells = self.mainTableview.visibleCells.last {
-                    
-                    let lastVisibleCellsIndexPath = NSIndexPath(forRow: self.mainTableview.indexPathForCell(lastVisibleCells)!.row, inSection: 0)
-                    
-                    self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
-                    
-                    if (lastVisibleCellsIndexPath.row >= bottomIndexPath.row - 1) {
-                        print("scroll to bottom")
-                        self.mainTableview.scrollToRowAtIndexPath(self.bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
+                if msg["rid"].string == NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRid") as? String {
+                    var type = ""
+                    if let t = msg["t"].string{
+                        type = t
                     }
                     
-                } else {
-                    //When we are in an empty room and a we have an incoming message to another room we have joined
-                    print("No need to scroll")
-                    self.bottomIndexPath = NSIndexPath(forRow: 0, inSection: 0)
+                    let timestamp = [msg["ts"]["$date"].number! as NSNumber]
+                    let timestampInDouble = timestamp as! [Double]
+                    let timestampInMilliseconds = timestampInDouble[0] / 1000
                     
-                }
+                    let incomingMsg = ChatMessage(rid: msg["rid"].string!,user_id: msg["u"]["_id"].string!, username: msg["u"]["username"].string!, msg: msg["msg"].string!, msgType: type, ts: timestampInMilliseconds)
+                    
+                    if self.chatMessageData[self.lastJoinedRoom!] != nil{
+                        self.chatMessageData[self.lastJoinedRoom!]!.append(incomingMsg)
+                    } else {
+                        self.chatMessageData[self.lastJoinedRoom!] = [incomingMsg]
+                    }
+                    
+                    self.lastSeenTimeStamp = Double(msg["ts"]["$date"].number! as NSNumber)
+                    
+                    
+                    
+                    //Reloading data and if we are at the bottom scroll the view to the last row
+                    self.mainTableview.reloadData()
+                    
+                    if let lastVisibleCells = self.mainTableview.visibleCells.last {
+                        
+                        let lastVisibleCellsIndexPath = NSIndexPath(forRow: self.mainTableview.indexPathForCell(lastVisibleCells)!.row, inSection: 0)
+                        
+                        self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
+                        
+                        if (lastVisibleCellsIndexPath.row >= bottomIndexPath.row - 1) {
+                            print("scroll to bottom")
+                            self.mainTableview.scrollToRowAtIndexPath(self.bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
+                        }
+                        
+                    } else {
+                        //When we are in an empty room and a we have an incoming message to another room we have joined
+                        print("No need to scroll")
+                        self.bottomIndexPath = NSIndexPath(forRow: 0, inSection: 0)
+                        
+                    }
                 }
             }
         }
@@ -655,7 +655,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     }
     
     func connectionStatus(live:Bool) {
-
+        
         if (live){
             
             self.customIndicatorViewInViewController.hidden = true
@@ -674,7 +674,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             self.composeMsgButton.userInteractionEnabled = false
             self.composeMsgButton.enabled = false
         }
-
+        
         
     }
     
@@ -686,22 +686,22 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         self.lastJoinedRoomName = NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRoomName") as? String
         self.lastJoinedRoom = NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRid") as? String
         self.title = "#\(NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRoomName")!)"
-
-
+        
+        
         if self.chatMessageData[lastJoinedRoom!] == nil {
-
+            
             loadHistory(self.lastJoinedRoom!, numberOfMessages: 50)
             
         }else {
-
+            
             self.mainTableview.reloadData()
             
-                //If iOS 8 scrolling doesn't work properly.
-                self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
-                
-                //Uncomment this if you want to scroll at the bottom even when selecting the current channel
-                self.mainTableview.scrollToRowAtIndexPath(self.bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
-
+            //If iOS 8 scrolling doesn't work properly.
+            self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
+            
+            //Uncomment this if you want to scroll at the bottom even when selecting the current channel
+            self.mainTableview.scrollToRowAtIndexPath(self.bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
+            
         }
         
     }
@@ -764,14 +764,14 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                         }
                         
                     }
-                
+                    
                     self.chatMessageData[room] = self.chatMessageData[room]!.reverse()
                     //Reload data and scroll to the bottom of the tableview
                     self.mainTableview.reloadData()
                     //If iOS 8 scrolling doesn't work properly.
                     self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[room]!.count, inSection: 0)
                     self.mainTableview.scrollToRowAtIndexPath(self.bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
-
+                    
                 }else {
                     self.mainTableview.reloadData()
                 }

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -486,9 +486,12 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             
             self.mainTableview.reloadData()
             
-            //If iOS 8 scrolling doesn't work properly.
-            self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
-            self.mainTableview.scrollToRowAtIndexPath(self.bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
+            if self.chatMessageData[self.lastJoinedRoom!] != nil {
+                //If iOS 8 scrolling doesn't work properly.
+                self.bottomIndexPath = NSIndexPath(forRow: self.chatMessageData[self.lastJoinedRoom!]!.count, inSection: 0)
+                self.mainTableview.scrollToRowAtIndexPath(self.bottomIndexPath, atScrollPosition: UITableViewScrollPosition.Bottom, animated: false)
+            }
+            
             
             var messageObject = NSDictionary()
             messageObject = [
@@ -723,7 +726,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                 let result = JSON(response)
                 self.chatMessages = result["result"]["messages"]
                 
-                if self.chatMessages.count != 0 {
+                if self.chatMessages.count > 0 {
                     
                     for (_,subJson) in self.chatMessages {
                         

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -44,6 +44,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     var lastSeenTimeStamp:Double?
     
     
+    var currentUsername:String?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -119,6 +120,13 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                 print(response)
                 //Add observer to handle incoming messages
                 NSNotificationCenter.defaultCenter().addObserver(self, selector: "didReceiveUpdate:", name: "stream-messages_added", object: nil)
+                
+                let users = self.meteor.collections["users"] as! M13MutableOrderedDictionary
+                
+                let user = users.objectAtIndex(0)
+                self.currentUsername = user["username"] as? String
+
+                
                 
             }
         }
@@ -481,7 +489,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         
         if (composeMsg.text != ""){
             
-            self.tmpChatMessage = ChatMessage(rid: self.lastJoinedRoom!, user_id: self.meteor.userId, username: "komic", msg: composeMsg.text, msgType: "tmp", ts: NSDate().timeIntervalSince1970 * 1000.0)
+            self.tmpChatMessage = ChatMessage(rid: self.lastJoinedRoom!, user_id: self.meteor.userId, username: self.currentUsername!, msg: composeMsg.text, msgType: "tmp", ts: NSDate().timeIntervalSince1970 * 1000.0)
             
             self.chatMessageData[self.lastJoinedRoom!]?.append(self.tmpChatMessage!)
             

--- a/Rocket.Chat.iOS/ViewControllers/ViewController.swift
+++ b/Rocket.Chat.iOS/ViewControllers/ViewController.swift
@@ -42,58 +42,6 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     var tmpChatMessage:ChatMessage?
     var lastSeenTimeStamp:Double?
     
-    override func viewWillAppear(animated: Bool) {
-        
-        if (NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRid") != nil) {
-            self.lastJoinedRoomName = NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRoomName") as? String
-            self.lastJoinedRoom = NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRid") as? String
-        }else {
-            self.lastJoinedRoomName = "general"
-            self.lastJoinedRoom = "GENERAL"
-        }
-        
-        self.title = "#\(self.lastJoinedRoomName!)"
-        
-        //After login join general room
-        let ad = UIApplication.sharedApplication().delegate as! AppDelegate
-        meteor = ad.meteorClient
-        
-        //Subscribe to rocketchat_message collection for the GENERAL channel
-        self.meteor.addSubscription("stream-messages")
-
-        meteor.callMethodName("channelsList", parameters: nil) { (response, error) -> Void in
-            
-            if error != nil {
-                print(error.description)
-                return
-            }
-            
-            //print(response["result"]!["channels"]!![0]!)
-        }
-
-        meteor.callMethodName("joinDefaultChannels", parameters: []) { (response, error) -> Void in
-            
-            if error != nil {
-                print("Error:\(error.description)")
-                return
-            }else{
-                
-                //Add observer to handle incoming messages
-                NSNotificationCenter.defaultCenter().addObserver(self, selector: "didReceiveUpdate:", name: "stream-messages_added", object: nil)
-
-            }
-        }
-
-        //Get last 50 messages
-        loadHistory(self.lastJoinedRoom!, numberOfMessages: 50)
-
-        //Get the leftViewController instance and use it to notify this ViewController about changing the channel using the SwitchRoomDelegate
-        let leftNavController = ad.centerContainer?.leftDrawerViewController as! UINavigationController
-        let leftViewController = leftNavController.viewControllers.first as! LeftViewController
-        leftViewController.viewController = self
-        
-    }
-    
     
     
     override func viewDidLoad() {
@@ -130,6 +78,60 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         dateFormatter.dateFormat = "HH:mm"
         
         self.tmpChatMessage?.messageType = ""
+        
+        
+        
+        if (NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRid") != nil) {
+            self.lastJoinedRoomName = NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRoomName") as? String
+            self.lastJoinedRoom = NSUserDefaults.standardUserDefaults().valueForKey("lastJoinedRid") as? String
+        }else {
+            self.lastJoinedRoomName = "general"
+            self.lastJoinedRoom = "GENERAL"
+        }
+        
+        self.title = "#\(self.lastJoinedRoomName!)"
+        
+        //After login join general room
+        let ad = UIApplication.sharedApplication().delegate as! AppDelegate
+        meteor = ad.meteorClient
+        
+        //Subscribe to rocketchat_message collection for the GENERAL channel
+        self.meteor.addSubscription("stream-messages")
+        
+        
+        meteor.callMethodName("channelsList", parameters: nil) { (response, error) -> Void in
+            
+            if error != nil {
+                print(error.description)
+                return
+            }
+            
+            //print(response["result"]!["channels"]!![0]!)
+        }
+        
+        meteor.callMethodName("joinDefaultChannels", parameters: []) { (response, error) -> Void in
+            
+            if error != nil {
+                print("Error:\(error.description)")
+                return
+            }else{
+                
+                //Add observer to handle incoming messages
+                NSNotificationCenter.defaultCenter().addObserver(self, selector: "didReceiveUpdate:", name: "stream-messages_added", object: nil)
+                
+            }
+        }
+        
+        //Get last 50 messages
+        loadHistory(self.lastJoinedRoom!, numberOfMessages: 50)
+        
+        
+        //Get the leftViewController instance and use it to notify this ViewController about changing the channel using the SwitchRoomDelegate
+        let leftNavController = ad.centerContainer?.leftDrawerViewController as! UINavigationController
+        let leftViewController = leftNavController.viewControllers.first as! LeftViewController
+        leftViewController.viewController = self
+        
+        
     }
         
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
Now the channels in the left menu are showing. You can switch between rooms. When entering the settings now you can go back by selecting a room or by selecting a status. When you close the app completely it remembers the last room you have joined and next time loads that channel again. When you switch to a different room it scrolls down to the latest message. For now when you start the app and it loads the room give it some time to load it and then change room. If you change to another room before it loads the current room the app crashes. This will be fixed by adding a loading screen.

Also after talking with @Sing-Li I switched the subscription from messages to stream-messages in order to get the chat messages.

Please feel free to review and provide any feedback...