### PR TITLE
[FIX] Make sure empty user's name returns username instead when setting is enabled

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -1116,7 +1116,7 @@
 					};
 					41DF76F21D2C50720028DBF8 = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = FWD9V5VYJ2;
+						DevelopmentTeam = S6UPZG7ZR3;
 						LastSwiftMigration = 0900;
 						TestTargetID = 41DF76DE1D2C50710028DBF8;
 					};
@@ -1855,7 +1855,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				DEVELOPMENT_TEAM = FWD9V5VYJ2;
+				DEVELOPMENT_TEAM = S6UPZG7ZR3;
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Rocket.ChatTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -1875,7 +1875,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				DEVELOPMENT_TEAM = FWD9V5VYJ2;
+				DEVELOPMENT_TEAM = S6UPZG7ZR3;
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = Rocket.ChatTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;

--- a/Rocket.Chat/Models/User.swift
+++ b/Rocket.Chat/Models/User.swift
@@ -37,7 +37,13 @@ extension User {
             return username ?? ""
         }
 
-        return (settings.useUserRealName ? name : username) ?? ""
+        if let name = name {
+            if settings.useUserRealName && !name.isEmpty {
+                return name
+            }
+        }
+
+        return username ?? ""
     }
 
 }

--- a/Rocket.ChatTests/Models/UserSpec.swift
+++ b/Rocket.ChatTests/Models/UserSpec.swift
@@ -72,4 +72,29 @@ class UserSpec: XCTestCase {
         XCTAssertEqual(user.displayName(), "Full Name", "User.displayName() will return name property")
         XCTAssertNotEqual(user.displayName(), "username", "User.displayName() won't return username property")
     }
+
+    func testUserDisplayNameHonorNameSettingsWhenEmpty() {
+        let settings = AuthSettings()
+        settings.useUserRealName = true
+
+        AuthSettingsManager.shared.internalSettings = settings
+
+        let user = User()
+        user.name = ""
+        user.username = "username"
+
+        XCTAssertEqual(user.displayName(), "username", "User.displayName() will return username property because name is empty")
+    }
+
+    func testUserDisplayNameHonorNameSettingsWhenNil() {
+        let settings = AuthSettings()
+        settings.useUserRealName = true
+
+        AuthSettingsManager.shared.internalSettings = settings
+
+        let user = User()
+        user.username = "username"
+
+        XCTAssertEqual(user.displayName(), "username", "User.displayName() will return username property because name is nil")
+    }
 }


### PR DESCRIPTION
@RocketChat/ios

Closes #668