### PR TITLE
update so that users can change to other servers

### DIFF
--- a/Rocket.Chat/Controllers/MainViewController.swift
+++ b/Rocket.Chat/Controllers/MainViewController.swift
@@ -27,7 +27,7 @@ final class MainViewController: BaseViewController {
 
         if let auth = AuthManager.isAuthenticated() {
             labelAuthenticationStatus.text = "Logging in..."
-            buttonConnect.isEnabled = false
+            buttonConnect.isEnabled = true
 
             AuthManager.resume(auth, completion: { [weak self] response in
                 guard !response.isError() else {


### PR DESCRIPTION
right now, if a user logs into the mobile console, then logs out on a desktop (log out of all other devices), then there is no way for the user to make it back to the server in the mobile iOS instance.  enabling the button at all times gives people the option of being able to connect to a different server whenever they wish.

@RocketChat/iOS

Closes #ISSUE_NUMBER
