### PR TITLE
Fix general warnings and errors in Xcode 9

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChatDataController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatDataController.swift
@@ -85,14 +85,12 @@ final class ChatDataController {
                     lastObj.timestamp.year != newObj.timestamp.year) {
 
                     // Check if already contains some separator with this data
-                    // swiftlint:disable for_where
                     var insert = true
-                    for obj in data.filter({ $0.type == .daySeparator }) {
-                        if lastObj.timestamp.day == obj.timestamp.day &&
-                           lastObj.timestamp.month == obj.timestamp.month &&
-                           lastObj.timestamp.year == obj.timestamp.year {
-                            insert = false
-                        }
+                    for obj in data.filter({ $0.type == .daySeparator })
+                        where lastObj.timestamp.day == obj.timestamp.day &&
+                            lastObj.timestamp.month == obj.timestamp.month &&
+                            lastObj.timestamp.year == obj.timestamp.year {
+                                insert = false
                     }
 
                     if insert {
@@ -115,11 +113,10 @@ final class ChatDataController {
             customItem.indexPath = indexPath
             normalizeds.append(customItem)
 
-            for identifier in identifiers {
-                if identifier == item.identifier {
+            for identifier in identifiers
+                where identifier == item.identifier {
                     indexPaths.append(indexPath)
                     break
-                }
             }
         }
 
@@ -128,25 +125,18 @@ final class ChatDataController {
     }
 
     func update(_ message: Message) -> Int {
-        for index in data.indices {
-            guard data.count > index else { continue }
-
-            var obj = data[index]
-
-            if obj.message?.identifier == message.identifier {
-                data[index].message = message
+        for var obj in data
+            where obj.message?.identifier == message.identifier {
+                obj.message = message
                 return obj.indexPath.row
-            }
         }
 
         return -1
     }
 
     func oldestMessage() -> Message? {
-        for obj in data {
-            if obj.type == .message {
-                return obj.message
-            }
+        for obj in data where obj.type == .message {
+            return obj.message
         }
 
         return nil

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -449,10 +449,9 @@ final class ChatViewController: SLKTextViewController {
             for message in tempMessages {
                 var insert = true
 
-                for obj in self.dataController.data {
-                    if message.identifier == obj.message?.identifier {
+                for obj in self.dataController.data
+                    where message.identifier == obj.message?.identifier {
                         insert = false
-                    }
                 }
 
                 if insert {

--- a/Rocket.Chat/Managers/Model/AuthSettingsManager.swift
+++ b/Rocket.Chat/Managers/Model/AuthSettingsManager.swift
@@ -26,7 +26,7 @@ final class AuthSettingsManager {
         }
     }
 
-    static func updatePublicSettings(_ auth: Auth?, completion: @escaping MessageCompletionObject<AuthSettings?>) {
+    static func updatePublicSettings(_ auth: Auth?, completion: @escaping MessageCompletionObject<AuthSettings>) {
         let object = [
             "msg": "method",
             "method": "public-settings/get"

--- a/Rocket.Chat/Managers/Socket/SocketManager.swift
+++ b/Rocket.Chat/Managers/Socket/SocketManager.swift
@@ -15,7 +15,7 @@ public typealias RequestCompletion = (JSON?, Bool) -> Void
 public typealias VoidCompletion = () -> Void
 public typealias MessageCompletion = (SocketResponse) -> Void
 public typealias SocketCompletion = (WebSocket?, Bool) -> Void
-public typealias MessageCompletionObject <T: Object> = (T) -> Void
+public typealias MessageCompletionObject <T: Object> = (T?) -> Void
 public typealias MessageCompletionObjectsList <T: Object> = ([T]) -> Void
 
 protocol SocketConnectionHandler {


### PR DESCRIPTION
@RocketChat/iOS
Fixes warnings and errors:
1. Fix generics optional error issue in "MessageCompletionObject" closure
2. Optimizes "for if" conditions to "for where"
3. Fixes NotificationCenter observer removal warnings of self on view disappear

Closes #542
