### PR TITLE
[NEW] Honor UI_Use_Real_Name settings to show user full name or username all over the app

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		4112BEEC1E7971A400E734CB /* MainChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4112BEEB1E7971A400E734CB /* MainChatViewController.swift */; };
 		4116C52D1E69B15400AC4E43 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4116C52C1E69B15400AC4E43 /* GoogleService-Info.plist */; };
 		411D76E51F39F05A00B0A8DF /* AuthSettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411D76E41F39F05A00B0A8DF /* AuthSettingsManager.swift */; };
+		411D76E71F39FA7B00B0A8DF /* AuthSettingsManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411D76E61F39FA7B00B0A8DF /* AuthSettingsManagerSpec.swift */; };
 		411EDED51E3102CB00BC7BE3 /* UploadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411EDED41E3102CB00BC7BE3 /* UploadManager.swift */; };
 		412719441E6B353B00461FEE /* AuthViewControllerGoogleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412719431E6B353B00461FEE /* AuthViewControllerGoogleExtensions.swift */; };
 		412719461E6B403700461FEE /* RegisterUsernameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412719451E6B403700461FEE /* RegisterUsernameViewController.swift */; };
@@ -181,6 +182,7 @@
 		4112BEEB1E7971A400E734CB /* MainChatViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MainChatViewController.swift; path = Controllers/Chat/MainChatViewController.swift; sourceTree = "<group>"; };
 		4116C52C1E69B15400AC4E43 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		411D76E41F39F05A00B0A8DF /* AuthSettingsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthSettingsManager.swift; path = Managers/Model/AuthSettingsManager.swift; sourceTree = "<group>"; };
+		411D76E61F39FA7B00B0A8DF /* AuthSettingsManagerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthSettingsManagerSpec.swift; path = Managers/AuthSettingsManagerSpec.swift; sourceTree = "<group>"; };
 		411EDED41E3102CB00BC7BE3 /* UploadManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UploadManager.swift; path = Managers/Uploader/UploadManager.swift; sourceTree = "<group>"; };
 		412719431E6B353B00461FEE /* AuthViewControllerGoogleExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthViewControllerGoogleExtensions.swift; path = Controllers/Auth/AuthViewControllerGoogleExtensions.swift; sourceTree = "<group>"; };
 		412719451E6B403700461FEE /* RegisterUsernameViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RegisterUsernameViewController.swift; path = Controllers/Auth/RegisterUsernameViewController.swift; sourceTree = "<group>"; };
@@ -439,6 +441,7 @@
 			children = (
 				417A70011D47916C00FF46EE /* Socket */,
 				41BA89231D303D8B00CBF526 /* AuthManagerSpec.swift */,
+				411D76E61F39FA7B00B0A8DF /* AuthSettingsManagerSpec.swift */,
 				41DC7A1E1D3865FE00896FC0 /* MessageManagerSpec.swift */,
 			);
 			name = Managers;
@@ -1460,6 +1463,7 @@
 				41DC7A241D386CA800896FC0 /* DateExtensionsSpec.swift in Sources */,
 				41552F681D3035D80081438D /* SocketManagerSpec.swift in Sources */,
 				4161333C1D46E32F00E09DA2 /* UserSpec.swift in Sources */,
+				411D76E71F39FA7B00B0A8DF /* AuthSettingsManagerSpec.swift in Sources */,
 				4161333A1D46E0A200E09DA2 /* AuthSpec.swift in Sources */,
 				41DC7A1F1D3865FE00896FC0 /* MessageManagerSpec.swift in Sources */,
 				41BAE3E91D71C15A00C2445A /* NSURLExtensionSpec.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		4102E3AD1E53273E004BAA82 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4102E3AC1E53273E004BAA82 /* SettingsViewController.swift */; };
 		4112BEEC1E7971A400E734CB /* MainChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4112BEEB1E7971A400E734CB /* MainChatViewController.swift */; };
 		4116C52D1E69B15400AC4E43 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4116C52C1E69B15400AC4E43 /* GoogleService-Info.plist */; };
+		411D76E51F39F05A00B0A8DF /* AuthSettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411D76E41F39F05A00B0A8DF /* AuthSettingsManager.swift */; };
 		411EDED51E3102CB00BC7BE3 /* UploadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411EDED41E3102CB00BC7BE3 /* UploadManager.swift */; };
 		412719441E6B353B00461FEE /* AuthViewControllerGoogleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412719431E6B353B00461FEE /* AuthViewControllerGoogleExtensions.swift */; };
 		412719461E6B403700461FEE /* RegisterUsernameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412719451E6B403700461FEE /* RegisterUsernameViewController.swift */; };
@@ -179,6 +180,7 @@
 		4102E3AC1E53273E004BAA82 /* SettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SettingsViewController.swift; path = Controllers/Settings/SettingsViewController.swift; sourceTree = "<group>"; };
 		4112BEEB1E7971A400E734CB /* MainChatViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MainChatViewController.swift; path = Controllers/Chat/MainChatViewController.swift; sourceTree = "<group>"; };
 		4116C52C1E69B15400AC4E43 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		411D76E41F39F05A00B0A8DF /* AuthSettingsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthSettingsManager.swift; path = Managers/Model/AuthSettingsManager.swift; sourceTree = "<group>"; };
 		411EDED41E3102CB00BC7BE3 /* UploadManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UploadManager.swift; path = Managers/Uploader/UploadManager.swift; sourceTree = "<group>"; };
 		412719431E6B353B00461FEE /* AuthViewControllerGoogleExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthViewControllerGoogleExtensions.swift; path = Controllers/Auth/AuthViewControllerGoogleExtensions.swift; sourceTree = "<group>"; };
 		412719451E6B403700461FEE /* RegisterUsernameViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RegisterUsernameViewController.swift; path = Controllers/Auth/RegisterUsernameViewController.swift; sourceTree = "<group>"; };
@@ -424,6 +426,7 @@
 			isa = PBXGroup;
 			children = (
 				41552F651D30308C0081438D /* AuthManager.swift */,
+				411D76E41F39F05A00B0A8DF /* AuthSettingsManager.swift */,
 				41DAE93B1D318E280098E068 /* SubscriptionManager.swift */,
 				41DC7A1C1D38471700896FC0 /* MessageManager.swift */,
 				4162E1521D651A8800AAAE49 /* UserManager.swift */,
@@ -1426,6 +1429,7 @@
 				41499C911F2A1A7200790EA7 /* TimestampCoordinator.swift in Sources */,
 				D3CFAFBD1E907D8900BADC0A /* ChatMessageTextViewModel.swift in Sources */,
 				415029BD1E72E0FD009F596C /* ChannelInfoCellProtocol.swift in Sources */,
+				411D76E51F39F05A00B0A8DF /* AuthSettingsManager.swift in Sources */,
 				415029B51E72D519009F596C /* ChannelInfoBasicCell.swift in Sources */,
 				D32E28251DFD86C300D6019C /* LauncherProtocol.swift in Sources */,
 				41DF76E31D2C50710028DBF8 /* AppDelegate.swift in Sources */,

--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -125,7 +125,7 @@ final class ConnectServerViewController: BaseViewController {
             }
 
             SocketManager.connect(socketURL) { (_, connected) in
-                AuthManager.updatePublicSettings(nil) { (settings) in
+                AuthSettingsManager.updatePublicSettings(nil) { (settings) in
                     self?.serverPublicSettings = settings
 
                     if connected {

--- a/Rocket.Chat/Controllers/Chat/ChannelInfoViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChannelInfoViewController.swift
@@ -56,8 +56,8 @@ class ChannelInfoViewController: BaseViewController {
         super.viewDidLoad()
         title = localized("chat.info.title")
 
-        if let auth = AuthManager.isAuthenticated() {
-            if auth.settings?.favoriteRooms ?? false {
+        if let settings = AuthSettingsManager.settings {
+            if settings.favoriteRooms {
                 let defaultImage = UIImage(named: "Star")?.imageWithTint(UIColor.RCGray()).withRenderingMode(.alwaysOriginal)
                 let buttonFavorite = UIBarButtonItem(image: defaultImage, style: .plain, target: self, action: #selector(buttonFavoriteDidPressed))
                 navigationItem.rightBarButtonItem = buttonFavorite

--- a/Rocket.Chat/Controllers/Chat/ChannelInfoViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChannelInfoViewController.swift
@@ -35,7 +35,7 @@ class ChannelInfoViewController: BaseViewController {
                 let description = subscription.roomDescription?.characters.count ?? 0 == 0 ? localized("chat.info.item.no_description") : subscription.roomDescription
 
                 tableViewData = [[
-                    ChannelInfoBasicCellData(title: "#\(subscription.name)"),
+                    ChannelInfoBasicCellData(title: "#\(subscription.displayName())"),
                     ChannelInfoDescriptionCellData(
                         title: localized("chat.info.item.topic"),
                         description: topic

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -287,7 +287,7 @@ final class ChatViewController: SLKTextViewController {
             token.stop()
         }
 
-        title = subscription?.name
+        title = subscription?.displayName()
         chatTitleView?.subscription = subscription
         textView.resignFirstResponder()
 

--- a/Rocket.Chat/Controllers/MainViewController.swift
+++ b/Rocket.Chat/Controllers/MainViewController.swift
@@ -57,7 +57,7 @@ final class MainViewController: BaseViewController {
                 }
 
                 SubscriptionManager.updateSubscriptions(auth, completion: { _ in
-                    AuthManager.updatePublicSettings(auth, completion: { _ in
+                    AuthSettingsManager.updatePublicSettings(auth, completion: { _ in
 
                     })
 

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
@@ -191,7 +191,7 @@ extension SubscriptionsViewController {
         guard let labelUsername = self.labelUsername else { return }
         guard let viewUserStatus = self.viewUserStatus else { return }
 
-        labelUsername.text = user.username ?? ""
+        labelUsername.text = user.displayName()
 
         switch user.status {
         case .online:
@@ -269,7 +269,7 @@ extension SubscriptionsViewController {
             ])
 
             searchResultsGroup = searchResultsGroup.sorted {
-                return $0.name < $1.name
+                return $0.displayName() < $1.displayName()
             }
 
             groupSubscriptions?.append(searchResultsGroup)

--- a/Rocket.Chat/Extensions/Models/MessageExtensions.swift
+++ b/Rocket.Chat/Extensions/Models/MessageExtensions.swift
@@ -30,21 +30,21 @@ extension Message {
                 return String(
                     format: localized("chat.message.type.room_name_changed"),
                     text,
-                    self.user?.username ?? ""
+                    self.user?.displayName() ?? ""
                 )
 
             case .userAdded:
                 return String(
                     format: localized("chat.message.type.user_added_by"),
                     text,
-                    self.user?.username ?? ""
+                    self.user?.displayName() ?? ""
                 )
 
             case .userRemoved:
                 return String(
                     format: localized("chat.message.type.user_removed_by"),
                     text,
-                    self.user?.username ?? ""
+                    self.user?.displayName() ?? ""
                 )
 
             case .userJoined:
@@ -57,14 +57,14 @@ extension Message {
                 return String(
                     format: localized("chat.message.type.user_muted"),
                     text,
-                    self.user?.username ?? ""
+                    self.user?.displayName() ?? ""
                 )
 
             case .userUnmuted:
                 return String(
                     format: localized("chat.message.type.user_unmuted"),
                     text,
-                    self.user?.username ?? ""
+                    self.user?.displayName() ?? ""
                 )
 
             case .welcome:
@@ -81,7 +81,7 @@ extension Message {
                     format: localized("chat.message.type.subscription_role_added"),
                     text,
                     role,
-                    self.user?.username ?? ""
+                    self.user?.displayName() ?? ""
                 )
 
             case .subscriptionRoleRemoved:
@@ -89,7 +89,7 @@ extension Message {
                     format: localized("chat.message.type.subscription_role_removed"),
                     text,
                     role,
-                    self.user?.username ?? ""
+                    self.user?.displayName() ?? ""
                 )
 
             case .roomArchived:

--- a/Rocket.Chat/Info.plist
+++ b/Rocket.Chat/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.5</string>
+	<string>1.1.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>70</string>
+	<string>71</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/Rocket.Chat/Managers/Model/AuthManager.swift
+++ b/Rocket.Chat/Managers/Model/AuthManager.swift
@@ -276,31 +276,4 @@ extension AuthManager {
         }
     }
 
-    static func updatePublicSettings(_ auth: Auth?, completion: @escaping MessageCompletionObject<AuthSettings?>) {
-        let object = [
-            "msg": "method",
-            "method": "public-settings/get"
-        ] as [String : Any]
-
-        SocketManager.send(object) { (response) in
-            guard !response.isError() else {
-                completion(nil)
-                return
-            }
-
-            Realm.executeOnMainThread({ realm in
-                let settings = AuthManager.isAuthenticated()?.settings ?? AuthSettings()
-                settings.map(response.result["result"], realm: realm)
-                realm.add(settings, update: true)
-
-                if let auth = AuthManager.isAuthenticated() {
-                    auth.settings = settings
-                    realm.add(auth, update: true)
-                }
-
-                let unmanagedSettings = AuthSettings(value: settings)
-                completion(unmanagedSettings)
-            })
-        }
-    }
 }

--- a/Rocket.Chat/Managers/Model/AuthSettingsManager.swift
+++ b/Rocket.Chat/Managers/Model/AuthSettingsManager.swift
@@ -12,11 +12,9 @@ import RealmSwift
 final class AuthSettingsManager {
 
     static let shared = AuthSettingsManager()
-    static var settings: AuthSettings? {
-        get { return shared.settings }
-    }
+    static var settings: AuthSettings? { return shared.settings }
 
-    fileprivate var internalSettings: AuthSettings?
+    internal var internalSettings: AuthSettings?
     var settings: AuthSettings? {
         set { }
         get {

--- a/Rocket.Chat/Managers/Model/AuthSettingsManager.swift
+++ b/Rocket.Chat/Managers/Model/AuthSettingsManager.swift
@@ -1,0 +1,69 @@
+//
+//  AuthSettingsManager.swift
+//  Rocket.Chat
+//
+//  Created by Rafael Kellermann Streit on 08/08/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+final class AuthSettingsManager {
+
+    static let shared = AuthSettingsManager()
+
+    fileprivate var internalSettings: AuthSettings?
+    var settings: AuthSettings? {
+        set { }
+        get {
+            if internalSettings == nil {
+                updateCachedSettings()
+            }
+
+            return internalSettings
+        }
+    }
+
+    static func updatePublicSettings(_ auth: Auth?, completion: @escaping MessageCompletionObject<AuthSettings?>) {
+        let object = [
+            "msg": "method",
+            "method": "public-settings/get"
+            ] as [String : Any]
+
+        SocketManager.send(object) { (response) in
+            guard !response.isError() else {
+                completion(nil)
+                return
+            }
+
+            Realm.executeOnMainThread({ realm in
+                let settings = AuthManager.isAuthenticated()?.settings ?? AuthSettings()
+                settings.map(response.result["result"], realm: realm)
+                realm.add(settings, update: true)
+
+                if let auth = AuthManager.isAuthenticated() {
+                    auth.settings = settings
+                    realm.add(auth, update: true)
+                }
+
+                let unmanagedSettings = AuthSettings(value: settings)
+                shared.internalSettings = unmanagedSettings
+                completion(unmanagedSettings)
+            })
+        }
+    }
+
+    func updateCachedSettings() {
+        guard let auth = AuthManager.isAuthenticated() else { return }
+        guard let settings = auth.settings else { return }
+
+        let unmanagedSettings = AuthSettings(value: settings)
+        internalSettings = unmanagedSettings
+    }
+
+    func clearCachedSettings() {
+        internalSettings = nil
+    }
+
+}

--- a/Rocket.Chat/Managers/Model/AuthSettingsManager.swift
+++ b/Rocket.Chat/Managers/Model/AuthSettingsManager.swift
@@ -12,6 +12,9 @@ import RealmSwift
 final class AuthSettingsManager {
 
     static let shared = AuthSettingsManager()
+    static var settings: AuthSettings? {
+        get { return shared.settings }
+    }
 
     fileprivate var internalSettings: AuthSettings?
     var settings: AuthSettings? {

--- a/Rocket.Chat/Managers/Socket/SocketManager.swift
+++ b/Rocket.Chat/Managers/Socket/SocketManager.swift
@@ -112,7 +112,7 @@ extension SocketManager {
             }
 
             SubscriptionManager.updateSubscriptions(auth, completion: { _ in
-                AuthManager.updatePublicSettings(auth, completion: { _ in
+                AuthSettingsManager.updatePublicSettings(auth, completion: { _ in
 
                 })
 

--- a/Rocket.Chat/Managers/Uploader/UploadManager.swift
+++ b/Rocket.Chat/Managers/Uploader/UploadManager.swift
@@ -63,8 +63,8 @@ class UploadManager {
     }
 
     func upload(file: FileUpload, subscription: Subscription, progress: UploadProgressBlock, completion: @escaping UploadCompletionBlock) {
-        guard let auth = AuthManager.isAuthenticated() else { return }
-        guard let store = auth.settings?.uploadStorageType else { return }
+        guard let settings = AuthSettingsManager.settings else { return }
+        guard let store = settings.uploadStorageType else { return }
 
         if store == "AmazonS3" {
             uploadToAmazonS3(file: file, subscription: subscription, progress: progress, completion: completion)

--- a/Rocket.Chat/Models/AuthSettings.swift
+++ b/Rocket.Chat/Models/AuthSettings.swift
@@ -14,6 +14,9 @@ final class AuthSettings: BaseModel {
     dynamic var siteURL: String?
     dynamic var cdnPrefixURL: String?
 
+    // User
+    dynamic var useUserRealName = false
+
     // Rooms
     dynamic var favoriteRooms = true
 

--- a/Rocket.Chat/Models/Mapping/AuthSettingsModelMapping.swift
+++ b/Rocket.Chat/Models/Mapping/AuthSettingsModelMapping.swift
@@ -19,6 +19,8 @@ extension AuthSettings: ModelMappeable {
         self.siteURL = objectForKey(object: values, key: "Site_Url")?.string
         self.cdnPrefixURL = objectForKey(object: values, key: "CDN_PREFIX")?.string
 
+        self.useUserRealName = objectForKey(object: values, key: "UI_Use_Real_Name")?.bool ?? false
+
         self.favoriteRooms = objectForKey(object: values, key: "Favorite_Rooms")?.bool ?? true
 
         self.isUsernameEmailAuthenticationEnabled = objectForKey(object: values, key: "Accounts_ShowFormLogin")?.bool ?? true

--- a/Rocket.Chat/Models/Mapping/SubscriptionModelMapping.swift
+++ b/Rocket.Chat/Models/Mapping/SubscriptionModelMapping.swift
@@ -18,6 +18,7 @@ extension Subscription: ModelMappeable {
 
         self.rid = values["rid"].string ?? ""
         self.name = values["name"].string ?? ""
+        self.fname = values["fname"].string ?? ""
         self.unread = values["unread"].int ?? 0
         self.open = values["open"].bool ?? false
         self.alert = values["alert"].bool ?? false

--- a/Rocket.Chat/Models/Mapping/UserModelMapping.swift
+++ b/Rocket.Chat/Models/Mapping/UserModelMapping.swift
@@ -20,6 +20,10 @@ extension User: ModelMappeable {
             self.username = username
         }
 
+        if let name = values["name"].string {
+            self.name = name
+        }
+
         if let status = values["status"].string {
             self.status = UserStatus(rawValue: status) ?? .offline
         }

--- a/Rocket.Chat/Models/Subscription.swift
+++ b/Rocket.Chat/Models/Subscription.swift
@@ -63,7 +63,7 @@ extension Subscription {
             return name
         }
 
-        guard let settings = AuthSettingsManager.shared.settings else {
+        guard let settings = AuthSettingsManager.settings else {
             return name
         }
 

--- a/Rocket.Chat/Models/Subscription.swift
+++ b/Rocket.Chat/Models/Subscription.swift
@@ -27,7 +27,14 @@ class Subscription: BaseModel {
 
     dynamic var rid = ""
 
+    // Name of the subscription
     dynamic var name = ""
+
+    // Full name of the user, in the case of
+    // using the full user name setting
+    // Setting: UI_Use_Real_Name
+    dynamic var fname = ""
+
     dynamic var unread = 0
     dynamic var open = false
     dynamic var alert = false
@@ -50,6 +57,21 @@ class Subscription: BaseModel {
 }
 
 extension Subscription {
+
+    func displayName() -> String {
+        if type != .directMessage {
+            return name
+        }
+
+        guard
+            let auth = AuthManager.isAuthenticated(),
+            let settings = auth.settings
+            else {
+                return name
+        }
+
+        return settings.useUserRealName ? fname : name
+    }
 
     func isValid() -> Bool {
         return self.rid.characters.count > 0

--- a/Rocket.Chat/Models/Subscription.swift
+++ b/Rocket.Chat/Models/Subscription.swift
@@ -63,11 +63,8 @@ extension Subscription {
             return name
         }
 
-        guard
-            let auth = AuthManager.isAuthenticated(),
-            let settings = auth.settings
-            else {
-                return name
+        guard let settings = AuthSettingsManager.shared.settings else {
+            return name
         }
 
         return settings.useUserRealName ? fname : name

--- a/Rocket.Chat/Models/Subscription.swift
+++ b/Rocket.Chat/Models/Subscription.swift
@@ -19,7 +19,7 @@ enum SubscriptionType: String {
 class Subscription: BaseModel {
     dynamic var auth: Auth?
 
-    fileprivate dynamic var privateType = SubscriptionType.channel.rawValue
+    internal dynamic var privateType = SubscriptionType.channel.rawValue
     var type: SubscriptionType {
         get { return SubscriptionType(rawValue: privateType) ?? SubscriptionType.group }
         set { privateType = newValue.rawValue }

--- a/Rocket.Chat/Models/User.swift
+++ b/Rocket.Chat/Models/User.swift
@@ -29,3 +29,17 @@ class User: BaseModel {
         set { privateStatus = newValue.rawValue }
     }
 }
+
+extension User {
+
+    func displayName() -> String {
+        guard let auth = AuthManager.isAuthenticated(),
+              let settings = auth.settings
+            else {
+                return username ?? ""
+        }
+
+        return (settings.useUserRealName ? name : username) ?? ""
+    }
+
+}

--- a/Rocket.Chat/Models/User.swift
+++ b/Rocket.Chat/Models/User.swift
@@ -33,10 +33,8 @@ class User: BaseModel {
 extension User {
 
     func displayName() -> String {
-        guard let auth = AuthManager.isAuthenticated(),
-              let settings = auth.settings
-            else {
-                return username ?? ""
+        guard let settings = AuthSettingsManager.shared.settings else {
+            return username ?? ""
         }
 
         return (settings.useUserRealName ? name : username) ?? ""

--- a/Rocket.Chat/Models/User.swift
+++ b/Rocket.Chat/Models/User.swift
@@ -33,7 +33,7 @@ class User: BaseModel {
 extension User {
 
     func displayName() -> String {
-        guard let settings = AuthSettingsManager.shared.settings else {
+        guard let settings = AuthSettingsManager.settings else {
             return username ?? ""
         }
 

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -182,7 +182,7 @@ final class ChatMessageCell: UICollectionViewCell {
         if message.alias.characters.count > 0 {
             labelUsername.text = message.alias
         } else {
-            labelUsername.text = message.user?.username
+            labelUsername.text = message.user?.displayName() ?? "Unknown"
         }
 
         if let text = MessageTextCacheManager.shared.message(for: message) {

--- a/Rocket.Chat/Views/Cells/Subscription/SubscriptionCell.swift
+++ b/Rocket.Chat/Views/Cells/Subscription/SubscriptionCell.swift
@@ -39,7 +39,7 @@ final class SubscriptionCell: UITableViewCell {
 
         updateIconImage()
 
-        labelName.text = subscription.name
+        labelName.text = subscription.displayName()
 
         if subscription.unread > 0 || subscription.alert {
             labelName.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.headline)

--- a/Rocket.Chat/Views/Chat/ChatPreviewModeView.swift
+++ b/Rocket.Chat/Views/Chat/ChatPreviewModeView.swift
@@ -18,7 +18,7 @@ final class ChatPreviewModeView: UIView {
     var subscription: Subscription! {
         didSet {
             let format = localized("chat.channel_preview_view.title")
-            let string = String(format: format, subscription.name)
+            let string = String(format: format, subscription.displayName())
             labelTitle.text = string
         }
     }

--- a/Rocket.Chat/Views/Chat/ChatTitleView.swift
+++ b/Rocket.Chat/Views/Chat/ChatTitleView.swift
@@ -25,7 +25,7 @@ final class ChatTitleView: UIView {
 
     var subscription: Subscription! {
         didSet {
-            labelTitle.text = subscription.name
+            labelTitle.text = subscription.displayName()
 
             switch subscription.type {
             case .channel:

--- a/Rocket.ChatTests/Managers/AuthSettingsManagerSpec.swift
+++ b/Rocket.ChatTests/Managers/AuthSettingsManagerSpec.swift
@@ -1,0 +1,95 @@
+//
+//  AuthSettingsManagerSpec.swift
+//  Rocket.Chat
+//
+//  Created by Rafael Kellermann Streit on 08/08/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import XCTest
+import RealmSwift
+
+@testable import Rocket_Chat
+
+class AuthSettingsManagerSpec: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+
+        // Clear all the Auth objects in Realm
+        Realm.executeOnMainThread({ realm in
+            for obj in realm.objects(Auth.self) {
+                realm.delete(obj)
+            }
+
+            for obj in realm.objects(AuthSettings.self) {
+                realm.delete(obj)
+            }
+        })
+    }
+
+    func testStaticSettingsAndSharedAreTheSame() {
+        let settings = AuthSettings()
+        settings.cdnPrefixURL = "foo.bar.baz"
+
+        AuthSettingsManager.shared.internalSettings = settings
+
+        XCTAssertEqual(AuthSettingsManager.shared.settings?.cdnPrefixURL, AuthSettingsManager.settings?.cdnPrefixURL, "static and shared instances are the same")
+    }
+
+    func testStaticSettingsAndInternalAreTheSame() {
+        let settings = AuthSettings()
+        settings.cdnPrefixURL = "foo.bar.baz"
+
+        AuthSettingsManager.shared.internalSettings = settings
+
+        XCTAssertEqual(AuthSettingsManager.shared.internalSettings?.cdnPrefixURL, AuthSettingsManager.settings?.cdnPrefixURL, "static and internal instances are the same")
+    }
+
+    func testClearSettings() {
+        let settings = AuthSettings()
+        settings.cdnPrefixURL = "foo.bar.baz"
+
+        AuthSettingsManager.shared.internalSettings = settings
+        XCTAssertEqual(AuthSettingsManager.settings?.cdnPrefixURL, "foo.bar.baz", "settings value exists")
+
+        AuthSettingsManager.shared.clearCachedSettings()
+        XCTAssertNil(AuthSettingsManager.shared.internalSettings?.cdnPrefixURL, "settings does not exists")
+    }
+
+    func testInternalCachedSettingsUpdatedFromAuth() {
+        Realm.executeOnMainThread({ realm in
+            let settings = AuthSettings()
+            settings.identifier = "dumb.settings.01"
+            settings.cdnPrefixURL = "foo.bar.baz"
+
+            let auth = Auth()
+            auth.serverURL = "one"
+            auth.lastAccess = Date()
+            auth.settings = settings
+
+            realm.add(auth)
+        })
+
+        XCTAssertEqual(AuthSettingsManager.settings?.cdnPrefixURL, "foo.bar.baz", "settings are update from auth object")
+    }
+
+    func testUpdateCachedSettings() {
+        Realm.executeOnMainThread({ realm in
+            let settings = AuthSettings()
+            settings.identifier = "dumb.settings.02"
+            settings.cdnPrefixURL = "foo.bar.baz"
+
+            let auth = Auth()
+            auth.serverURL = "two"
+            auth.lastAccess = Date()
+            auth.settings = settings
+
+            realm.add(auth)
+        })
+
+        AuthSettingsManager.shared.updateCachedSettings()
+        XCTAssertEqual(AuthSettingsManager.settings?.cdnPrefixURL, "foo.bar.baz", "settings are update from auth object after running update")
+    }
+
+}

--- a/Rocket.ChatTests/Models/SubscriptionSpec.swift
+++ b/Rocket.ChatTests/Models/SubscriptionSpec.swift
@@ -83,4 +83,73 @@ class SubscriptionSpec: XCTestCase {
             XCTAssert(auth.subscriptions.first?.identifier == first?.identifier, "Auth relationship with Subscription is OK")
         })
     }
+
+    func testSubscriptionDisplayNameHonorFullnameSettings() {
+        let settings = AuthSettings()
+        settings.useUserRealName = false
+
+        AuthSettingsManager.shared.internalSettings = settings
+
+        // Direct Messages
+        let directMessage = Subscription()
+        directMessage.name = "direct.message"
+        directMessage.fname = "DM"
+        directMessage.privateType = "d"
+
+        XCTAssertNotEqual(directMessage.displayName(), "DM", "Subscription.displayName() will return fname property")
+        XCTAssertEqual(directMessage.displayName(), "direct.message", "Subscription.displayName() won't return name property")
+
+        // Channels
+        let channel = Subscription()
+        channel.name = "channel"
+        channel.fname = "CHANNEL"
+        channel.privateType = "c"
+
+        XCTAssertEqual(channel.displayName(), "channel", "Subscription.displayName() will always return name for channels")
+        XCTAssertNotEqual(channel.displayName(), "CHANNEL", "Subscription.displayName() will always return name for channels")
+
+        // Groups and Private Groups
+        let group = Subscription()
+        group.name = "group"
+        group.fname = "GROUP"
+        group.privateType = "p"
+
+        XCTAssertEqual(group.displayName(), "group", "Subscription.displayName() will always return name for groups")
+        XCTAssertNotEqual(group.displayName(), "GROUP", "Subscription.displayName() will always return name for groups")
+    }
+
+    func testSubscriptionDisplayNameHonorNameSettings() {
+        let settings = AuthSettings()
+        settings.useUserRealName = true
+
+        AuthSettingsManager.shared.internalSettings = settings
+
+        // Direct Messages
+        let directMessage = Subscription()
+        directMessage.name = "direct.message"
+        directMessage.fname = "DM"
+        directMessage.privateType = "d"
+
+        XCTAssertEqual(directMessage.displayName(), "DM", "Subscription.displayName() will return fname property")
+        XCTAssertNotEqual(directMessage.displayName(), "direct.message", "Subscription.displayName() won't return name property")
+
+        // Channels
+        let channel = Subscription()
+        channel.name = "channel"
+        channel.fname = "CHANNEL"
+        channel.privateType = "c"
+
+        XCTAssertEqual(channel.displayName(), "channel", "Subscription.displayName() will always return name for channels")
+        XCTAssertNotEqual(channel.displayName(), "CHANNEL", "Subscription.displayName() will always return name for channels")
+
+        // Groups and Private Groups
+        let group = Subscription()
+        group.name = "group"
+        group.fname = "GROUP"
+        group.privateType = "p"
+
+        XCTAssertEqual(group.displayName(), "group", "Subscription.displayName() will always return name for groups")
+        XCTAssertNotEqual(group.displayName(), "GROUP", "Subscription.displayName() will always return name for groups")
+    }
+
 }

--- a/Rocket.ChatTests/Models/UserSpec.swift
+++ b/Rocket.ChatTests/Models/UserSpec.swift
@@ -44,4 +44,32 @@ class UserSpec: XCTestCase {
             XCTAssert(first?.identifier == "123", "User object was created with success")
         })
     }
+
+    func testUserDisplayNameHonorFullnameSettings() {
+        let settings = AuthSettings()
+        settings.useUserRealName = false
+
+        AuthSettingsManager.shared.internalSettings = settings
+
+        let user = User()
+        user.name = "Full Name"
+        user.username = "username"
+
+        XCTAssertNotEqual(user.displayName(), "Full Name", "User.displayName() won't return name property")
+        XCTAssertEqual(user.displayName(), "username", "User.displayName() will return username property")
+    }
+
+    func testUserDisplayNameHonorNameSettings() {
+        let settings = AuthSettings()
+        settings.useUserRealName = true
+
+        AuthSettingsManager.shared.internalSettings = settings
+
+        let user = User()
+        user.name = "Full Name"
+        user.username = "username"
+
+        XCTAssertEqual(user.displayName(), "Full Name", "User.displayName() will return name property")
+        XCTAssertNotEqual(user.displayName(), "username", "User.displayName() won't return username property")
+    }
 }


### PR DESCRIPTION
Closes #543

## Description

**When `UI_Use_Real_Name == true`**

- Every part of the app that uses `Subscription` model will display `fname` property;
- Every part of the app that uses `User` model will display `name` property;

**When `UI_Use_Real_Name == false`**

- Every part of the app that uses `Subscription` model will display `name` property;
- Every part of the app that uses `User` model will display `username` property;

## Progress

- [x] Honor settings
- [x] Cache settings in memory to don't need to go to DB every single time
- [x] Update other parts of the code that uses settings to use the cached one
- [x] Unit tests on new methods
