### PR TITLE
[FIX] Reset search after cancel pressed

### DIFF
--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
@@ -152,6 +152,7 @@ extension SubscriptionsViewController {
     @IBAction func buttonCancelSearchDidPressed(_ sender: Any) {
         textFieldSearch.resignFirstResponder()
         textFieldSearch.text = ""
+        searchBy()
     }
 
     func searchBy(_ text: String = "") {


### PR DESCRIPTION
@RocketChat/ios 

Closes #655 

Simply calling the search function again after clearing the text does the job.