### PR TITLE
[FIX] Temp message and text field spacing

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -373,7 +373,9 @@ final class ChatViewController: SLKTextViewController {
                     }
 
                     self.messages.append(contentsOf: newMessages)
-                    self.appendMessages(messages: newMessages, completion: nil)
+                    self.appendMessages(messages: newMessages, completion: {
+                        self.scrollToBottom()
+                    })
                     self.markAsRead()
                 }
 


### PR DESCRIPTION
@RocketChat/ios

Closes #673

Every time a new message is appended in the collection view, a method is called. The method completion was nil and now it set a new offset value to the collection view.
