### PR TITLE
[FIX] Text wrapping on iPhone SE and Plus

### DIFF
--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -60,7 +60,7 @@ final class ChatMessageCell: UICollectionViewCell {
         let attributedString = MessageTextCacheManager.shared.message(for: message)
         let height = attributedString?.heightForView(withWidth: fullWidth - 62)
 
-        var total = (height ?? 0) + (sequential ? 8 : 28)
+        var total = (height ?? 0) + (sequential ? 8 : 29)
 
         for url in message.urls {
             guard url.isValid() else { continue }


### PR DESCRIPTION
@RocketChat/ios

Closes #665 

Text rendering can do some different stuff between devices. iPhone SE and Plus require an additional pixel to render some wrapped texts correctly.