### PR TITLE
[CHORE] Migrate 'demo.rocket.chat' references to 'open.rocket.chat'

### DIFF
--- a/Rocket.Chat/API/API.swift
+++ b/Rocket.Chat/API/API.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftyJSON
 
 class API {
-    static let shared: API! = API(host: "https://demo.rocket.chat")
+    static let shared: API! = API(host: "https://open.rocket.chat")
 
     var host: URL
     var authToken: String?

--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -12,7 +12,7 @@ import semver
 
 final class ConnectServerViewController: BaseViewController {
 
-    internal let defaultURL = "https://demo.rocket.chat"
+    internal let defaultURL = "https://open.rocket.chat"
     internal var connecting = false
     internal var serverURL: URL!
 

--- a/Rocket.ChatTests/Extensions/NSURLExtensionSpec.swift
+++ b/Rocket.ChatTests/Extensions/NSURLExtensionSpec.swift
@@ -14,9 +14,9 @@ class NSURLExtensionSpec: XCTestCase {
 
     func testSocketURLComponents() {
         let tests = [
-            "http://demo.rocket.chat/",
-            "wss://demo.rocket.chat/",
-            "wss://demo.rocket.chat/websocket",
+            "http://open.rocket.chat/",
+            "wss://open.rocket.chat/",
+            "wss://open.rocket.chat/websocket",
             "ftp://foo.bar.websocket.foo/chat/",
             "http://foo/websocket",
             "http://127.0.0.1/websocket"


### PR DESCRIPTION
@RocketChat/ios

Closes #744

I replaced the 'demo.rocket.chat' occurrences to 'open.rocket.chat'.