### PR TITLE
[FIX] Show cancel button if search not empty + reset text when pressed

### DIFF
--- a/Rocket.Chat/Controllers/Chat/MainChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MainChatViewController.swift
@@ -54,25 +54,23 @@ class MainChatViewController: SideMenuController, SideMenuControllerDelegate {
 
     func sideMenuControllerWillHide(_ sideMenuController: SideMenuController) {
         ChatViewController.shared?.textView.resignFirstResponder()
-        SubscriptionsViewController.shared?.textFieldSearch.resignFirstResponder()
+        SubscriptionsViewController.shared?.willHide()
     }
 
     func sideMenuControllerDidHide(_ sideMenuController: SideMenuController) {
         ChatViewController.shared?.textView.resignFirstResponder()
-        SubscriptionsViewController.shared?.textFieldSearch.resignFirstResponder()
+        SubscriptionsViewController.shared?.didHide()
         SubscriptionsPageViewController.shared?.showSubscriptionsList(animated: false)
     }
 
     func sideMenuControllerDidReveal(_ sideMenuController: SideMenuController) {
         ChatViewController.shared?.textView.resignFirstResponder()
-        SubscriptionsViewController.shared?.textFieldSearch.resignFirstResponder()
+        SubscriptionsViewController.shared?.didReveal()
     }
 
     func sideMenuControllerWillReveal(_ sideMenuController: SideMenuController) {
         ChatViewController.shared?.textView.resignFirstResponder()
-
-        SubscriptionsViewController.shared?.textFieldSearch.resignFirstResponder()
-        SubscriptionsViewController.shared?.updateData()
+        SubscriptionsViewController.shared?.willReveal()
     }
 
     // MARK: Authentication & Server management

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
@@ -156,7 +156,7 @@ extension SubscriptionsViewController {
 
     func searchBy(_ text: String = "") {
         guard let auth = AuthManager.isAuthenticated() else { return }
-        subscriptions = auth.subscriptions.filterBy(name: searchText)
+        subscriptions = auth.subscriptions.filterBy(name: text)
 
         if text.characters.count == 0 {
             isSearchingLocally = false

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
@@ -20,11 +20,7 @@ final class SubscriptionsViewController: BaseViewController {
             buttonCancelSearch.setTitle(localized("global.cancel"), for: .normal)
         }
     }
-    @IBOutlet weak var buttonCancelSearchWidthConstraint: NSLayoutConstraint! {
-        didSet {
-            buttonCancelSearchWidthConstraint.constant = 0
-        }
-    }
+    @IBOutlet weak var buttonCancelSearchWidthConstraint: NSLayoutConstraint!
 
     @IBOutlet weak var textFieldSearch: UITextField! {
         didSet {
@@ -125,15 +121,42 @@ final class SubscriptionsViewController: BaseViewController {
     }
 }
 
+// MARK: Side Menu callbacks
+extension SubscriptionsViewController {
+    func willHide() {
+        self.textFieldSearch.resignFirstResponder()
+    }
+
+    func didHide() {
+        self.textFieldSearch.resignFirstResponder()
+    }
+
+    func willReveal() {
+        if searchText.isEmpty {
+            hideCancelSearchButton()
+        } else {
+            showCancelSearchButton()
+        }
+
+        self.textFieldSearch.resignFirstResponder()
+        self.updateData()
+    }
+
+    func didReveal() {
+        self.textFieldSearch.resignFirstResponder()
+    }
+}
+
 extension SubscriptionsViewController {
 
     @IBAction func buttonCancelSearchDidPressed(_ sender: Any) {
         textFieldSearch.resignFirstResponder()
+        textFieldSearch.text = ""
     }
 
     func searchBy(_ text: String = "") {
         guard let auth = AuthManager.isAuthenticated() else { return }
-        subscriptions = auth.subscriptions.filter("name CONTAINS %@", text)
+        subscriptions = auth.subscriptions.filterBy(name: searchText)
 
         if text.characters.count == 0 {
             isSearchingLocally = false
@@ -442,8 +465,16 @@ extension SubscriptionsViewController: UITableViewDelegate {
 
 extension SubscriptionsViewController: UITextFieldDelegate {
 
-    func textFieldDidBeginEditing(_ textField: UITextField) {
+    func showCancelSearchButton() {
         buttonCancelSearchWidthConstraint.constant = defaultButtonCancelSearchWidth
+    }
+
+    func hideCancelSearchButton() {
+        buttonCancelSearchWidthConstraint.constant = 0
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        self.showCancelSearchButton()
 
         UIView.animate(withDuration: 0.1) {
             self.view.layoutIfNeeded()
@@ -451,7 +482,7 @@ extension SubscriptionsViewController: UITextFieldDelegate {
     }
 
     func textFieldDidEndEditing(_ textField: UITextField) {
-        buttonCancelSearchWidthConstraint.constant = 0
+        hideCancelSearchButton()
 
         UIView.animate(withDuration: 0.1) {
             self.view.layoutIfNeeded()


### PR DESCRIPTION
@RocketChat/ios

Closes #645 

Also noticed the cancel button doesn't remove the text and reset the search after pressing like the web version, so i fixed that too.