### PR TITLE
[FIX] Crash on Subscriptions list on headerView section

### DIFF
--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
@@ -355,8 +355,11 @@ extension SubscriptionsViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let group = groupInfomation?[section] else { return nil }
-        guard let view = SubscriptionSectionView.instantiateFromNib() else {
+        guard
+            groupInfomation?.count ?? 0 > section,
+            let group = groupInfomation?[section],
+            let view = SubscriptionSectionView.instantiateFromNib()
+        else {
             return nil
         }
 


### PR DESCRIPTION
Closes #578 

# Description

This PR fixes a crash when the index isn't available in `groupInfomation` array.