### PR TITLE
[FIX] Fixed some networking (check when the app starts) and scrolling issues

### DIFF
--- a/Rocket.Chat/Controllers/MainViewController.swift
+++ b/Rocket.Chat/Controllers/MainViewController.swift
@@ -37,7 +37,7 @@ final class MainViewController: BaseViewController {
             performSegue(withIdentifier: "Auth", sender: nil)
         }
 
-        if !NetworkManager.shared.isConnected {
+        if !NetworkManager.isConnected {
             openChat()
         }
     }
@@ -55,7 +55,7 @@ final class MainViewController: BaseViewController {
             buttonConnect.isHidden = true
             activityIndicator.startAnimating()
 
-            if NetworkManager.shared.isConnected {
+            if NetworkManager.isConnected {
                 AuthManager.resume(auth, completion: { [weak self] response in
                     guard !response.isError() else {
                         self?.labelAuthenticationStatus.isHidden = false

--- a/Rocket.Chat/Info.plist
+++ b/Rocket.Chat/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>97</string>
+	<string>98</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/Rocket.Chat/Managers/Launcher/NetworkCoordinator.swift
+++ b/Rocket.Chat/Managers/Launcher/NetworkCoordinator.swift
@@ -10,6 +10,6 @@ import Foundation
 
 struct NetworkCoordinator: LauncherProtocol {
     func prepareToLaunch(with options: [UIApplicationLaunchOptionsKey: Any]?) {
-        NetworkManager.shared
+        NetworkManager.shared.start()
     }
 }

--- a/Rocket.Chat/Managers/NetworkManager.swift
+++ b/Rocket.Chat/Managers/NetworkManager.swift
@@ -12,30 +12,18 @@ import ReachabilitySwift
 class NetworkManager {
 
     static let shared = NetworkManager()
-
-    var isConnected = false
     var reachability: Reachability?
 
-    init() {
-        if let reachability = Reachability() {
-            self.reachability = reachability
-
-            reachability.whenReachable = { reachability in
-                self.isConnected = true
-            }
-
-            reachability.whenUnreachable = { reachability in
-                self.isConnected = false
-            }
-
-            do {
-                try reachability.startNotifier()
-            } catch {
-                Log.debug("Unable to start notifier")
-            }
-        } else {
-            Log.debug("Unable to start Reachability()")
+    static var isConnected: Bool {
+        if self.shared.reachability != nil {
+            self.shared.reachability = Reachability()
         }
+
+        return self.shared.reachability?.connection != .none
+    }
+
+    func start() {
+        reachability = Reachability()
     }
 
 }

--- a/Rocket.ChatTests/Managers/NetworkManagerSpec.swift
+++ b/Rocket.ChatTests/Managers/NetworkManagerSpec.swift
@@ -12,7 +12,9 @@ import XCTest
 class NetworkManagerSpec: XCTestCase {
 
     func testReachbilityNotNil() {
-        let manager = NetworkManager()
+        let manager = NetworkManager.shared
+        manager.start()
+
         XCTAssertNotNil(manager.reachability, "reachability is not nil after init")
     }
 


### PR DESCRIPTION
@RocketChat/ios

Closes #692 

# Description

This PR avoids starting the app without knowing the networking state and prevents from adding the same Message twice... since the `append` method is executed in background, we were experiencing this issue in some rare cases.