### PR TITLE
[FIX] User's full name in spotlight search as well

### DIFF
--- a/Rocket.Chat/Managers/Model/SubscriptionManager.swift
+++ b/Rocket.Chat/Managers/Model/SubscriptionManager.swift
@@ -204,6 +204,7 @@ struct SubscriptionManager {
                     subscription.otherUserId = user.identifier
                     subscription.type = .directMessage
                     subscription.name = user.username ?? ""
+                    subscription.fname = user.name ?? ""
                     subscriptions.append(subscription)
 
                     if let identifier = subscription.identifier {


### PR DESCRIPTION
@RocketChat/ios 

Closes #626 

# Description

When server is configured to use user's real name instead of username, the search on Spotlight wasn't saving the `fname` property in Subscription instance.