### PR TITLE
[FIX] Alternate link markdown crashes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -20,7 +20,7 @@ def shared_pods
   pod 'SimpleImageViewer', :git => 'https://github.com/cardoso/SimpleImageViewer.git'
 
   # Text Processing
-  pod 'RCMarkdownParser'
+  pod 'RCMarkdownParser', :git => 'https://github.com/RocketChat/RCMarkdownParser.git'
 
   # Database
   pod 'RealmSwift'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
     - GTMSessionFetcher/Core (= 1.1.12)
   - MobilePlayer (1.2.0)
   - OAuthSwift (1.2.0)
-  - RCMarkdownParser (3.0.3)
+  - RCMarkdownParser (3.0.4)
   - ReachabilitySwift (4.1.0)
   - Realm (3.0.0):
     - Realm/Headers (= 3.0.0)
@@ -64,7 +64,7 @@ DEPENDENCIES:
   - Google/SignIn
   - MobilePlayer
   - OAuthSwift
-  - RCMarkdownParser
+  - RCMarkdownParser (from `https://github.com/RocketChat/RCMarkdownParser.git`)
   - ReachabilitySwift
   - RealmSwift
   - SDWebImage (~> 3)
@@ -76,6 +76,8 @@ DEPENDENCIES:
   - SwiftyJSON (from `https://github.com/SwiftyJSON/SwiftyJSON.git`, tag `4.0.0-alpha.1`)
 
 EXTERNAL SOURCES:
+  RCMarkdownParser:
+    :git: https://github.com/RocketChat/RCMarkdownParser.git
   semver:
     :branch: chore/swift4
     :git: https://github.com/rafaelks/Semver.Swift.git
@@ -91,6 +93,9 @@ EXTERNAL SOURCES:
     :tag: 4.0.0-alpha.1
 
 CHECKOUT OPTIONS:
+  RCMarkdownParser:
+    :commit: 8d90207815f563f9e1a1a5b7a0a8fe1c1c94ff34
+    :git: https://github.com/RocketChat/RCMarkdownParser.git
   semver:
     :commit: a8ad3f3c1b168dfa6a8f1f7de2e5cae59239d9bf
     :git: https://github.com/rafaelks/Semver.Swift.git
@@ -121,7 +126,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: ebaa1f79a5366922c1735f1566901f50beba23b7
   MobilePlayer: 069b13482499f14c25b6ce53f63a91e17975b073
   OAuthSwift: 7fd6855b8e4d58eb5a30d156ea9bed7a8aecd1ca
-  RCMarkdownParser: 062a5f014134dffe7cf1b0d0dc34c3abb4b0f203
+  RCMarkdownParser: db98166953cad4d0045d28f627d93330b36eb7ff
   ReachabilitySwift: 6849231cd4e06559f3b9ef4a97a0a0f96d41e09f
   Realm: dec0de73be8c57506e39db72694d513c189493b3
   RealmSwift: 44a7090b16d1b22a406c6bf129bdd602db1bbecc
@@ -133,6 +138,6 @@ SPEC CHECKSUMS:
   Starscream: b512c62f6706421221b5ceb2ba01a9f58aca5bea
   SwiftyJSON: c4d27c2ca659d5c91460cd17cc60fd212b26074d
 
-PODFILE CHECKSUM: d0bff1fbe3b90ec7618c2aae0c3cf6906c0e1900
+PODFILE CHECKSUM: 1979c9a9c7ea139f514c884201a02cebded9258f
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
@RocketChat/ios

You can join #ios_crash_test in open.rocket.chat to test this.

Closes #854 
Closes #816 
