### PR TITLE
[NEW] Start using REST API

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		80A63C511F719FB300FE5AC4 /* ChannelInfoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A63C501F719FB300FE5AC4 /* ChannelInfoRequest.swift */; };
 		80A63C531F71BD2900FE5AC4 /* UserInfoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A63C521F71BD2900FE5AC4 /* UserInfoRequest.swift */; };
 		80A63C551F71BF3A00FE5AC4 /* UserInfoRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A63C541F71BF3A00FE5AC4 /* UserInfoRequestSpec.swift */; };
+		80A63C571F71D2E400FE5AC4 /* APISpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A63C561F71D2E400FE5AC4 /* APISpec.swift */; };
 		925FF74E1E8EFB3E00982043 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925FF74D1E8EFB3E00982043 /* SettingsViewModel.swift */; };
 		925FF7511E8EFCAD00982043 /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925FF7501E8EFCAD00982043 /* SettingsViewModelTests.swift */; };
 		A0FFC1611E8A9D8D00A1B5EA /* TintedTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0FFC1601E8A9D8D00A1B5EA /* TintedTextField.swift */; };
@@ -404,6 +405,7 @@
 		80A63C501F719FB300FE5AC4 /* ChannelInfoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelInfoRequest.swift; sourceTree = "<group>"; };
 		80A63C521F71BD2900FE5AC4 /* UserInfoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRequest.swift; sourceTree = "<group>"; };
 		80A63C541F71BF3A00FE5AC4 /* UserInfoRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRequestSpec.swift; sourceTree = "<group>"; };
+		80A63C561F71D2E400FE5AC4 /* APISpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APISpec.swift; sourceTree = "<group>"; };
 		925FF74D1E8EFB3E00982043 /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		925FF7501E8EFCAD00982043 /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
 		A0FFC1601E8A9D8D00A1B5EA /* TintedTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TintedTextField.swift; path = Views/Subscriptions/TintedTextField.swift; sourceTree = "<group>"; };
@@ -1006,6 +1008,7 @@
 			isa = PBXGroup;
 			children = (
 				D18675E81F70A56800406FB4 /* Requests */,
+				80A63C561F71D2E400FE5AC4 /* APISpec.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1698,6 +1701,7 @@
 				4161333C1D46E32F00E09DA2 /* UserSpec.swift in Sources */,
 				411D76E71F39FA7B00B0A8DF /* AuthSettingsManagerSpec.swift in Sources */,
 				D1411A2A1F6777F300D6EDF7 /* ChannelSpec.swift in Sources */,
+				80A63C571F71D2E400FE5AC4 /* APISpec.swift in Sources */,
 				4161333A1D46E0A200E09DA2 /* AuthSpec.swift in Sources */,
 				41DC7A1F1D3865FE00896FC0 /* MessageManagerSpec.swift in Sources */,
 				D1DA25251F695ABF00DB6ABB /* ChatDataControllerSpec.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -172,6 +172,8 @@
 		597ECBA41E3708B10041C5C5 /* PushManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597ECBA31E3708B10041C5C5 /* PushManager.swift */; };
 		68D186DF1ED9714F0030EE8C /* MessageURLSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D186DE1ED9714F0030EE8C /* MessageURLSpec.swift */; };
 		7DE1B07114BBD1D46E9CC71B /* Pods_Rocket_Chat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F5191CD6C53AEA006C82524 /* Pods_Rocket_Chat.framework */; };
+		80A63C4F1F719F9600FE5AC4 /* ChannelInfoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A63C4E1F719F9600FE5AC4 /* ChannelInfoRequest.swift */; };
+		80A63C511F719FB300FE5AC4 /* ChannelInfoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A63C501F719FB300FE5AC4 /* ChannelInfoRequest.swift */; };
 		925FF74E1E8EFB3E00982043 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925FF74D1E8EFB3E00982043 /* SettingsViewModel.swift */; };
 		925FF7511E8EFCAD00982043 /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925FF7501E8EFCAD00982043 /* SettingsViewModelTests.swift */; };
 		A0FFC1611E8A9D8D00A1B5EA /* TintedTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0FFC1601E8A9D8D00A1B5EA /* TintedTextField.swift */; };
@@ -396,6 +398,8 @@
 		597ECBA31E3708B10041C5C5 /* PushManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushManager.swift; path = Managers/PushManager.swift; sourceTree = "<group>"; };
 		68D186DE1ED9714F0030EE8C /* MessageURLSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MessageURLSpec.swift; path = Models/MessageURLSpec.swift; sourceTree = "<group>"; };
 		68D870A8D54F5431A14607AE /* Pods_Rocket_ChatTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rocket_ChatTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		80A63C4E1F719F9600FE5AC4 /* ChannelInfoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelInfoRequest.swift; sourceTree = "<group>"; };
+		80A63C501F719FB300FE5AC4 /* ChannelInfoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelInfoRequest.swift; sourceTree = "<group>"; };
 		925FF74D1E8EFB3E00982043 /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		925FF7501E8EFCAD00982043 /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
 		A0FFC1601E8A9D8D00A1B5EA /* TintedTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TintedTextField.swift; path = Views/Subscriptions/TintedTextField.swift; sourceTree = "<group>"; };
@@ -1007,6 +1011,7 @@
 			children = (
 				D18675E91F70A58B00406FB4 /* InfoRequestSpec.swift */,
 				D18675ED1F716FBC00406FB4 /* LoginRequestSpec.swift */,
+				80A63C501F719FB300FE5AC4 /* ChannelInfoRequest.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -1027,6 +1032,7 @@
 			children = (
 				D1D535F01F70864C006625D2 /* InfoRequest.swift */,
 				D18675EB1F716A0D00406FB4 /* LoginRequest.swift */,
+				80A63C4E1F719F9600FE5AC4 /* ChannelInfoRequest.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -1644,6 +1650,7 @@
 				41900C271D9FE35400308EF4 /* Attachment.swift in Sources */,
 				412719441E6B353B00461FEE /* AuthViewControllerGoogleExtensions.swift in Sources */,
 				41499C911F2A1A7200790EA7 /* TimestampCoordinator.swift in Sources */,
+				80A63C4F1F719F9600FE5AC4 /* ChannelInfoRequest.swift in Sources */,
 				D3CFAFBD1E907D8900BADC0A /* ChatMessageTextViewModel.swift in Sources */,
 				D1D535F11F70864C006625D2 /* InfoRequest.swift in Sources */,
 				415029BD1E72E0FD009F596C /* ChannelInfoCellProtocol.swift in Sources */,
@@ -1696,6 +1703,7 @@
 				4151807C1EAE249F0000A039 /* ChatMessageTextViewModelSpec.swift in Sources */,
 				411119B81F6825C30019854B /* NetworkManagerSpec.swift in Sources */,
 				416296F91F41B42B00BCCEDD /* UploadHelperSpec.swift in Sources */,
+				80A63C511F719FB300FE5AC4 /* ChannelInfoRequest.swift in Sources */,
 				41FE55531F6038D60071E97A /* DatabaseManagerSpec.swift in Sources */,
 				416296FC1F41D42800BCCEDD /* DownloadManagerSpec.swift in Sources */,
 				D1A403D91F6760BC00798EDA /* NSAttributedStringExtensionsSpec.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -174,6 +174,8 @@
 		7DE1B07114BBD1D46E9CC71B /* Pods_Rocket_Chat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F5191CD6C53AEA006C82524 /* Pods_Rocket_Chat.framework */; };
 		80A63C4F1F719F9600FE5AC4 /* ChannelInfoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A63C4E1F719F9600FE5AC4 /* ChannelInfoRequest.swift */; };
 		80A63C511F719FB300FE5AC4 /* ChannelInfoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A63C501F719FB300FE5AC4 /* ChannelInfoRequest.swift */; };
+		80A63C531F71BD2900FE5AC4 /* UserInfoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A63C521F71BD2900FE5AC4 /* UserInfoRequest.swift */; };
+		80A63C551F71BF3A00FE5AC4 /* UserInfoRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A63C541F71BF3A00FE5AC4 /* UserInfoRequestSpec.swift */; };
 		925FF74E1E8EFB3E00982043 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925FF74D1E8EFB3E00982043 /* SettingsViewModel.swift */; };
 		925FF7511E8EFCAD00982043 /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925FF7501E8EFCAD00982043 /* SettingsViewModelTests.swift */; };
 		A0FFC1611E8A9D8D00A1B5EA /* TintedTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0FFC1601E8A9D8D00A1B5EA /* TintedTextField.swift */; };
@@ -400,6 +402,8 @@
 		68D870A8D54F5431A14607AE /* Pods_Rocket_ChatTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rocket_ChatTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		80A63C4E1F719F9600FE5AC4 /* ChannelInfoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelInfoRequest.swift; sourceTree = "<group>"; };
 		80A63C501F719FB300FE5AC4 /* ChannelInfoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelInfoRequest.swift; sourceTree = "<group>"; };
+		80A63C521F71BD2900FE5AC4 /* UserInfoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRequest.swift; sourceTree = "<group>"; };
+		80A63C541F71BF3A00FE5AC4 /* UserInfoRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRequestSpec.swift; sourceTree = "<group>"; };
 		925FF74D1E8EFB3E00982043 /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		925FF7501E8EFCAD00982043 /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
 		A0FFC1601E8A9D8D00A1B5EA /* TintedTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TintedTextField.swift; path = Views/Subscriptions/TintedTextField.swift; sourceTree = "<group>"; };
@@ -1012,6 +1016,7 @@
 				D18675E91F70A58B00406FB4 /* InfoRequestSpec.swift */,
 				D18675ED1F716FBC00406FB4 /* LoginRequestSpec.swift */,
 				80A63C501F719FB300FE5AC4 /* ChannelInfoRequest.swift */,
+				80A63C541F71BF3A00FE5AC4 /* UserInfoRequestSpec.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -1033,6 +1038,7 @@
 				D1D535F01F70864C006625D2 /* InfoRequest.swift */,
 				D18675EB1F716A0D00406FB4 /* LoginRequest.swift */,
 				80A63C4E1F719F9600FE5AC4 /* ChannelInfoRequest.swift */,
+				80A63C521F71BD2900FE5AC4 /* UserInfoRequest.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -1635,6 +1641,7 @@
 				415DC7F61F67F5D30039FB4F /* NetworkManager.swift in Sources */,
 				41C45AEF1DFAD42800D9969C /* ChatDataController.swift in Sources */,
 				41EE157E1E05BED600754D45 /* ChatControllerAutocomplete.swift in Sources */,
+				80A63C531F71BD2900FE5AC4 /* UserInfoRequest.swift in Sources */,
 				4162E1531D651A8800AAAE49 /* UserManager.swift in Sources */,
 				4112BEEC1E7971A400E734CB /* MainChatViewController.swift in Sources */,
 				419ECCA41F3CA21A005F224B /* DownloadManager.swift in Sources */,
@@ -1699,6 +1706,7 @@
 				41ADDD4B1E9E787E0007A458 /* LoaderViewSpec.swift in Sources */,
 				41DC7A221D386B4700896FC0 /* StringExtensionSpec.swift in Sources */,
 				68D186DF1ED9714F0030EE8C /* MessageURLSpec.swift in Sources */,
+				80A63C551F71BF3A00FE5AC4 /* UserInfoRequestSpec.swift in Sources */,
 				B5893BF61F6C4B1D00365768 /* UserReviewManagerSpec.swift in Sources */,
 				4151807C1EAE249F0000A039 /* ChatMessageTextViewModelSpec.swift in Sources */,
 				411119B81F6825C30019854B /* NetworkManagerSpec.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -186,6 +186,8 @@
 		D1411A2C1F6779A200D6EDF7 /* MentionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1411A2B1F6779A200D6EDF7 /* MentionSpec.swift */; };
 		D15C83861F70991F001AB155 /* APIResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15C83851F70991F001AB155 /* APIResult.swift */; };
 		D18675EA1F70A58B00406FB4 /* InfoRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18675E91F70A58B00406FB4 /* InfoRequestSpec.swift */; };
+		D18675EC1F716A0D00406FB4 /* LoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18675EB1F716A0D00406FB4 /* LoginRequest.swift */; };
+		D18675EE1F716FBC00406FB4 /* LoginRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18675ED1F716FBC00406FB4 /* LoginRequestSpec.swift */; };
 		D1A403D91F6760BC00798EDA /* NSAttributedStringExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A403D81F6760BC00798EDA /* NSAttributedStringExtensionsSpec.swift */; };
 		D1C536CC1F688B2F00EBA8D9 /* MarkdownManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C536CB1F688B2F00EBA8D9 /* MarkdownManager.swift */; };
 		D1C536CE1F688B7100EBA8D9 /* UIFontExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C536CD1F688B7100EBA8D9 /* UIFontExtensions.swift */; };
@@ -409,6 +411,8 @@
 		D1411A2B1F6779A200D6EDF7 /* MentionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MentionSpec.swift; path = Models/MentionSpec.swift; sourceTree = "<group>"; };
 		D15C83851F70991F001AB155 /* APIResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResult.swift; sourceTree = "<group>"; };
 		D18675E91F70A58B00406FB4 /* InfoRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoRequestSpec.swift; sourceTree = "<group>"; };
+		D18675EB1F716A0D00406FB4 /* LoginRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequest.swift; sourceTree = "<group>"; };
+		D18675ED1F716FBC00406FB4 /* LoginRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequestSpec.swift; sourceTree = "<group>"; };
 		D1A403D81F6760BC00798EDA /* NSAttributedStringExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSAttributedStringExtensionsSpec.swift; path = Extensions/NSAttributedStringExtensionsSpec.swift; sourceTree = "<group>"; };
 		D1C536CB1F688B2F00EBA8D9 /* MarkdownManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MarkdownManager.swift; path = Managers/MarkdownManager.swift; sourceTree = "<group>"; };
 		D1C536CD1F688B7100EBA8D9 /* UIFontExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIFontExtensions.swift; path = Extensions/UIFontExtensions.swift; sourceTree = "<group>"; };
@@ -1002,6 +1006,7 @@
 			isa = PBXGroup;
 			children = (
 				D18675E91F70A58B00406FB4 /* InfoRequestSpec.swift */,
+				D18675ED1F716FBC00406FB4 /* LoginRequestSpec.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -1021,6 +1026,7 @@
 			isa = PBXGroup;
 			children = (
 				D1D535F01F70864C006625D2 /* InfoRequest.swift */,
+				D18675EB1F716A0D00406FB4 /* LoginRequest.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -1645,6 +1651,7 @@
 				415029B51E72D519009F596C /* ChannelInfoBasicCell.swift in Sources */,
 				D32E28251DFD86C300D6019C /* LauncherProtocol.swift in Sources */,
 				41DF76E31D2C50710028DBF8 /* AppDelegate.swift in Sources */,
+				D18675EC1F716A0D00406FB4 /* LoginRequest.swift in Sources */,
 				4174CB131D2D99960086DAC8 /* BaseViewController.swift in Sources */,
 				597ECBA21E3708A50041C5C5 /* DataExtension.swift in Sources */,
 				414A1FFC1D46395900093E10 /* SocketResponse.swift in Sources */,
@@ -1669,6 +1676,7 @@
 				4171ABA51E7C056E009FC3F0 /* AvatarViewSpec.swift in Sources */,
 				D18675EA1F70A58B00406FB4 /* InfoRequestSpec.swift in Sources */,
 				417A70031D47918200FF46EE /* ResponseMessageSpec.swift in Sources */,
+				D18675EE1F716FBC00406FB4 /* LoginRequestSpec.swift in Sources */,
 				41BA89241D303D8B00CBF526 /* AuthManagerSpec.swift in Sources */,
 				925FF7511E8EFCAD00982043 /* SettingsViewModelTests.swift in Sources */,
 				41DC7A241D386CA800896FC0 /* DateExtensionsSpec.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -184,9 +184,14 @@
 		D12D34031F69C76400AED992 /* SubscriptionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12D34021F69C76400AED992 /* SubscriptionExtensions.swift */; };
 		D1411A2A1F6777F300D6EDF7 /* ChannelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1411A291F6777F300D6EDF7 /* ChannelSpec.swift */; };
 		D1411A2C1F6779A200D6EDF7 /* MentionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1411A2B1F6779A200D6EDF7 /* MentionSpec.swift */; };
+		D15C83861F70991F001AB155 /* APIResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15C83851F70991F001AB155 /* APIResult.swift */; };
+		D18675EA1F70A58B00406FB4 /* InfoRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18675E91F70A58B00406FB4 /* InfoRequestSpec.swift */; };
 		D1A403D91F6760BC00798EDA /* NSAttributedStringExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A403D81F6760BC00798EDA /* NSAttributedStringExtensionsSpec.swift */; };
 		D1C536CC1F688B2F00EBA8D9 /* MarkdownManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C536CB1F688B2F00EBA8D9 /* MarkdownManager.swift */; };
 		D1C536CE1F688B7100EBA8D9 /* UIFontExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C536CD1F688B7100EBA8D9 /* UIFontExtensions.swift */; };
+		D1D535EC1F7081FA006625D2 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D535EB1F7081FA006625D2 /* API.swift */; };
+		D1D535EE1F708628006625D2 /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D535ED1F708628006625D2 /* APIRequest.swift */; };
+		D1D535F11F70864C006625D2 /* InfoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D535F01F70864C006625D2 /* InfoRequest.swift */; };
 		D1DA25251F695ABF00DB6ABB /* ChatDataControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1DA25241F695ABF00DB6ABB /* ChatDataControllerSpec.swift */; };
 		D32E28241DFD86C300D6019C /* BugTrackingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32E28211DFD86C300D6019C /* BugTrackingCoordinator.swift */; };
 		D32E28251DFD86C300D6019C /* LauncherProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32E28221DFD86C300D6019C /* LauncherProtocol.swift */; };
@@ -402,9 +407,14 @@
 		D12D34021F69C76400AED992 /* SubscriptionExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SubscriptionExtensions.swift; path = Extensions/Models/SubscriptionExtensions.swift; sourceTree = "<group>"; };
 		D1411A291F6777F300D6EDF7 /* ChannelSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ChannelSpec.swift; path = Models/ChannelSpec.swift; sourceTree = "<group>"; };
 		D1411A2B1F6779A200D6EDF7 /* MentionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MentionSpec.swift; path = Models/MentionSpec.swift; sourceTree = "<group>"; };
+		D15C83851F70991F001AB155 /* APIResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResult.swift; sourceTree = "<group>"; };
+		D18675E91F70A58B00406FB4 /* InfoRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoRequestSpec.swift; sourceTree = "<group>"; };
 		D1A403D81F6760BC00798EDA /* NSAttributedStringExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSAttributedStringExtensionsSpec.swift; path = Extensions/NSAttributedStringExtensionsSpec.swift; sourceTree = "<group>"; };
 		D1C536CB1F688B2F00EBA8D9 /* MarkdownManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MarkdownManager.swift; path = Managers/MarkdownManager.swift; sourceTree = "<group>"; };
 		D1C536CD1F688B7100EBA8D9 /* UIFontExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIFontExtensions.swift; path = Extensions/UIFontExtensions.swift; sourceTree = "<group>"; };
+		D1D535EB1F7081FA006625D2 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
+		D1D535ED1F708628006625D2 /* APIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
+		D1D535F01F70864C006625D2 /* InfoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoRequest.swift; sourceTree = "<group>"; };
 		D1DA25241F695ABF00DB6ABB /* ChatDataControllerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ChatDataControllerSpec.swift; path = Controllers/ChatDataControllerSpec.swift; sourceTree = "<group>"; };
 		D32E28211DFD86C300D6019C /* BugTrackingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BugTrackingCoordinator.swift; sourceTree = "<group>"; };
 		D32E28221DFD86C300D6019C /* LauncherProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LauncherProtocol.swift; sourceTree = "<group>"; };
@@ -879,6 +889,7 @@
 		41DF76E11D2C50710028DBF8 /* Rocket.Chat */ = {
 			isa = PBXGroup;
 			children = (
+				D1D535EA1F7081E6006625D2 /* API */,
 				4199A9861DABCC2E0035F820 /* External */,
 				41A79C0D1D2F084F00A1968E /* Models */,
 				4174CB1D1D2DB3270086DAC8 /* Extensions */,
@@ -902,6 +913,7 @@
 		41DF76F61D2C50720028DBF8 /* Rocket.ChatTests */ = {
 			isa = PBXGroup;
 			children = (
+				D18675E71F70A55D00406FB4 /* API */,
 				D1DA25261F695AC700DB6ABB /* Controllers */,
 				416133361D46DB0900E09DA2 /* Models */,
 				41DC7A201D386B2C00896FC0 /* Extensions */,
@@ -976,6 +988,41 @@
 				925FF7501E8EFCAD00982043 /* SettingsViewModelTests.swift */,
 			);
 			name = Settings;
+			sourceTree = "<group>";
+		};
+		D18675E71F70A55D00406FB4 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				D18675E81F70A56800406FB4 /* Requests */,
+			);
+			path = API;
+			sourceTree = "<group>";
+		};
+		D18675E81F70A56800406FB4 /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				D18675E91F70A58B00406FB4 /* InfoRequestSpec.swift */,
+			);
+			path = Requests;
+			sourceTree = "<group>";
+		};
+		D1D535EA1F7081E6006625D2 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				D1D535EF1F70863C006625D2 /* Requests */,
+				D1D535EB1F7081FA006625D2 /* API.swift */,
+				D1D535ED1F708628006625D2 /* APIRequest.swift */,
+				D15C83851F70991F001AB155 /* APIResult.swift */,
+			);
+			path = API;
+			sourceTree = "<group>";
+		};
+		D1D535EF1F70863C006625D2 /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				D1D535F01F70864C006625D2 /* InfoRequest.swift */,
+			);
+			path = Requests;
 			sourceTree = "<group>";
 		};
 		D1DA25261F695AC700DB6ABB /* Controllers */ = {
@@ -1528,6 +1575,7 @@
 				415029B91E72D541009F596C /* ChannelInfoDescriptionCell.swift in Sources */,
 				41A1748C1DD9F2F900188E3B /* UIViewControllerExtension.swift in Sources */,
 				41D701D61E67111E00FED2EE /* MessageTextFontAttributes.swift in Sources */,
+				D1D535EE1F708628006625D2 /* APIRequest.swift in Sources */,
 				41C275DF1D848005003C88CF /* AvatarView.swift in Sources */,
 				4147CE7F1F5EB27B00C322C3 /* AddServerCell.swift in Sources */,
 				A0FFC1611E8A9D8D00A1B5EA /* TintedTextField.swift in Sources */,
@@ -1540,6 +1588,7 @@
 				41A79C131D2F09F200A1968E /* Auth.swift in Sources */,
 				41E53A171E546F5500C3FBB3 /* UINibExtensions.swift in Sources */,
 				D32E28241DFD86C300D6019C /* BugTrackingCoordinator.swift in Sources */,
+				D1D535EC1F7081FA006625D2 /* API.swift in Sources */,
 				41DAE93E1D318F350098E068 /* Subscription.swift in Sources */,
 				41D4ABAB1F4CD10C00ACDDDD /* ChatCollectionViewFlowLayout.swift in Sources */,
 				4151B4541E2D1A9E00F8AA1B /* SubscriptionModelHandler.swift in Sources */,
@@ -1568,6 +1617,7 @@
 				D12D34031F69C76400AED992 /* SubscriptionExtensions.swift in Sources */,
 				41A91AF11E51CD41005C94B1 /* SubscriptionUserStatusView.swift in Sources */,
 				412731D71DE0A89B00FC45A0 /* ChatPreviewModeView.swift in Sources */,
+				D15C83861F70991F001AB155 /* APIResult.swift in Sources */,
 				4180204F1E718E370012A092 /* ChannelInfoViewController.swift in Sources */,
 				4147CE7D1F5EAAB300C322C3 /* ServerCell.swift in Sources */,
 				415DC7F61F67F5D30039FB4F /* NetworkManager.swift in Sources */,
@@ -1589,6 +1639,7 @@
 				412719441E6B353B00461FEE /* AuthViewControllerGoogleExtensions.swift in Sources */,
 				41499C911F2A1A7200790EA7 /* TimestampCoordinator.swift in Sources */,
 				D3CFAFBD1E907D8900BADC0A /* ChatMessageTextViewModel.swift in Sources */,
+				D1D535F11F70864C006625D2 /* InfoRequest.swift in Sources */,
 				415029BD1E72E0FD009F596C /* ChannelInfoCellProtocol.swift in Sources */,
 				411D76E51F39F05A00B0A8DF /* AuthSettingsManager.swift in Sources */,
 				415029B51E72D519009F596C /* ChannelInfoBasicCell.swift in Sources */,
@@ -1616,6 +1667,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4171ABA51E7C056E009FC3F0 /* AvatarViewSpec.swift in Sources */,
+				D18675EA1F70A58B00406FB4 /* InfoRequestSpec.swift in Sources */,
 				417A70031D47918200FF46EE /* ResponseMessageSpec.swift in Sources */,
 				41BA89241D303D8B00CBF526 /* AuthManagerSpec.swift in Sources */,
 				925FF7511E8EFCAD00982043 /* SettingsViewModelTests.swift in Sources */,

--- a/Rocket.Chat/API/API.swift
+++ b/Rocket.Chat/API/API.swift
@@ -13,6 +13,8 @@ class API {
     static let shared: API! = API(host: "https://demo.rocket.chat")
 
     var host: URL
+    var authToken: String?
+    var userId: String?
 
     convenience init?(host: String) {
         guard let url = URL(string: host) else {
@@ -27,7 +29,11 @@ class API {
     }
 
     func fetch<R>(_ request: R, completion: ((_ result: APIResult<R>?) -> Void)?) {
-        let request = request.request(for: self)
+        guard let request = request.request(for: self) else {
+            completion?(nil)
+            return
+        }
+
         let task = URLSession.shared.dataTask(with: request) { (data, _, _) in
             guard let data = data else { return }
             let json = try? JSON(data: data)

--- a/Rocket.Chat/API/API.swift
+++ b/Rocket.Chat/API/API.swift
@@ -10,22 +10,30 @@ import Foundation
 import SwiftyJSON
 
 class API {
-    static let shared = API()
+    static let shared: API! = API(host: "https://demo.rocket.chat")
 
-    var host: String
-    init(host: String = "https://demo.rocket.chat") {
+    var host: URL
+
+    convenience init?(host: String) {
+        guard let url = URL(string: host) else {
+            return nil
+        }
+
+        self.init(host: url)
+    }
+
+    init(host: URL) {
         self.host = host
     }
 
     func fetch<R>(_ request: R, completion: ((_ result: APIResult<R>?) -> Void)?) {
-        if let request = request.request(for: self) {
-            let task = URLSession.shared.dataTask(with: request) { (data, _, _) in
-                guard let data = data else { return }
-                let json = try? JSON(data: data)
-                completion?(APIResult<R>(raw: json))
-            }
-
-            task.resume()
+        let request = request.request(for: self)
+        let task = URLSession.shared.dataTask(with: request) { (data, _, _) in
+            guard let data = data else { return }
+            let json = try? JSON(data: data)
+            completion?(APIResult<R>(raw: json))
         }
+
+        task.resume()
     }
 }

--- a/Rocket.Chat/API/API.swift
+++ b/Rocket.Chat/API/API.swift
@@ -17,8 +17,8 @@ class API {
         self.host = host
     }
 
-    func fetch<R>(completion: ((_ result: APIResult<R>?) -> Void)?) {
-        if let request = R.request(for: self) {
+    func fetch<R>(_ request: R, completion: ((_ result: APIResult<R>?) -> Void)?) {
+        if let request = request.request(for: self) {
             let task = URLSession.shared.dataTask(with: request) { (data, _, _) in
                 guard let data = data else { return }
                 let json = try? JSON(data: data)

--- a/Rocket.Chat/API/API.swift
+++ b/Rocket.Chat/API/API.swift
@@ -1,0 +1,31 @@
+//
+//  API.swift
+//  Rocket.Chat
+//
+//  Created by Matheus Cardoso on 9/18/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import Foundation
+import SwiftyJSON
+
+class API {
+    static let shared = API()
+
+    var host: String
+    init(host: String = "https://demo.rocket.chat") {
+        self.host = host
+    }
+
+    func fetch<R>(completion: ((_ result: APIResult<R>?) -> Void)?) {
+        if let request = R.request(for: self) {
+            let task = URLSession.shared.dataTask(with: request) { (data, _, _) in
+                guard let data = data else { return }
+                let json = try? JSON(data: data)
+                completion?(APIResult<R>(raw: json))
+            }
+
+            task.resume()
+        }
+    }
+}

--- a/Rocket.Chat/API/APIRequest.swift
+++ b/Rocket.Chat/API/APIRequest.swift
@@ -10,14 +10,29 @@ import Foundation
 
 protocol APIRequest {
     static var path: String { get }
-    static func request(for api: API) -> URLRequest?
+    static var method: String { get }
+    func body() -> Data?
+    func request(for api: API) -> URLRequest?
 }
 
 extension APIRequest {
-    static func request(for api: API) -> URLRequest? {
+    static var method: String {
+        return "GET"
+    }
+
+    func body() -> Data? {
+        return nil
+    }
+
+    func request(for api: API) -> URLRequest? {
         if var url = URL(string: api.host) {
-            url.appendPathComponent(path)
-            return URLRequest(url: url)
+            url.appendPathComponent(Self.path)
+
+            var request = URLRequest(url: url)
+            request.httpMethod = Self.method
+            request.httpBody = self.body()
+
+            return request
         }
 
         return nil

--- a/Rocket.Chat/API/APIRequest.swift
+++ b/Rocket.Chat/API/APIRequest.swift
@@ -15,7 +15,7 @@ protocol APIRequest {
     var query: String { get }
 
     func body() -> Data?
-    func request(for api: API) -> URLRequest?
+    func request(for api: API) -> URLRequest
 }
 
 extension APIRequest {
@@ -31,16 +31,13 @@ extension APIRequest {
         return nil
     }
 
-    func request(for api: API) -> URLRequest? {
-        let urlString = "\(api.host)\(Self.path)\(self.query)"
-        if let url = URL(string: urlString) {
-            var request = URLRequest(url: url)
-            request.httpMethod = Self.method
-            request.httpBody = self.body()
+    func request(for api: API) -> URLRequest {
+        let url = api.host.appendingPathComponent("\(Self.path)\(self.query)")
 
-            return request
-        }
+        var request = URLRequest(url: url)
+        request.httpMethod = Self.method
+        request.httpBody = self.body()
 
-        return nil
+        return request
     }
 }

--- a/Rocket.Chat/API/APIRequest.swift
+++ b/Rocket.Chat/API/APIRequest.swift
@@ -11,6 +11,9 @@ import Foundation
 protocol APIRequest {
     static var path: String { get }
     static var method: String { get }
+
+    var query: String { get }
+
     func body() -> Data?
     func request(for api: API) -> URLRequest?
 }
@@ -20,14 +23,17 @@ extension APIRequest {
         return "GET"
     }
 
+    var query: String {
+        return ""
+    }
+
     func body() -> Data? {
         return nil
     }
 
     func request(for api: API) -> URLRequest? {
-        if var url = URL(string: api.host) {
-            url.appendPathComponent(Self.path)
-
+        let urlString = "\(api.host)\(Self.path)\(self.query)"
+        if let url = URL(string: urlString) {
             var request = URLRequest(url: url)
             request.httpMethod = Self.method
             request.httpBody = self.body()

--- a/Rocket.Chat/API/APIRequest.swift
+++ b/Rocket.Chat/API/APIRequest.swift
@@ -1,0 +1,25 @@
+//
+//  APIRequest.swift
+//  Rocket.Chat
+//
+//  Created by Matheus Cardoso on 9/18/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import Foundation
+
+protocol APIRequest {
+    static var path: String { get }
+    static func request(for api: API) -> URLRequest?
+}
+
+extension APIRequest {
+    static func request(for api: API) -> URLRequest? {
+        if var url = URL(string: api.host) {
+            url.appendPathComponent(path)
+            return URLRequest(url: url)
+        }
+
+        return nil
+    }
+}

--- a/Rocket.Chat/API/APIResult.swift
+++ b/Rocket.Chat/API/APIResult.swift
@@ -1,0 +1,17 @@
+//
+//  APIResult.swift
+//  Rocket.Chat
+//
+//  Created by Matheus Cardoso on 9/18/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import Foundation
+import SwiftyJSON
+
+class APIResult<T: APIRequest> {
+    let raw: JSON?
+    init(raw: JSON?) {
+        self.raw = raw
+    }
+}

--- a/Rocket.Chat/API/Requests/ChannelInfoRequest.swift
+++ b/Rocket.Chat/API/Requests/ChannelInfoRequest.swift
@@ -14,7 +14,7 @@ typealias ChannelInfoResult = APIResult<ChannelInfoRequest>
 class ChannelInfoRequest: APIRequest {
     static let path = "/api/v1/channels.info"
 
-    let query: String
+    let query: String?
 
     let roomId: String?
     let roomName: String?
@@ -22,13 +22,13 @@ class ChannelInfoRequest: APIRequest {
     init(roomId: String) {
         self.roomId = roomId
         self.roomName = nil
-        self.query = "?roomId=\(roomId)"
+        self.query = "roomId=\(roomId)"
     }
 
     init(roomName: String) {
         self.roomName = roomName
         self.roomId = nil
-        self.query = "?roomName=\(roomName)"
+        self.query = "roomName=\(roomName)"
     }
 }
 

--- a/Rocket.Chat/API/Requests/ChannelInfoRequest.swift
+++ b/Rocket.Chat/API/Requests/ChannelInfoRequest.swift
@@ -1,0 +1,43 @@
+//
+//  ChannelInfoRequest.swift
+//  Rocket.Chat
+//
+//  Created by Matheus Cardoso on 9/19/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+//  DOCS: https://rocket.chat/docs/developer-guides/rest-api/channels/info
+
+import SwiftyJSON
+
+typealias ChannelInfoResult = APIResult<ChannelInfoRequest>
+
+class ChannelInfoRequest: APIRequest {
+    static let path = "/api/v1/channels.info"
+
+    let query: String
+
+    let roomId: String?
+    let roomName: String?
+
+    init(roomId: String) {
+        self.roomId = roomId
+        self.roomName = nil
+        self.query = "?roomId=\(roomId)"
+    }
+
+    init(roomName: String) {
+        self.roomName = roomName
+        self.roomId = nil
+        self.query = "?roomName=\(roomName)"
+    }
+}
+
+extension APIResult where T == ChannelInfoRequest {
+    var channel: JSON? {
+        return raw?["channel"]
+    }
+
+    var usernames: [String]? {
+        return channel?["usernames"].arrayValue.map { $0.stringValue }
+    }
+}

--- a/Rocket.Chat/API/Requests/InfoRequest.swift
+++ b/Rocket.Chat/API/Requests/InfoRequest.swift
@@ -7,6 +7,8 @@
 //
 //  DOCS: https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/info
 
+import SwiftyJSON
+
 typealias InfoResult = APIResult<InfoRequest>
 
 class InfoRequest: APIRequest {
@@ -14,7 +16,11 @@ class InfoRequest: APIRequest {
 }
 
 extension APIResult where T == InfoRequest {
+    var info: JSON? {
+        return raw?["info"]
+    }
+
     var version: String? {
-        return raw?["info"]["version"].string
+        return info?["version"].string
     }
 }

--- a/Rocket.Chat/API/Requests/InfoRequest.swift
+++ b/Rocket.Chat/API/Requests/InfoRequest.swift
@@ -1,0 +1,19 @@
+//
+//  InfoRequest.swift
+//  Rocket.Chat
+//
+//  Created by Matheus Cardoso on 9/18/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+typealias InfoResult = APIResult<InfoRequest>
+
+class InfoRequest: APIRequest {
+    static let path: String = "/api/v1/info"
+}
+
+extension APIResult where T == InfoRequest {
+    var version: String? {
+        return self.raw?["info"]["version"].string
+    }
+}

--- a/Rocket.Chat/API/Requests/InfoRequest.swift
+++ b/Rocket.Chat/API/Requests/InfoRequest.swift
@@ -5,6 +5,7 @@
 //  Created by Matheus Cardoso on 9/18/17.
 //  Copyright © 2017 Rocket.Chat. All rights reserved.
 //
+//  DOCS: https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/info
 
 typealias InfoResult = APIResult<InfoRequest>
 
@@ -14,6 +15,6 @@ class InfoRequest: APIRequest {
 
 extension APIResult where T == InfoRequest {
     var version: String? {
-        return self.raw?["info"]["version"].string
+        return raw?["info"]["version"].string
     }
 }

--- a/Rocket.Chat/API/Requests/LoginRequest.swift
+++ b/Rocket.Chat/API/Requests/LoginRequest.swift
@@ -2,7 +2,7 @@
 //  LoginRequest.swift
 //  Rocket.Chat
 //
-//  Created by Matheus Martins on 9/19/17.
+//  Created by Matheus Cardoso on 9/19/17.
 //  Copyright © 2017 Rocket.Chat. All rights reserved.
 //
 //  DOCS: https://rocket.chat/docs/developer-guides/rest-api/authentication/login

--- a/Rocket.Chat/API/Requests/LoginRequest.swift
+++ b/Rocket.Chat/API/Requests/LoginRequest.swift
@@ -1,0 +1,47 @@
+//
+//  LoginRequest.swift
+//  Rocket.Chat
+//
+//  Created by Matheus Martins on 9/19/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+//  DOCS: https://rocket.chat/docs/developer-guides/rest-api/authentication/login
+
+import SwiftyJSON
+
+typealias LoginResult = APIResult<LoginRequest>
+
+class LoginRequest: APIRequest {
+    static let method: String = "POST"
+    static let path = "/api/v1/login"
+
+    let username: String
+    let password: String
+
+    init(_ username: String, _ password: String) {
+        self.username = username
+        self.password = password
+    }
+
+    func body() -> Data? {
+        let string = """
+        { "username": "\(username)", "password": "\(password)" }
+        """
+
+        return string.data(using: .utf8)
+    }
+}
+
+extension APIResult where T == LoginRequest {
+    var data: JSON? {
+        return raw?["data"]
+    }
+
+    var authToken: String? {
+        return data?["authToken"].string
+    }
+
+    var userId: String? {
+        return data?["userId"].string
+    }
+}

--- a/Rocket.Chat/API/Requests/UserInfoRequest.swift
+++ b/Rocket.Chat/API/Requests/UserInfoRequest.swift
@@ -1,0 +1,55 @@
+//
+//  UserInfoRequest.swift
+//  Rocket.Chat
+//
+//  Created by Matheus Cardoso on 9/19/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+//  DOCS: https://rocket.chat/docs/developer-guides/rest-api/users/info
+
+import SwiftyJSON
+
+typealias UserInfoResult = APIResult<UserInfoRequest>
+
+class UserInfoRequest: APIRequest {
+    static let path = "/api/v1/users.info"
+
+    let query: String
+
+    let userId: String?
+    let username: String?
+
+    init(userId: String) {
+        self.userId = userId
+        self.username = nil
+        self.query = "?userId=\(userId)"
+    }
+
+    init(username: String) {
+        self.username = username
+        self.userId = nil
+        self.query = "?username=\(username)"
+    }
+}
+
+extension APIResult where T == UserInfoRequest {
+    var user: JSON? {
+        return raw?["user"]
+    }
+
+    var id: String? {
+        return user?["_id"].string
+    }
+
+    var type: String? {
+        return user?["type"].string
+    }
+
+    var name: String? {
+        return user?["name"].string
+    }
+
+    var username: String? {
+        return user?["username"].string
+    }
+}

--- a/Rocket.Chat/API/Requests/UserInfoRequest.swift
+++ b/Rocket.Chat/API/Requests/UserInfoRequest.swift
@@ -14,7 +14,7 @@ typealias UserInfoResult = APIResult<UserInfoRequest>
 class UserInfoRequest: APIRequest {
     static let path = "/api/v1/users.info"
 
-    let query: String
+    let query: String?
 
     let userId: String?
     let username: String?
@@ -22,13 +22,13 @@ class UserInfoRequest: APIRequest {
     init(userId: String) {
         self.userId = userId
         self.username = nil
-        self.query = "?userId=\(userId)"
+        self.query = "userId=\(userId)"
     }
 
     init(username: String) {
         self.username = username
         self.userId = nil
-        self.query = "?username=\(username)"
+        self.query = "username=\(username)"
     }
 }
 

--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -166,7 +166,7 @@ final class ConnectServerViewController: BaseViewController {
     }
 
     func validate(completion: @escaping RequestCompletion) {
-        API.shared.fetch { (result: InfoResult?) -> Void in
+        API.shared.fetch(InfoRequest()) { result in
             guard let version = result?.version else {
                 return completion(nil, true)
             }

--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -121,11 +121,10 @@ final class ConnectServerViewController: BaseViewController {
             text = defaultURL
         }
 
-        API.shared.host = text
-
         guard let url = URL(string: text) else { return alertInvalidURL() }
         guard let socketURL = url.socketURL() else { return alertInvalidURL() }
-        guard let validateURL = url.validateURL() else { return alertInvalidURL() }
+
+        API.shared.host = url
 
         connecting = true
         textFieldServerURL.alpha = 0.5

--- a/Rocket.ChatTests/API/APISpec.swift
+++ b/Rocket.ChatTests/API/APISpec.swift
@@ -1,0 +1,19 @@
+//
+//  APISpec.swift
+//  Rocket.ChatTests
+//
+//  Created by Matheus Cardoso on 9/19/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import XCTest
+import SwiftyJSON
+
+@testable import Rocket_Chat
+
+class APISpec: XCTestCase {
+    func testInit() {
+        XCTAssertNil(API(host: "invalid host"), "API is nil")
+        XCTAssertNotNil(API(host: "http://localhost"), "API is not nil")
+    }
+}

--- a/Rocket.ChatTests/API/Requests/ChannelInfoRequest.swift
+++ b/Rocket.ChatTests/API/Requests/ChannelInfoRequest.swift
@@ -12,17 +12,18 @@ import SwiftyJSON
 @testable import Rocket_Chat
 
 class ChannelInfoRequestSpec: XCTestCase {
-    func testRequestNotNil() {
-        let request1 = ChannelInfoRequest(roomId: "ByehQjC44FwMeiLbX")
-        XCTAssertNotNil(request1.request(for: API.shared), "request is not nil")
-
-        let request2 = ChannelInfoRequest(roomName: "general")
-        XCTAssertNotNil(request2.request(for: API.shared), "request is not nil")
+    func testRequestWithRoomId() {
+        let request = ChannelInfoRequest(roomId: "ByehQjC44FwMeiLbX").request(for: API.shared)
+        let expectedURL = API.shared.host.appendingPathComponent("\(ChannelInfoRequest.path)?roomId=ByehQjC44FwMeiLbX")
+        XCTAssertEqual(request.url, expectedURL, "url is correct")
+        XCTAssertEqual(request.httpMethod, "GET", "http method is correct")
     }
 
-    func testRequestNil() {
-        let request = ChannelInfoRequest(roomId: "ByehQjC44FwMeiLbX")
-        XCTAssertNil(request.request(for: API(host: "malformed host")), "request is nil")
+    func testRequestWithRoomName() {
+        let request = ChannelInfoRequest(roomName: "testing").request(for: API.shared)
+        let expectedURL = API.shared.host.appendingPathComponent("\(ChannelInfoRequest.path)?roomName=testing")
+        XCTAssertEqual(request.url, expectedURL, "url is correct")
+        XCTAssertEqual(request.httpMethod, "GET", "http method is correct")
     }
 
     func testProperties() {

--- a/Rocket.ChatTests/API/Requests/ChannelInfoRequest.swift
+++ b/Rocket.ChatTests/API/Requests/ChannelInfoRequest.swift
@@ -13,16 +13,26 @@ import SwiftyJSON
 
 class ChannelInfoRequestSpec: XCTestCase {
     func testRequestWithRoomId() {
-        let request = ChannelInfoRequest(roomId: "ByehQjC44FwMeiLbX").request(for: API.shared)
-        let expectedURL = API.shared.host.appendingPathComponent("\(ChannelInfoRequest.path)?roomId=ByehQjC44FwMeiLbX")
-        XCTAssertEqual(request.url, expectedURL, "url is correct")
+        guard let request = ChannelInfoRequest(roomId: "ByehQjC44FwMeiLbX").request(for: API.shared) else {
+            return XCTFail("request is not nil")
+        }
+        let url = API.shared.host.appendingPathComponent(ChannelInfoRequest.path)
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        urlComponents?.query = "roomId=ByehQjC44FwMeiLbX"
+
+        XCTAssertEqual(request.url, urlComponents?.url, "url is correct")
         XCTAssertEqual(request.httpMethod, "GET", "http method is correct")
     }
 
     func testRequestWithRoomName() {
-        let request = ChannelInfoRequest(roomName: "testing").request(for: API.shared)
-        let expectedURL = API.shared.host.appendingPathComponent("\(ChannelInfoRequest.path)?roomName=testing")
-        XCTAssertEqual(request.url, expectedURL, "url is correct")
+        guard let request = ChannelInfoRequest(roomName: "testing").request(for: API.shared) else {
+            return XCTFail("request is not nil")
+        }
+        let url = API.shared.host.appendingPathComponent(ChannelInfoRequest.path)
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        urlComponents?.query = "roomName=testing"
+
+        XCTAssertEqual(request.url, urlComponents?.url, "url is correct")
         XCTAssertEqual(request.httpMethod, "GET", "http method is correct")
     }
 

--- a/Rocket.ChatTests/API/Requests/ChannelInfoRequest.swift
+++ b/Rocket.ChatTests/API/Requests/ChannelInfoRequest.swift
@@ -1,0 +1,57 @@
+//
+//  ChannelInfoRequest.swift
+//  Rocket.ChatTests
+//
+//  Created by Matheus Cardoso on 9/19/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import XCTest
+import SwiftyJSON
+
+@testable import Rocket_Chat
+
+class ChannelInfoRequestSpec: XCTestCase {
+    func testRequestNotNil() {
+        let request1 = ChannelInfoRequest(roomId: "ByehQjC44FwMeiLbX")
+        XCTAssertNotNil(request1.request(for: API.shared), "request is not nil")
+
+        let request2 = ChannelInfoRequest(roomName: "general")
+        XCTAssertNotNil(request2.request(for: API.shared), "request is not nil")
+    }
+
+    func testRequestNil() {
+        let request = ChannelInfoRequest(roomId: "ByehQjC44FwMeiLbX")
+        XCTAssertNil(request.request(for: API(host: "malformed host")), "request is nil")
+    }
+
+    func testProperties() {
+        let jsonString = """
+        {
+            "channel": {
+                "_id": "ByehQjC44FwMeiLbX",
+                "ts": "2016-11-30T21:23:04.737Z",
+                "t": "c",
+                "name": "testing",
+                "usernames": [
+                      "testing",
+                      "testing1",
+                      "testing2"
+                ],
+                "msgs": 1,
+                "default": true,
+                "_updatedAt": "2016-12-09T12:50:51.575Z",
+                "lm": "2016-12-09T12:50:51.555Z"
+            },
+            "success": true
+        }
+        """
+
+        let json = JSON(parseJSON: jsonString)
+
+        let result = ChannelInfoResult(raw: json)
+
+        XCTAssertEqual(result.channel, json["channel"])
+        XCTAssertEqual(result.usernames ?? [], ["testing", "testing1", "testing2"])
+    }
+}

--- a/Rocket.ChatTests/API/Requests/InfoRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/InfoRequestSpec.swift
@@ -15,8 +15,8 @@ class InfoRequestSpec: XCTestCase {
     func testRequest() {
         let request1 = InfoRequest().request(for: API.shared)
         let expectedURL = API.shared.host.appendingPathComponent(InfoRequest.path)
-        XCTAssertEqual(request1.url, expectedURL, "url is correct")
-        XCTAssertEqual(request1.httpMethod, "GET", "http method is correct")
+        XCTAssertEqual(request1?.url, expectedURL, "url is correct")
+        XCTAssertEqual(request1?.httpMethod, "GET", "http method is correct")
     }
 
     func testProperties() {

--- a/Rocket.ChatTests/API/Requests/InfoRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/InfoRequestSpec.swift
@@ -22,32 +22,33 @@ class InfoRequestSpec: XCTestCase {
 
     func testProperties() {
         let jsonString = """
-            {
-                "success": true,
-                "info": {
-                    "version": "0.47.0-develop",
-                    "build": {
-                        "nodeVersion": "v4.6.2",
-                        "arch": "x64",
-                        "platform": "linux",
-                        "cpus": 4
-                    },
-                    "commit": {
-                        "hash": "5901cc7270e3587101631ee222def950d705c611",
-                        "date": "Thu Dec 1 19:08:01 2016 -0200",
-                        "author": "Gabriel Engel",
-                        "subject": "Merge branch 'develop' into experimental",
-                        "tag": "0.46.0",
-                        "branch": "experimental"
-                    }
+        {
+            "success": true,
+            "info": {
+                "version": "0.47.0-develop",
+                "build": {
+                    "nodeVersion": "v4.6.2",
+                    "arch": "x64",
+                    "platform": "linux",
+                    "cpus": 4
+                },
+                "commit": {
+                    "hash": "5901cc7270e3587101631ee222def950d705c611",
+                    "date": "Thu Dec 1 19:08:01 2016 -0200",
+                    "author": "Gabriel Engel",
+                    "subject": "Merge branch 'develop' into experimental",
+                    "tag": "0.46.0",
+                    "branch": "experimental"
                 }
             }
+        }
         """
 
         let json = JSON(parseJSON: jsonString)
 
         let result = InfoResult(raw: json)
 
+        XCTAssertEqual(result.info, json["info"])
         XCTAssertEqual(result.version, "0.47.0-develop")
     }
 }

--- a/Rocket.ChatTests/API/Requests/InfoRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/InfoRequestSpec.swift
@@ -13,11 +13,11 @@ import SwiftyJSON
 
 class InfoRequestSpec: XCTestCase {
     func testRequestNotNil() {
-        XCTAssertNotNil(InfoRequest.request(for: API.shared), "request is not nil")
+        XCTAssertNotNil(InfoRequest().request(for: API.shared), "request is not nil")
     }
 
     func testRequestNil() {
-        XCTAssertNil(InfoRequest.request(for: API(host: "malformed host")), "request is nil")
+        XCTAssertNil(InfoRequest().request(for: API(host: "malformed host")), "request is nil")
     }
 
     func testProperties() {

--- a/Rocket.ChatTests/API/Requests/InfoRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/InfoRequestSpec.swift
@@ -1,0 +1,53 @@
+//
+//  InfoRequestSpec.swift
+//  Rocket.ChatTests
+//
+//  Created by Matheus Cardoso on 9/18/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import XCTest
+import SwiftyJSON
+
+@testable import Rocket_Chat
+
+class InfoRequestSpec: XCTestCase {
+    func testRequestNotNil() {
+        XCTAssertNotNil(InfoRequest.request(for: API.shared), "request is not nil")
+    }
+
+    func testRequestNil() {
+        XCTAssertNil(InfoRequest.request(for: API(host: "malformed host")), "request is nil")
+    }
+
+    func testProperties() {
+        let jsonString = """
+            {
+                "success": true,
+                "info": {
+                    "version": "0.47.0-develop",
+                    "build": {
+                        "nodeVersion": "v4.6.2",
+                        "arch": "x64",
+                        "platform": "linux",
+                        "cpus": 4
+                    },
+                    "commit": {
+                        "hash": "5901cc7270e3587101631ee222def950d705c611",
+                        "date": "Thu Dec 1 19:08:01 2016 -0200",
+                        "author": "Gabriel Engel",
+                        "subject": "Merge branch 'develop' into experimental",
+                        "tag": "0.46.0",
+                        "branch": "experimental"
+                    }
+                }
+            }
+        """
+
+        let json = JSON(parseJSON: jsonString)
+
+        let result = InfoResult(raw: json)
+
+        XCTAssertEqual(result.version, "0.47.0-develop")
+    }
+}

--- a/Rocket.ChatTests/API/Requests/InfoRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/InfoRequestSpec.swift
@@ -12,12 +12,11 @@ import SwiftyJSON
 @testable import Rocket_Chat
 
 class InfoRequestSpec: XCTestCase {
-    func testRequestNotNil() {
-        XCTAssertNotNil(InfoRequest().request(for: API.shared), "request is not nil")
-    }
-
-    func testRequestNil() {
-        XCTAssertNil(InfoRequest().request(for: API(host: "malformed host")), "request is nil")
+    func testRequest() {
+        let request1 = InfoRequest().request(for: API.shared)
+        let expectedURL = API.shared.host.appendingPathComponent(InfoRequest.path)
+        XCTAssertEqual(request1.url, expectedURL, "url is correct")
+        XCTAssertEqual(request1.httpMethod, "GET", "http method is correct")
     }
 
     func testProperties() {

--- a/Rocket.ChatTests/API/Requests/LoginRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/LoginRequestSpec.swift
@@ -13,13 +13,16 @@ import SwiftyJSON
 
 class LoginRequestSpec: XCTestCase {
     func testRequest() {
-        let request1 = LoginRequest("testUsername", "testPassword").request(for: API.shared)
+        guard let request = LoginRequest("testUsername", "testPassword").request(for: API.shared) else {
+            return XCTFail("request is not nil")
+        }
+
         let expectedURL = API.shared.host.appendingPathComponent(LoginRequest.path)
 
-        XCTAssertEqual(request1.url, expectedURL, "url is correct")
-        XCTAssertEqual(request1.httpMethod, "POST", "http method is correct")
+        XCTAssertEqual(request.url, expectedURL, "url is correct")
+        XCTAssertEqual(request.httpMethod, "POST", "http method is correct")
 
-        guard let body = request1.httpBody else { return XCTFail("body exists") }
+        guard let body = request.httpBody else { return XCTFail("body exists") }
         guard let json = try? JSON(data: body) else { return XCTFail("body is json") }
 
         let expectedJSON = JSON(parseJSON:

--- a/Rocket.ChatTests/API/Requests/LoginRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/LoginRequestSpec.swift
@@ -1,0 +1,44 @@
+//
+//  LoginRequest.swift
+//  Rocket.ChatTests
+//
+//  Created by Matheus Martins on 9/19/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import XCTest
+import SwiftyJSON
+
+@testable import Rocket_Chat
+
+class LoginRequestSpec: XCTestCase {
+    func testRequestNotNil() {
+        let request = LoginRequest("username", "password")
+        XCTAssertNotNil(request.request(for: API.shared), "request is not nil")
+    }
+
+    func testRequestNil() {
+        let request = LoginRequest("username", "password")
+        XCTAssertNil(request.request(for: API(host: "malformed host")), "request is nil")
+    }
+
+    func testProperties() {
+        let jsonString = """
+            {
+              "status": "success",
+              "data": {
+                  "authToken": "9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq",
+                  "userId": "aobEdbYhXfu5hkeqG"
+               }
+            }
+        """
+
+        let json = JSON(parseJSON: jsonString)
+
+        let result = LoginResult(raw: json)
+
+        XCTAssertEqual(result.data, json["data"])
+        XCTAssertEqual(result.authToken, "9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq")
+        XCTAssertEqual(result.userId, "aobEdbYhXfu5hkeqG")
+    }
+}

--- a/Rocket.ChatTests/API/Requests/LoginRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/LoginRequestSpec.swift
@@ -2,7 +2,7 @@
 //  LoginRequest.swift
 //  Rocket.ChatTests
 //
-//  Created by Matheus Martins on 9/19/17.
+//  Created by Matheus Cardoso on 9/19/17.
 //  Copyright © 2017 Rocket.Chat. All rights reserved.
 //
 
@@ -24,13 +24,13 @@ class LoginRequestSpec: XCTestCase {
 
     func testProperties() {
         let jsonString = """
-            {
-              "status": "success",
-              "data": {
-                  "authToken": "9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq",
-                  "userId": "aobEdbYhXfu5hkeqG"
-               }
+        {
+            "status": "success",
+            "data": {
+                "authToken": "9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq",
+                "userId": "aobEdbYhXfu5hkeqG"
             }
+        }
         """
 
         let json = JSON(parseJSON: jsonString)

--- a/Rocket.ChatTests/API/Requests/LoginRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/LoginRequestSpec.swift
@@ -12,14 +12,23 @@ import SwiftyJSON
 @testable import Rocket_Chat
 
 class LoginRequestSpec: XCTestCase {
-    func testRequestNotNil() {
-        let request = LoginRequest("username", "password")
-        XCTAssertNotNil(request.request(for: API.shared), "request is not nil")
-    }
+    func testRequest() {
+        let request1 = LoginRequest("testUsername", "testPassword").request(for: API.shared)
+        let expectedURL = API.shared.host.appendingPathComponent(LoginRequest.path)
 
-    func testRequestNil() {
-        let request = LoginRequest("username", "password")
-        XCTAssertNil(request.request(for: API(host: "malformed host")), "request is nil")
+        XCTAssertEqual(request1.url, expectedURL, "url is correct")
+        XCTAssertEqual(request1.httpMethod, "POST", "http method is correct")
+
+        guard let body = request1.httpBody else { return XCTFail("body exists") }
+        guard let json = try? JSON(data: body) else { return XCTFail("body is json") }
+
+        let expectedJSON = JSON(parseJSON:
+            """
+            {"username":"testUsername","password":"testPassword"}
+            """
+        )
+
+        XCTAssertEqual(json, expectedJSON, "body is correct")
     }
 
     func testProperties() {

--- a/Rocket.ChatTests/API/Requests/UserInfoRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/UserInfoRequestSpec.swift
@@ -1,0 +1,55 @@
+//
+//  UserInfoRequestSpec.swift
+//  Rocket.ChatTests
+//
+//  Created by Matheus Cardoso on 9/19/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import XCTest
+import SwiftyJSON
+
+@testable import Rocket_Chat
+
+class UserInfoRequestSpec: XCTestCase {
+    func testRequestNotNil() {
+        let request1 = UserInfoRequest(userId: "nSYqWzZ4GsKTX4dyK")
+        XCTAssertNotNil(request1.request(for: API.shared), "request is not nil")
+
+        let request2 = UserInfoRequest(username: "example")
+        XCTAssertNotNil(request2.request(for: API.shared), "request is not nil")
+    }
+
+    func testRequestNil() {
+        let request = UserInfoRequest(userId: "nSYqWzZ4GsKTX4dyK")
+        XCTAssertNil(request.request(for: API(host: "malformed host")), "request is nil")
+    }
+
+    func testProperties() {
+        let jsonString = """
+        {
+            "user": {
+                "_id": "nSYqWzZ4GsKTX4dyK",
+                "type": "user",
+                "status": "offline",
+                "active": true,
+                "name": "Example User",
+                "utcOffset": 0,
+                "username": "example"
+            },
+            "success": true
+        }
+        """
+
+        let json = JSON(parseJSON: jsonString)
+
+        let result = UserInfoResult(raw: json)
+
+        XCTAssertEqual(result.user, json["user"], "user is correct")
+        XCTAssertEqual(result.id, "nSYqWzZ4GsKTX4dyK", "id is correct")
+        XCTAssertEqual(result.type, "user", "type is correct")
+        XCTAssertEqual(result.name, "Example User", "name is correct")
+        XCTAssertEqual(result.username, "example", "username is correct")
+    }
+}
+

--- a/Rocket.ChatTests/API/Requests/UserInfoRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/UserInfoRequestSpec.swift
@@ -12,17 +12,18 @@ import SwiftyJSON
 @testable import Rocket_Chat
 
 class UserInfoRequestSpec: XCTestCase {
-    func testRequestNotNil() {
-        let request1 = UserInfoRequest(userId: "nSYqWzZ4GsKTX4dyK")
-        XCTAssertNotNil(request1.request(for: API.shared), "request is not nil")
-
-        let request2 = UserInfoRequest(username: "example")
-        XCTAssertNotNil(request2.request(for: API.shared), "request is not nil")
+    func testRequestWithUserId() {
+        let request = UserInfoRequest(userId: "nSYqWzZ4GsKTX4dyK").request(for: API.shared)
+        let expectedURL = API.shared.host.appendingPathComponent("\(UserInfoRequest.path)?userId=nSYqWzZ4GsKTX4dyK")
+        XCTAssertEqual(request.url, expectedURL, "url is correct")
+        XCTAssertEqual(request.httpMethod, "GET", "http method is correct")
     }
 
-    func testRequestNil() {
-        let request = UserInfoRequest(userId: "nSYqWzZ4GsKTX4dyK")
-        XCTAssertNil(request.request(for: API(host: "malformed host")), "request is nil")
+    func testRequestWithUsername() {
+        let request = UserInfoRequest(username: "example").request(for: API.shared)
+        let expectedURL = API.shared.host.appendingPathComponent("\(UserInfoRequest.path)?username=example")
+        XCTAssertEqual(request.url, expectedURL, "url is correct")
+        XCTAssertEqual(request.httpMethod, "GET", "http method is correct")
     }
 
     func testProperties() {
@@ -52,4 +53,3 @@ class UserInfoRequestSpec: XCTestCase {
         XCTAssertEqual(result.username, "example", "username is correct")
     }
 }
-

--- a/Rocket.ChatTests/API/Requests/UserInfoRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/UserInfoRequestSpec.swift
@@ -13,16 +13,26 @@ import SwiftyJSON
 
 class UserInfoRequestSpec: XCTestCase {
     func testRequestWithUserId() {
-        let request = UserInfoRequest(userId: "nSYqWzZ4GsKTX4dyK").request(for: API.shared)
-        let expectedURL = API.shared.host.appendingPathComponent("\(UserInfoRequest.path)?userId=nSYqWzZ4GsKTX4dyK")
-        XCTAssertEqual(request.url, expectedURL, "url is correct")
+        guard let request = UserInfoRequest(userId: "nSYqWzZ4GsKTX4dyK").request(for: API.shared) else {
+            return XCTFail("request is not nil")
+        }
+        let url = API.shared.host.appendingPathComponent(UserInfoRequest.path)
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        urlComponents?.query = "userId=nSYqWzZ4GsKTX4dyK"
+
+        XCTAssertEqual(request.url, urlComponents?.url, "url is correct")
         XCTAssertEqual(request.httpMethod, "GET", "http method is correct")
     }
 
     func testRequestWithUsername() {
-        let request = UserInfoRequest(username: "example").request(for: API.shared)
-        let expectedURL = API.shared.host.appendingPathComponent("\(UserInfoRequest.path)?username=example")
-        XCTAssertEqual(request.url, expectedURL, "url is correct")
+        guard let request = UserInfoRequest(username: "example").request(for: API.shared) else {
+            return XCTFail("request is not nil")
+        }
+        let url = API.shared.host.appendingPathComponent(UserInfoRequest.path)
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        urlComponents?.query = "username=example"
+
+        XCTAssertEqual(request.url, urlComponents?.url, "url is correct")
         XCTAssertEqual(request.httpMethod, "GET", "http method is correct")
     }
 


### PR DESCRIPTION
@RocketChat/ios

Implementing wrappers over Rocket.Chat's REST API

The current idea is we specify the kind of resource we want to receive and let generics + type inference take care of the job:

```swift
API.shared.fetch(InfoRequest()) { result in
    guard let version = result.version else {
        print("InfoRequest failed to retrieve Rocket.Chat version")
    }
    print("Rocket.Chat version is \(version)")
}
```

```swift
API.shared.fetch(LoginRequest("username", "password")) { result in
    guard let token = result.authToken else {
        print("Invalid username or password")
    }
    print("Congratulations! Your auth token is: \(token)")
}
```

All we need to do when we want to add a new API is to subclass APIRequest and extend APIResult:

```swift
typealias InfoResult = APIResult<InfoRequest>

class InfoRequest: APIRequest {
    static let path: String = "/api/v1/info"
}

extension APIResult where T == InfoRequest {
    var version: String? {
        return self.raw?["info"]["version"].string
    }
}
```

```swift
typealias LoginResult = APIResult<LoginRequest>

class LoginRequest: APIRequest {
    static let method: String = "POST"
    static let path = "/api/v1/login"

    let username: String
    let password: String

    init(_ username: String, _ password: String) {
        self.username = username
        self.password = password
    }

    func body() -> Data? {
        let string = """
        { "username": "\(username)", "password": "\(password)" }
        """

        return string.data(using: .utf8)
    }
}

extension APIResult where T == LoginRequest {
    var data: JSON? {
        return raw?["data"]
    }

    var authToken: String? {
        return data?["authToken"].string
    }

    var userId: String? {
        return data?["userId"].string
    }
}
```