### PR TITLE
[NEW] Save message drafts per chat

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -235,6 +235,7 @@
 		89AEB7F81F7D225D00112A09 /* SubscriptionCreateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89AEB7F71F7D225D00112A09 /* SubscriptionCreateRequest.swift */; };
 		89AFF3C81F94374D00D07A30 /* NewRoomViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89AFF3C71F94374D00D07A30 /* NewRoomViewControllerSpec.swift */; };
 		925FF74E1E8EFB3E00982043 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925FF74D1E8EFB3E00982043 /* SettingsViewModel.swift */; };
+		993E513A1FB1E18D006403D5 /* DraftMessageManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993E51391FB1E18D006403D5 /* DraftMessageManagerSpec.swift */; };
 		99B060CE1FB1225200F471C2 /* DraftMessageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B060CD1FB1225200F471C2 /* DraftMessageManager.swift */; };
 		A0FFC1611E8A9D8D00A1B5EA /* TintedTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0FFC1601E8A9D8D00A1B5EA /* TintedTextField.swift */; };
 		B5893BF41F6C4A5F00365768 /* UserReviewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5893BF31F6C4A5E00365768 /* UserReviewManager.swift */; };
@@ -525,6 +526,7 @@
 		89AEB7F71F7D225D00112A09 /* SubscriptionCreateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionCreateRequest.swift; sourceTree = "<group>"; };
 		89AFF3C71F94374D00D07A30 /* NewRoomViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NewRoomViewControllerSpec.swift; path = Controllers/NewRoomViewControllerSpec.swift; sourceTree = "<group>"; };
 		925FF74D1E8EFB3E00982043 /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
+		993E51391FB1E18D006403D5 /* DraftMessageManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DraftMessageManagerSpec.swift; path = Managers/DraftMessageManagerSpec.swift; sourceTree = "<group>"; };
 		99B060CD1FB1225200F471C2 /* DraftMessageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DraftMessageManager.swift; path = Managers/DraftMessageManager.swift; sourceTree = "<group>"; };
 		A0FFC1601E8A9D8D00A1B5EA /* TintedTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TintedTextField.swift; path = Views/Subscriptions/TintedTextField.swift; sourceTree = "<group>"; };
 		B5893BF31F6C4A5E00365768 /* UserReviewManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserReviewManager.swift; path = Managers/UserReviewManager.swift; sourceTree = "<group>"; };
@@ -659,6 +661,7 @@
 				411119B71F6825C30019854B /* NetworkManagerSpec.swift */,
 				B5893BF51F6C4B1D00365768 /* UserReviewManagerSpec.swift */,
 				808792351FB145B200EFE77F /* PermissionManagerSpec.swift */,
+				993E51391FB1E18D006403D5 /* DraftMessageManagerSpec.swift */,
 			);
 			name = Managers;
 			sourceTree = "<group>";
@@ -827,6 +830,7 @@
 				419ECCA31F3CA21A005F224B /* DownloadManager.swift */,
 				412F8DD81F599EF100AF7786 /* DatabaseManager.swift */,
 				80113DF91F9E086D0048F2C2 /* OAuthManager.swift */,
+				99B060CD1FB1225200F471C2 /* DraftMessageManager.swift */,
 			);
 			name = Managers;
 			sourceTree = "<group>";
@@ -2034,6 +2038,7 @@
 				41DC7A1F1D3865FE00896FC0 /* MessageManagerSpec.swift in Sources */,
 				D1DA25251F695ABF00DB6ABB /* ChatDataControllerSpec.swift in Sources */,
 				41BAE3E91D71C15A00C2445A /* NSURLExtensionSpec.swift in Sources */,
+				993E513A1FB1E18D006403D5 /* DraftMessageManagerSpec.swift in Sources */,
 				416133401D46E6A800E09DA2 /* MessageSpec.swift in Sources */,
 				41ADDD4B1E9E787E0007A458 /* LoaderViewSpec.swift in Sources */,
 				418C74451FA3820F00499577 /* CompoundPickerViewDelegateSpec.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -235,6 +235,7 @@
 		89AEB7F81F7D225D00112A09 /* SubscriptionCreateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89AEB7F71F7D225D00112A09 /* SubscriptionCreateRequest.swift */; };
 		89AFF3C81F94374D00D07A30 /* NewRoomViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89AFF3C71F94374D00D07A30 /* NewRoomViewControllerSpec.swift */; };
 		925FF74E1E8EFB3E00982043 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925FF74D1E8EFB3E00982043 /* SettingsViewModel.swift */; };
+		99B060CE1FB1225200F471C2 /* DraftMessageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B060CD1FB1225200F471C2 /* DraftMessageManager.swift */; };
 		A0FFC1611E8A9D8D00A1B5EA /* TintedTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0FFC1601E8A9D8D00A1B5EA /* TintedTextField.swift */; };
 		B5893BF41F6C4A5F00365768 /* UserReviewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5893BF31F6C4A5E00365768 /* UserReviewManager.swift */; };
 		B5893BF61F6C4B1D00365768 /* UserReviewManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5893BF51F6C4B1D00365768 /* UserReviewManagerSpec.swift */; };
@@ -524,6 +525,7 @@
 		89AEB7F71F7D225D00112A09 /* SubscriptionCreateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionCreateRequest.swift; sourceTree = "<group>"; };
 		89AFF3C71F94374D00D07A30 /* NewRoomViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NewRoomViewControllerSpec.swift; path = Controllers/NewRoomViewControllerSpec.swift; sourceTree = "<group>"; };
 		925FF74D1E8EFB3E00982043 /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
+		99B060CD1FB1225200F471C2 /* DraftMessageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DraftMessageManager.swift; path = Managers/DraftMessageManager.swift; sourceTree = "<group>"; };
 		A0FFC1601E8A9D8D00A1B5EA /* TintedTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TintedTextField.swift; path = Views/Subscriptions/TintedTextField.swift; sourceTree = "<group>"; };
 		B5893BF31F6C4A5E00365768 /* UserReviewManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserReviewManager.swift; path = Managers/UserReviewManager.swift; sourceTree = "<group>"; };
 		B5893BF51F6C4B1D00365768 /* UserReviewManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UserReviewManagerSpec.swift; path = Managers/UserReviewManagerSpec.swift; sourceTree = "<group>"; };
@@ -637,6 +639,7 @@
 				4162E1521D651A8800AAAE49 /* UserManager.swift */,
 				8073719D1F9688B200D53ADF /* LoginServiceManager.swift */,
 				806401341FB09F8A00990572 /* PermissionManager.swift */,
+				99B060CD1FB1225200F471C2 /* DraftMessageManager.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -1909,6 +1912,7 @@
 				800FCD4F1F728EC800D9A692 /* ChannelInfoUserCell.swift in Sources */,
 				800FCD4D1F728EC800D9A692 /* ChannelInfoDescriptionCell.swift in Sources */,
 				41A79C0F1D2F085F00A1968E /* User.swift in Sources */,
+				99B060CE1FB1225200F471C2 /* DraftMessageManager.swift in Sources */,
 				41E2FA071D41513C00238DFD /* ChatViewController.swift in Sources */,
 				4151B45E1E2D32EA00F8AA1B /* MessageURLModelMapping.swift in Sources */,
 				897083D51F8CF08100233561 /* TextFieldTableViewCell.swift in Sources */,

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -94,6 +94,8 @@ final class ChatViewController: SLKTextViewController {
             if let oldValue = oldValue, oldValue.identifier != subscription.identifier {
                 unsubscribe(for: oldValue)
             }
+
+            textView.text = DraftMessageManager.draftMessage(for: subscription)
         }
     }
 
@@ -313,6 +315,7 @@ final class ChatViewController: SLKTextViewController {
     }
 
     override func textViewDidChange(_ textView: UITextView) {
+        DraftMessageManager.update(draftMessage: textView.text, for: subscription)
         if textView.text?.isEmpty ?? true {
             SubscriptionManager.sendTypingStatus(subscription, isTyping: false)
         } else {
@@ -347,6 +350,7 @@ final class ChatViewController: SLKTextViewController {
         })
 
         if let message = message {
+            DraftMessageManager.update(draftMessage: "", for: subscription)
             textView.text = ""
             rightButton.isEnabled = true
             SubscriptionManager.sendTypingStatus(subscription, isTyping: false)

--- a/Rocket.Chat/Managers/DraftMessageManager.swift
+++ b/Rocket.Chat/Managers/DraftMessageManager.swift
@@ -25,7 +25,7 @@ struct DraftMessageManager {
 
     /**
          This method takes a subscription id and returns a more meaningful key
-         for us to persist.
+         than the id only for us to persist.
 
          - parameter identifier: The subscription id to update or retrieve a draft message.
      */
@@ -63,9 +63,9 @@ struct DraftMessageManager {
 
     /**
          This method takes a subscription and returns the current cached draft message
-         that is related to it.
+         that is related to it, if any.
 
-         - parameter subscription: The subscription we that we need the draft message.
+         - parameter subscription: The subscription we that we need to retrieve a draft message.
      */
     static func draftMessage(for subscription: Subscription) -> String {
         guard !selectedServerKey.isEmpty else { return "" }

--- a/Rocket.Chat/Managers/DraftMessageManager.swift
+++ b/Rocket.Chat/Managers/DraftMessageManager.swift
@@ -74,9 +74,9 @@ struct DraftMessageManager {
         if let serverDraftMessages = userDefaults.dictionary(forKey: selectedServerKey),
             let draftMessage = serverDraftMessages[subscriptionKey] as? String {
             return draftMessage
-        } else {
-            return ""
         }
+
+        return ""
     }
 
 }

--- a/Rocket.Chat/Managers/DraftMessageManager.swift
+++ b/Rocket.Chat/Managers/DraftMessageManager.swift
@@ -14,10 +14,7 @@ struct DraftMessageManager {
 
     /**
          This property gets the selected server's URL for us to use it as a identification
-         to store and retrieve its subscriptions's draft messages. If the server URL
-         wind up changing the clients will need to logout and add a new server, since we clear
-         the cache when the user logouts, using the server URL will help us to avoid keeping invalid
-         server draft messages stored.
+         to store and retrieve its subscriptions's draft messages.
      */
     static var selectedServerKey: String {
         return DatabaseManager.servers?[DatabaseManager.selectedIndex][ServerPersistKeys.serverURL] ?? ""

--- a/Rocket.Chat/Managers/DraftMessageManager.swift
+++ b/Rocket.Chat/Managers/DraftMessageManager.swift
@@ -1,0 +1,51 @@
+//
+//  DraftMessageManager.swift
+//  Rocket.Chat
+//
+//  Created by Filipe Alvarenga on 06/11/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import Foundation
+
+struct DraftMessageManager {
+
+    static let userDefaults = UserDefaults.standard
+    static var selectedServerKey: String {
+        return DatabaseManager.servers?[DatabaseManager.selectedIndex][ServerPersistKeys.serverURL] ?? ""
+    }
+
+    static internal func draftMessageKey(for identifier: String) -> String {
+        return String(format: "\(identifier)-cacheddraftmessage")
+    }
+
+    static func clearServerDraftMessages() {
+        guard !selectedServerKey.isEmpty else { return }
+        userDefaults.set(nil, forKey: selectedServerKey)
+    }
+
+    static func update(draftMessage: String, for subscription: Subscription) {
+        guard !selectedServerKey.isEmpty else { return }
+        let subscriptionKey = draftMessageKey(for: subscription.rid)
+
+        if var currentServerDraftMessages = userDefaults.dictionary(forKey: selectedServerKey) {
+            currentServerDraftMessages[subscriptionKey] = draftMessage
+            userDefaults.set(currentServerDraftMessages, forKey: selectedServerKey)
+        } else {
+            userDefaults.set([subscriptionKey: draftMessage], forKey: selectedServerKey)
+        }
+    }
+
+    static func draftMessage(for subscription: Subscription) -> String {
+        guard !selectedServerKey.isEmpty else { return "" }
+        let subscriptionKey = draftMessageKey(for: subscription.rid)
+
+        if let serverDraftMessages = userDefaults.dictionary(forKey: selectedServerKey),
+            let draftMessage = serverDraftMessages[subscriptionKey] as? String {
+            return draftMessage
+        } else {
+            return ""
+        }
+    }
+
+}

--- a/Rocket.Chat/Managers/DraftMessageManager.swift
+++ b/Rocket.Chat/Managers/DraftMessageManager.swift
@@ -11,19 +11,44 @@ import Foundation
 struct DraftMessageManager {
 
     static let userDefaults = UserDefaults.standard
+
+    /**
+         This property gets the selected server's URL for us to use it as a identification
+         to store and retrieve its subscriptions's draft messages. If the server URL
+         wind up changing the clients will need to logout and add a new server, since we clear
+         the cache when the user logouts, using the server URL will help us to avoid keeping invalid
+         server draft messages stored.
+     */
     static var selectedServerKey: String {
         return DatabaseManager.servers?[DatabaseManager.selectedIndex][ServerPersistKeys.serverURL] ?? ""
     }
 
+    /**
+         This method takes a subscription id and returns a more meaningful key
+         for us to persist.
+
+         - parameter identifier: The subscription id to update or retrieve a draft message.
+     */
     static internal func draftMessageKey(for identifier: String) -> String {
         return String(format: "\(identifier)-cacheddraftmessage")
     }
 
+    /**
+         This method clears all the cached draft messages for the selected server if any.
+     */
     static func clearServerDraftMessages() {
         guard !selectedServerKey.isEmpty else { return }
         userDefaults.set(nil, forKey: selectedServerKey)
     }
 
+    /**
+         This method takes a draft message and a subscription so it can update
+         the subscription current draft message then when the user come back to
+         this subscription in the app the draft message will be available for him.
+
+         - parameter draftMessage: The new draft message to update.
+         - parameter subscription: The subscription that is related to the draftMessage.
+     */
     static func update(draftMessage: String, for subscription: Subscription) {
         guard !selectedServerKey.isEmpty else { return }
         let subscriptionKey = draftMessageKey(for: subscription.rid)
@@ -36,6 +61,12 @@ struct DraftMessageManager {
         }
     }
 
+    /**
+         This method takes a subscription and returns the current cached draft message
+         that is related to it.
+
+         - parameter subscription: The subscription we that we need the draft message.
+     */
     static func draftMessage(for subscription: Subscription) -> String {
         guard !selectedServerKey.isEmpty else { return "" }
         let subscriptionKey = draftMessageKey(for: subscription.rid)

--- a/Rocket.Chat/Managers/Model/AuthManager.swift
+++ b/Rocket.Chat/Managers/Model/AuthManager.swift
@@ -363,6 +363,7 @@ extension AuthManager {
         SocketManager.disconnect { (_, _) in
             GIDSignIn.sharedInstance().signOut()
 
+            DraftMessageManager.clearServerDraftMessages()
             DatabaseManager.removerSelectedDatabase()
 
             Realm.executeOnMainThread({ (realm) in

--- a/Rocket.ChatTests/Managers/DraftMessageManagerSpec.swift
+++ b/Rocket.ChatTests/Managers/DraftMessageManagerSpec.swift
@@ -57,7 +57,7 @@ class DraftMessageManagerSpec: XCTestCase {
         UserDefaults.standard.set(nil, forKey: ServerPersistKeys.servers)
         DraftMessageManager.clearServerDraftMessages()
 
-        XCTAssertEqual(UserDefaults.standard.dictionary(forKey: testServerURL) != nil, true, "no server data was cleared when clearing draft messages for a empty server")
+        XCTAssertNotNil(UserDefaults.standard.dictionary(forKey: testServerURL), "no server data was cleared when clearing draft messages for a empty server")
     }
 
     func testClearServerDraftMessages() {
@@ -66,7 +66,7 @@ class DraftMessageManagerSpec: XCTestCase {
         DraftMessageManager.update(draftMessage: draftMessage, for: subscription)
 
         DraftMessageManager.clearServerDraftMessages()
-        XCTAssertEqual(UserDefaults.standard.dictionary(forKey: DraftMessageManager.selectedServerKey) == nil, true, "successfully cleared selected server draft messages")
+        XCTAssertNil(UserDefaults.standard.dictionary(forKey: DraftMessageManager.selectedServerKey), "successfully cleared selected server draft messages")
     }
 
 }

--- a/Rocket.ChatTests/Managers/DraftMessageManagerSpec.swift
+++ b/Rocket.ChatTests/Managers/DraftMessageManagerSpec.swift
@@ -1,0 +1,72 @@
+//
+//  DraftMessageManagerSpec.swift
+//  Rocket.ChatTests
+//
+//  Created by Filipe Alvarenga on 07/11/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import XCTest
+@testable import Rocket_Chat
+
+class DraftMessageManagerSpec: XCTestCase {
+
+    var servers: [[String: String]] = []
+    let testServerURL = "wss://foo.com/websocket"
+    let draftMessage = "Testing draft messages per channel"
+    let subscription: Subscription = {
+        let subscription = Subscription()
+        subscription.rid = "testing-id"
+        return subscription
+    }()
+
+    override func setUp() {
+        super.setUp()
+
+        servers = [[
+            ServerPersistKeys.databaseName: "foo.realm",
+            ServerPersistKeys.serverURL: testServerURL,
+            ServerPersistKeys.token: "1",
+            ServerPersistKeys.userId: "1"
+        ]]
+    }
+
+    func testUpdateDraftMessage() {
+        UserDefaults.standard.set(servers, forKey: ServerPersistKeys.servers)
+        DatabaseManager.selectDatabase(at: 0)
+        DraftMessageManager.update(draftMessage: draftMessage, for: subscription)
+
+        let selectedServerDraftMessages = UserDefaults.standard.dictionary(forKey: DraftMessageManager.selectedServerKey)
+        let expectedSelectedServerDraftMessages: [String: Any] = [String(format: "\(subscription.rid)-cacheddraftmessage"): draftMessage]
+        XCTAssertEqual(selectedServerDraftMessages as NSObject?, expectedSelectedServerDraftMessages as NSObject, "cached draft messages by server data is correct")
+    }
+
+    func testDraftMessageRetrieving() {
+        UserDefaults.standard.set(servers, forKey: ServerPersistKeys.servers)
+        DatabaseManager.selectDatabase(at: 0)
+        DraftMessageManager.update(draftMessage: draftMessage, for: subscription)
+
+        XCTAssertEqual(DraftMessageManager.draftMessage(for: subscription), draftMessage, "draftMessage is correct")
+    }
+
+    func testClearEmptyServerDraftMessages() {
+        UserDefaults.standard.set(servers, forKey: ServerPersistKeys.servers)
+        DatabaseManager.selectDatabase(at: 0)
+        DraftMessageManager.update(draftMessage: draftMessage, for: subscription)
+
+        UserDefaults.standard.set(nil, forKey: ServerPersistKeys.servers)
+        DraftMessageManager.clearServerDraftMessages()
+
+        XCTAssertEqual(UserDefaults.standard.dictionary(forKey: testServerURL) != nil, true, "no server data was cleared when clearing draft messages for a empty server")
+    }
+
+    func testClearServerDraftMessages() {
+        UserDefaults.standard.set(servers, forKey: ServerPersistKeys.servers)
+        DatabaseManager.selectDatabase(at: 0)
+        DraftMessageManager.update(draftMessage: draftMessage, for: subscription)
+
+        DraftMessageManager.clearServerDraftMessages()
+        XCTAssertEqual(UserDefaults.standard.dictionary(forKey: DraftMessageManager.selectedServerKey) == nil, true, "successfully cleared selected server draft messages")
+    }
+
+}


### PR DESCRIPTION
@RocketChat/ios

Closes #859

@rafaelks I've addressed your suggestion to have a new class to handle the caching, take a look at `DraftMessageManager`. I tried to follow the same structure you applied in `MessageTextCacheManager` but with a struct and static functions.

Also I've added a `clearServerDraftMessages` function that runs on logout to avoid keeping data from servers that are not active anymore on the device.

What do you think about this approach?