### PR TITLE
[IMPROVEMENT] Highlight performance

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChatDataController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatDataController.swift
@@ -196,7 +196,10 @@ final class ChatDataController {
     func update(_ message: Message) -> Int {
         for (idx, obj) in data.enumerated()
             where obj.message?.identifier == message.identifier {
-                MessageTextCacheManager.shared.update(for: message)
+                if obj.message?.text != message.text {
+                    MessageTextCacheManager.shared.update(for: message)
+                }
+
                 data[idx].message = message
                 return obj.indexPath.row
         }


### PR DESCRIPTION
@RocketChat/ios

Closes #931 

This solved lots of redundant calls we were having:
```swift
if obj.message?.text != message.text {
        MessageTextCacheManager.shared.update(for: message)
}
```
Sometimes some metadata is updated, but doesn't mean the text is :)
