### PR TITLE
[FIX] Video receiving wrong extension when uploading

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChatControllerUploader.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerUploader.swift
@@ -68,7 +68,7 @@ extension ChatViewController: UIImagePickerControllerDelegate, UINavigationContr
 
     // MARK: UIImagePickerControllerDelegate
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
-        var filename = "\(String.random()).jpeg"
+        var filename = String.random()
         var file: FileUpload?
         var assetURL: URL?
 
@@ -93,7 +93,7 @@ extension ChatViewController: UIImagePickerControllerDelegate, UINavigationContr
 
             file = UploadHelper.file(
                 for: imageData,
-                name: filename,
+                name: "\(filename).jpeg",
                 mimeType: mimeType ?? "image/jpeg"
             )
         }
@@ -110,8 +110,8 @@ extension ChatViewController: UIImagePickerControllerDelegate, UINavigationContr
 
                 file = UploadHelper.file(
                     for: videoData as Data,
-                    name: filename,
-                    mimeType: UploadHelper.mimeTypeFor(videoURL)
+                    name: "\(filename).mp4",
+                    mimeType: "video/mp4"
                 )
 
                 semaphore.signal()

--- a/Rocket.Chat/Controllers/Chat/ChatControllerUploader.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerUploader.swift
@@ -110,7 +110,7 @@ extension ChatViewController: UIImagePickerControllerDelegate, UINavigationContr
 
                 file = UploadHelper.file(
                     for: videoData as Data,
-                    name: "\(filename).mp4",
+                    name: "\(filename.components(separatedBy: ".").first ?? "video").mp4",
                     mimeType: "video/mp4"
                 )
 

--- a/Rocket.Chat/Managers/Uploader/Helpers/UploadVideoCompression.swift
+++ b/Rocket.Chat/Managers/Uploader/Helpers/UploadVideoCompression.swift
@@ -24,8 +24,8 @@ struct UploadVideoCompression {
         }
 
         guard let newPathURL = URL(string: newPath) else { return completion(nil, true) }
-        guard let assetExport: AVAssetExportSession = AVAssetExportSession(asset: sourceAsset, presetName: AVAssetExportPresetMediumQuality) else { return completion(nil, true) }
-        assetExport.outputFileType = AVFileType.mov
+        guard let assetExport: AVAssetExportSession = AVAssetExportSession(asset: sourceAsset, presetName: AVAssetExportPresetPassthrough) else { return completion(nil, true) }
+        assetExport.outputFileType = AVFileType.mp4
         assetExport.outputURL = newPathURL
         assetExport.exportAsynchronously { () -> Void in
             switch assetExport.status {


### PR DESCRIPTION
@RocketChat/ios

Also changed the encoding to mpeg4, so it's now possible to view the videos in other clients (changing the extension wasn't enough)

Closes #754 