### PR TITLE
[NEW] Add "user is typing" view when some user is typing

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -50,6 +50,10 @@ final class ChatViewController: SLKTextViewController {
         didSet {
             updateSubscriptionInfo()
             markAsRead()
+
+            if let oldValue = oldValue {
+                unsubscribe(for: oldValue)
+            }
         }
     }
 
@@ -314,6 +318,11 @@ final class ChatViewController: SLKTextViewController {
         SubscriptionManager.markAsRead(subscription) { _ in
             // Nothing, for now
         }
+    }
+
+    internal func unsubscribe(for subscription: Subscription) {
+        SocketManager.unsubscribe(eventName: subscription.rid)
+        SocketManager.unsubscribe(eventName: "\(subscription.rid)/typing")
     }
 
     internal func updateSubscriptionInfo() {

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -312,6 +312,16 @@ final class ChatViewController: SLKTextViewController {
         }
     }
 
+    fileprivate func chatLogIsAtBottom() -> Bool {
+        let currentPosition = Int(collectionView?.contentOffset.y ?? 0)
+
+        let boundsHeight = collectionView?.bounds.size.height ?? 0
+        let sizeHeight = collectionView?.contentSize.height ?? 0
+        let offset = Int(max(sizeHeight - boundsHeight, 0))
+
+        return currentPosition == offset
+    }
+
     // MARK: Subscription
 
     fileprivate func markAsRead() {
@@ -383,10 +393,17 @@ final class ChatViewController: SLKTextViewController {
         SubscriptionManager.subscribeTypingEvent(subscription) { [weak self] username, flag in
             guard let username = username else { return }
 
+            let isAtBottom = self?.chatLogIsAtBottom()
+
             if flag {
                 self?.typingIndicatorView?.insertUsername(username)
             } else {
                 self?.typingIndicatorView?.removeUsername(username)
+            }
+
+            if let isAtBottom = isAtBottom,
+                isAtBottom == true {
+                self?.scrollToBottom(true)
             }
         }
     }

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -266,10 +266,10 @@ final class ChatViewController: SLKTextViewController {
     }
 
     override func textViewDidChange(_ textView: UITextView) {
-        if textView.text.characters.count > 0 {
-            SubscriptionManager.sendTypingStatus(subscription, isTyping: true)
-        } else {
+        if textView.text.isEmpty {
             SubscriptionManager.sendTypingStatus(subscription, isTyping: false)
+        } else {
+            SubscriptionManager.sendTypingStatus(subscription, isTyping: true)
         }
     }
 

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -260,8 +260,15 @@ final class ChatViewController: SLKTextViewController {
         scrollToBottom(true)
     }
 
-    // MARK: Message
+    override func textViewDidChange(_ textView: UITextView) {
+        if textView.text.characters.count > 0 {
+            SubscriptionManager.sendTypingStatus(subscription, isTyping: true)
+        } else {
+            SubscriptionManager.sendTypingStatus(subscription, isTyping: false)
+        }
+    }
 
+    // MARK: Message
     fileprivate func sendMessage() {
         guard let messageText = textView.text, messageText.characters.count > 0 else { return }
 
@@ -286,6 +293,7 @@ final class ChatViewController: SLKTextViewController {
         if let message = message {
             textView.text = ""
             rightButton.isEnabled = true
+            SubscriptionManager.sendTypingStatus(subscription, isTyping: false)
 
             SubscriptionManager.sendTextMessage(message) { response in
                 Realm.executeOnMainThread({ (realm) in

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -357,6 +357,21 @@ final class ChatViewController: SLKTextViewController {
         updateMessagesQueryNotificationBlock()
 
         MessageManager.changes(subscription)
+        typingEvent()
+    }
+
+    fileprivate func typingEvent() {
+        typingIndicatorView?.interval = 0
+
+        SubscriptionManager.subscribeTypingEvent(subscription) { [weak self] username, flag in
+            guard let username = username else { return }
+
+            if flag {
+                self?.typingIndicatorView?.insertUsername(username)
+            } else {
+                self?.typingIndicatorView?.removeUsername(username)
+            }
+        }
     }
 
     fileprivate func updateMessagesQueryNotificationBlock() {

--- a/Rocket.Chat/Managers/Model/MessageManager.swift
+++ b/Rocket.Chat/Managers/Model/MessageManager.swift
@@ -73,6 +73,7 @@ extension MessageManager {
         let request = [
             "msg": "sub",
             "name": "stream-room-messages",
+            "id": eventName,
             "params": [eventName, false]
         ] as [String : Any]
 

--- a/Rocket.Chat/Managers/Model/SubscriptionManager.swift
+++ b/Rocket.Chat/Managers/Model/SubscriptionManager.swift
@@ -164,6 +164,25 @@ struct SubscriptionManager {
         }
     }
 
+    static func subscribeTypingEvent(_ subscription: Subscription, completion: @escaping (String?, Bool) -> Void) {
+        let eventName = "\(subscription.rid)/typing"
+        let request = [
+            "msg": "sub",
+            "name": "stream-notify-room",
+            "params": [eventName, false]
+            ] as [String : Any]
+
+        SocketManager.subscribe(request, eventName: eventName) { response in
+            guard !response.isError() else { return Log.debug(response.result.string) }
+
+            let msg = response.result["fields"]["args"]
+            let userNameTyping = msg[0].string
+            let flag = (msg[1].int ?? 0) > 0
+
+            completion(userNameTyping, flag)
+        }
+    }
+    
     // MARK: Search
 
     static func spotlight(_ text: String, completion: @escaping MessageCompletionObjectsList<Subscription>) {

--- a/Rocket.Chat/Managers/Model/SubscriptionManager.swift
+++ b/Rocket.Chat/Managers/Model/SubscriptionManager.swift
@@ -171,6 +171,7 @@ struct SubscriptionManager {
         let request = [
             "msg": "sub",
             "name": "stream-notify-room",
+            "id": eventName,
             "params": [eventName, false]
         ] as [String : Any]
 


### PR DESCRIPTION
@RocketChat/ios

Closes #251 
Closes #690 

- [x] Show "user is typing"
- [x] When the user typing in iOS, [must send the notify on the room](https://rocket.chat/docs/developer-guides/realtime-api/method-calls/notify-room-stream#typing)
- [x] When user change the channel, don't show "user is typing" of previous channel
