### PR TITLE
Fix: Long press on message cell should be responded by message cell delegate

### DIFF
--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -100,9 +100,9 @@ final class ChatMessageCell: UICollectionViewCell {
     func insertGesturesIfNeeded() {
         if self.longPressGesture == nil {
             let gesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPressMessageCell(recognizer:)))
-            gesture.minimumPressDuration = 1
+            gesture.minimumPressDuration = 0.5
             gesture.delegate = self
-            contentView.addGestureRecognizer(gesture)
+            self.addGestureRecognizer(gesture)
             self.longPressGesture = gesture
         }
     }
@@ -210,7 +210,7 @@ final class ChatMessageCell: UICollectionViewCell {
 extension ChatMessageCell: UIGestureRecognizerDelegate {
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return false
+        return true
     }
 
 }

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -210,7 +210,7 @@ final class ChatMessageCell: UICollectionViewCell {
 extension ChatMessageCell: UIGestureRecognizerDelegate {
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
+        return false
     }
 
 }

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.xib
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -45,7 +45,7 @@
                             <constraint firstAttribute="width" constant="35" id="Cny-FU-tGi"/>
                         </constraints>
                     </view>
-                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Text" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="jz0-wl-Wig">
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Text" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jz0-wl-Wig">
                         <rect key="frame" x="42" y="23" width="300" height="44"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <color key="textColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="calibratedRGB"/>


### PR DESCRIPTION
@RocketChat/iOS

If long pressed on text view in message cell, the gesture event will not be sent to cell's delegate correctly as follows.

<img src="https://cloud.githubusercontent.com/assets/8500303/24611709/9427775c-18b5-11e7-9f47-d83fac41fa83.png" height="700"/>

