### PR TITLE
[NEW] Support "static" URL into the app

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		15A2FD223558011BFDE03883 /* Pods_Rocket_ChatTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68D870A8D54F5431A14607AE /* Pods_Rocket_ChatTests.framework */; };
 		4101BF011F8D0A1700F67E89 /* AppManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4101BF001F8D0A1700F67E89 /* AppManager.swift */; };
+		4101BF031F8D11FB00F67E89 /* AppManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4101BF021F8D11FB00F67E89 /* AppManagerSpec.swift */; };
 		4102E3AA1E532323004BAA82 /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4102E3A91E532323004BAA82 /* Settings.storyboard */; };
 		4102E3AD1E53273E004BAA82 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4102E3AC1E53273E004BAA82 /* SettingsViewController.swift */; };
 		411119B61F680DB00019854B /* NetworkCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411119B51F680DB00019854B /* NetworkCoordinator.swift */; };
@@ -242,6 +243,7 @@
 		0F5191CD6C53AEA006C82524 /* Pods_Rocket_Chat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rocket_Chat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		35AE3FC690B1D3DC4E9DE715 /* Pods-Rocket.ChatTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rocket.ChatTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Rocket.ChatTests/Pods-Rocket.ChatTests.release.xcconfig"; sourceTree = "<group>"; };
 		4101BF001F8D0A1700F67E89 /* AppManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppManager.swift; path = Managers/AppManager.swift; sourceTree = "<group>"; };
+		4101BF021F8D11FB00F67E89 /* AppManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppManagerSpec.swift; path = Managers/AppManagerSpec.swift; sourceTree = "<group>"; };
 		4102E3A91E532323004BAA82 /* Settings.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Settings.storyboard; path = Storyboards/Settings.storyboard; sourceTree = "<group>"; };
 		4102E3AC1E53273E004BAA82 /* SettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SettingsViewController.swift; path = Controllers/Settings/SettingsViewController.swift; sourceTree = "<group>"; };
 		411119B51F680DB00019854B /* NetworkCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkCoordinator.swift; sourceTree = "<group>"; };
@@ -556,6 +558,7 @@
 			isa = PBXGroup;
 			children = (
 				417A70011D47916C00FF46EE /* Socket */,
+				4101BF021F8D11FB00F67E89 /* AppManagerSpec.swift */,
 				41BA89231D303D8B00CBF526 /* AuthManagerSpec.swift */,
 				411D76E61F39FA7B00B0A8DF /* AuthSettingsManagerSpec.swift */,
 				41DC7A1E1D3865FE00896FC0 /* MessageManagerSpec.swift */,
@@ -1813,6 +1816,7 @@
 				416296FC1F41D42800BCCEDD /* DownloadManagerSpec.swift in Sources */,
 				D1A403D91F6760BC00798EDA /* NSAttributedStringExtensionsSpec.swift in Sources */,
 				416133381D46DB1D00E09DA2 /* BaseModelSpec.swift in Sources */,
+				4101BF031F8D11FB00F67E89 /* AppManagerSpec.swift in Sources */,
 				4161333E1D46E3AB00E09DA2 /* SubscriptionSpec.swift in Sources */,
 				4147CE811F5EE03300C322C3 /* ServerManagerSpec.swift in Sources */,
 				D1411A2C1F6779A200D6EDF7 /* MentionSpec.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		15A2FD223558011BFDE03883 /* Pods_Rocket_ChatTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68D870A8D54F5431A14607AE /* Pods_Rocket_ChatTests.framework */; };
+		4101BF011F8D0A1700F67E89 /* AppManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4101BF001F8D0A1700F67E89 /* AppManager.swift */; };
 		4102E3AA1E532323004BAA82 /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4102E3A91E532323004BAA82 /* Settings.storyboard */; };
 		4102E3AD1E53273E004BAA82 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4102E3AC1E53273E004BAA82 /* SettingsViewController.swift */; };
 		411119B61F680DB00019854B /* NetworkCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411119B51F680DB00019854B /* NetworkCoordinator.swift */; };
@@ -240,6 +241,7 @@
 /* Begin PBXFileReference section */
 		0F5191CD6C53AEA006C82524 /* Pods_Rocket_Chat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rocket_Chat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		35AE3FC690B1D3DC4E9DE715 /* Pods-Rocket.ChatTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rocket.ChatTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Rocket.ChatTests/Pods-Rocket.ChatTests.release.xcconfig"; sourceTree = "<group>"; };
+		4101BF001F8D0A1700F67E89 /* AppManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppManager.swift; path = Managers/AppManager.swift; sourceTree = "<group>"; };
 		4102E3A91E532323004BAA82 /* Settings.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Settings.storyboard; path = Storyboards/Settings.storyboard; sourceTree = "<group>"; };
 		4102E3AC1E53273E004BAA82 /* SettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SettingsViewController.swift; path = Controllers/Settings/SettingsViewController.swift; sourceTree = "<group>"; };
 		411119B51F680DB00019854B /* NetworkCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkCoordinator.swift; sourceTree = "<group>"; };
@@ -710,6 +712,7 @@
 				D32E28201DFD86AC00D6019C /* Launcher */,
 				41F1702C1D425358007E6948 /* Socket */,
 				41552F641D30307D0081438D /* Model */,
+				4101BF001F8D0A1700F67E89 /* AppManager.swift */,
 				D1C536CB1F688B2F00EBA8D9 /* MarkdownManager.swift */,
 				4174CB1B1D2DB2080086DAC8 /* LogManager.swift */,
 				415DC7F51F67F5D30039FB4F /* NetworkManager.swift */,
@@ -1705,6 +1708,7 @@
 				41DAE93C1D318E280098E068 /* SubscriptionManager.swift in Sources */,
 				4102E3AD1E53273E004BAA82 /* SettingsViewController.swift in Sources */,
 				D10E9C1E1F643474007F1796 /* ChannelModelMapping.swift in Sources */,
+				4101BF011F8D0A1700F67E89 /* AppManager.swift in Sources */,
 				414EFF921E54FE69004F001F /* AuthExtensions.swift in Sources */,
 				41EE15821E05BF9600754D45 /* ChatControllerSocketConnectionHandler.swift in Sources */,
 				414A1FFA1D46395400093E10 /* SocketManager.swift in Sources */,

--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -65,6 +65,11 @@ final class ConnectServerViewController: BaseViewController {
 
         SocketManager.sharedInstance.socket?.disconnect()
         DatabaseManager.cleanInvalidDatabases()
+
+        if let applicationServerURL = AppManager.applicationServerURL {
+            textFieldServerURL.text = applicationServerURL.host
+            connect()
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsPageViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsPageViewController.swift
@@ -36,6 +36,7 @@ class SubscriptionsPageViewController: UIPageViewController {
         let pageControl = UIPageControl()
         pageControl.numberOfPages = 2
         pageControl.currentPage = 1
+        pageControl.isHidden = !AppManager.supportsMultiServer
         view.addSubview(pageControl)
 
         pageControl.addTarget(self, action: #selector(SubscriptionsPageViewController.dotTapped(pageControl:)), for: .touchUpInside)
@@ -74,6 +75,7 @@ class SubscriptionsPageViewController: UIPageViewController {
     // MARK: Change controllers externally
 
     func showServersList(animated: Bool = true) {
+        guard AppManager.supportsMultiServer else { return }
         guard let serversController = self.serversController else { return }
         setViewControllers([serversController], direction: .reverse, animated: animated, completion: nil)
         pageControl?.currentPage = 0
@@ -112,6 +114,8 @@ extension SubscriptionsPageViewController: UIPageViewControllerDelegate {
 extension SubscriptionsPageViewController: UIPageViewControllerDataSource {
 
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+        guard AppManager.supportsMultiServer else { return nil }
+
         if viewController == subscriptionsController {
             return serversController
         }
@@ -120,6 +124,8 @@ extension SubscriptionsPageViewController: UIPageViewControllerDataSource {
     }
 
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+        guard AppManager.supportsMultiServer else { return nil }
+
         if viewController == serversController {
             return subscriptionsController
         }

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
@@ -12,6 +12,15 @@ import RealmSwift
 final class SubscriptionsViewController: BaseViewController {
 
     @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var tableViewBottomConstraint: NSLayoutConstraint! {
+        didSet {
+            // Remove the bottom constraint if we don't support multi server
+            if !AppManager.supportsMultiServer {
+                tableViewBottomConstraint.constant = 0
+            }
+        }
+    }
+
     @IBOutlet weak var activityViewSearching: UIActivityIndicatorView!
 
     let defaultButtonCancelSearchWidth = CGFloat(65)

--- a/Rocket.Chat/Managers/AppManager.swift
+++ b/Rocket.Chat/Managers/AppManager.swift
@@ -1,0 +1,39 @@
+//
+//  AppManager.swift
+//  Rocket.Chat
+//
+//  Created by Rafael Kellermann Streit on 10/10/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import Foundation
+
+struct AppManager {
+
+    private static let kApplicationServerURLKey = "SERVER_URL"
+
+    /**
+     The app allows the user to fix a URL and disable the multi-server support
+     by adding the value "SERVER_URL" to the Info.plist file. This will imply
+     in not allowing the user to type a custom server URL when authenticating.
+
+     - returns: The custom URL, if this app has some URL fixed in the settings.
+     */
+    static var applicationServerURL: URL? {
+        if let serverURL = Bundle.main.object(forInfoDictionaryKey: kApplicationServerURLKey) as? String {
+            return URL(string: serverURL)
+        }
+
+        return nil
+    }
+
+    /**
+     The app won't support multi-server if we have a fixed URL into the app.
+
+     - returns: If the server supports multi-server feature.
+     */
+    static var supportsMultiServer: Bool {
+        return applicationServerURL == nil
+    }
+
+}

--- a/Rocket.Chat/Managers/AppManager.swift
+++ b/Rocket.Chat/Managers/AppManager.swift
@@ -10,11 +10,11 @@ import Foundation
 
 struct AppManager {
 
-    private static let kApplicationServerURLKey = "SERVER_URL"
+    private static let kApplicationServerURLKey = "RC_SERVER_URL"
 
     /**
      The app allows the user to fix a URL and disable the multi-server support
-     by adding the value "SERVER_URL" to the Info.plist file. This will imply
+     by adding the value "RC_SERVER_URL" to the Info.plist file. This will imply
      in not allowing the user to type a custom server URL when authenticating.
 
      - returns: The custom URL, if this app has some URL fixed in the settings.

--- a/Rocket.Chat/Storyboards/Subscriptions.storyboard
+++ b/Rocket.Chat/Storyboards/Subscriptions.storyboard
@@ -232,6 +232,7 @@
                         <outlet property="labelServer" destination="2Qq-vp-NoK" id="ddj-Ab-OQx"/>
                         <outlet property="labelUsername" destination="K3h-Vc-Kfo" id="6sl-Ij-9ar"/>
                         <outlet property="tableView" destination="fKk-pZ-N3a" id="A7P-UJ-hQf"/>
+                        <outlet property="tableViewBottomConstraint" destination="PuM-RZ-IR8" id="tml-9g-pWy"/>
                         <outlet property="textFieldSearch" destination="TPV-i5-hsW" id="0ho-Fe-IZ9"/>
                         <outlet property="viewTextField" destination="qEc-o0-IxJ" id="1KL-CT-eAr"/>
                         <outlet property="viewUser" destination="ArO-ez-uRr" id="1qV-E6-iP0"/>

--- a/Rocket.ChatTests/Managers/AppManagerSpec.swift
+++ b/Rocket.ChatTests/Managers/AppManagerSpec.swift
@@ -1,0 +1,24 @@
+//
+//  AppManagerSpec.swift
+//  Rocket.ChatTests
+//
+//  Created by Rafael Kellermann Streit on 10/10/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import XCTest
+import RealmSwift
+
+@testable import Rocket_Chat
+
+class AppManagerSpec: XCTestCase {
+
+    func testMultiServerSupport() {
+        if AppManager.applicationServerURL != nil {
+            XCTAssertFalse(AppManager.supportsMultiServer, "app does not support multi-server with static server")
+        } else {
+            XCTAssertTrue(AppManager.supportsMultiServer, "app supports multi-server with static server")
+        }
+    }
+
+}


### PR DESCRIPTION
@RocketChat/ios

Closes #610 

# Description

This PR allows anyone to have a **static** URL into the app by simply having a new setting **RC_SERVER_URL** into *Info.plist* file of the app. Example:

> **Info.plist**
> RC_SERVER_URL = "https://open.rocket.chat"

It also removes the multi-server feature when the app is complied with a static URL.

## Progress

- [x] Add support to static URL;
- [x] Remove the multi-server support when setting exists;
- [x] Unit tests;