### PR TITLE
[IMPROVEMENT] Parse markdown and highlights in background thread

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChatDataController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatDataController.swift
@@ -87,6 +87,15 @@ final class ChatDataController {
         }.first
     }
 
+    func indexPathOfMessage(identifier: String) -> IndexPath? {
+        return data.filter { item in
+            guard let messageIdentifier = item.message?.identifier else { return false }
+            return messageIdentifier == identifier
+        }.flatMap { item in
+            item.indexPath
+        }.first
+    }
+
     // swiftlint:disable function_body_length cyclomatic_complexity
     @discardableResult
     func insert(_ items: [ChatData]) -> ([IndexPath], [IndexPath]) {
@@ -193,11 +202,11 @@ final class ChatDataController {
         return (indexPaths, removedIndexPaths)
     }
 
-    func update(_ message: Message) -> Int {
+    func update(_ message: Message, asyncUpdate: (() -> Void)?) -> Int {
         for (idx, obj) in data.enumerated()
             where obj.message?.identifier == message.identifier {
                 if obj.message?.text != message.text {
-                    MessageTextCacheManager.shared.update(for: message)
+                    MessageTextCacheManager.shared.update(for: message, asyncUpdate: asyncUpdate)
                 }
 
                 data[idx].message = message

--- a/Rocket.Chat/Controllers/Chat/ChatDataController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatDataController.swift
@@ -202,11 +202,11 @@ final class ChatDataController {
         return (indexPaths, removedIndexPaths)
     }
 
-    func update(_ message: Message, asyncUpdate: (() -> Void)?) -> Int {
+    func update(_ message: Message, completion: (() -> Void)?) -> Int {
         for (idx, obj) in data.enumerated()
             where obj.message?.identifier == message.identifier {
                 if obj.message?.text != message.text {
-                    MessageTextCacheManager.shared.update(for: message, asyncUpdate: asyncUpdate)
+                    MessageTextCacheManager.shared.update(for: message, completion: completion)
                 }
 
                 data[idx].message = message

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -361,7 +361,7 @@ final class ChatViewController: SLKTextViewController {
                     message.map(response.result["result"], realm: realm)
                     realm.add(message, update: true)
 
-                    MessageTextCacheManager.shared.update(for: message, asyncUpdate: nil)
+                    MessageTextCacheManager.shared.update(for: message, completion: nil)
                 })
             }
         }
@@ -370,7 +370,9 @@ final class ChatViewController: SLKTextViewController {
     fileprivate func updateCellForMessage(identifier: String) {
         guard let indexPath = self.dataController.indexPathOfMessage(identifier: identifier) else { return }
 
-        self.collectionView?.reloadItems(at: [indexPath])
+        UIView.performWithoutAnimation {
+            collectionView?.reloadItems(at: [indexPath])
+        }
     }
 
     fileprivate func chatLogIsAtBottom() -> Bool {
@@ -511,11 +513,9 @@ final class ChatViewController: SLKTextViewController {
 
                                 let message = Message(value: self.messagesQuery[modified])
                                 let identifier = message.identifier
-                                let index = self.dataController.update(message, asyncUpdate: { [weak self] in
+                                let index = self.dataController.update(message, completion: { [weak self] in
                                     guard let identifier = identifier else { return }
-                                    DispatchQueue.main.async {
-                                        self?.updateCellForMessage(identifier: identifier)
-                                    }
+                                    self?.updateCellForMessage(identifier: identifier)
                                 })
                                 if index >= 0 && !indexPathModifications.contains(index) {
                                     indexPathModifications.append(index)

--- a/Rocket.Chat/Extensions/NSAttributedStringExtensions.swift
+++ b/Rocket.Chat/Extensions/NSAttributedStringExtensions.swift
@@ -66,31 +66,44 @@ extension NSMutableAttributedString {
         return MarkdownManager.parser.attributedStringFromAttributedMarkdownString(self)
     }
 
-    func highlightMentions(for message: Message) {
+    func highlightMentions(_ mentions: [String], username: String?) {
         var handledHighlights: [String] = []
 
-        message.mentions.forEach {
-            if let username = $0.username, !handledHighlights.contains(username) {
-                handledHighlights.append(username)
+        mentions.forEach { mention in
+            if !handledHighlights.contains(mention) {
+                handledHighlights.append(mention)
 
-                let ranges = string.ranges(of: "@\(username)")
+                let background: UIColor
+                let font: UIColor
+                if mention == username {
+                    background = .primaryAction
+                    font = .white
+                } else if mention == "all" || mention == "here" {
+                    background = .attention
+                    font = .white
+                } else {
+                    background = .white
+                    font = .link
+                }
+
+                let ranges = string.ranges(of: "@\(mention)")
                 for range in ranges {
                     let range = NSRange(range, in: string)
-                    setBackgroundColor(UIColor.background(for: $0), range: range)
-                    setFontColor(UIColor.font(for: $0), range: range)
+                    setBackgroundColor(background, range: range)
+                    setFontColor(font, range: range)
                 }
             }
         }
     }
 
-    func highlightChannels(for message: Message) {
+    func highlightChannels(_ channels: [String]) {
         var handledHighlights: [String] = []
 
-        message.channels.forEach {
-            if let name = $0.name, !handledHighlights.contains(name) {
-                handledHighlights.append(name)
+        channels.forEach { channel in
+            if !handledHighlights.contains(channel) {
+                handledHighlights.append(channel)
 
-                let ranges = string.ranges(of: "#\(name)")
+                let ranges = string.ranges(of: "#\(channel)")
                 for range in ranges {
                     let range = NSRange(range, in: string)
                     setFontColor(.link, range: range)

--- a/Rocket.Chat/Managers/MessageTextCacheManager.swift
+++ b/Rocket.Chat/Managers/MessageTextCacheManager.swift
@@ -26,7 +26,7 @@ class MessageTextCacheManager {
         cache.removeObject(forKey: cachedKey(for: identifier))
     }
 
-    @discardableResult func update(for message: Message, asyncUpdate: (() -> Void)?) -> NSMutableAttributedString? {
+    @discardableResult func update(for message: Message, completion: (() -> Void)?) -> NSMutableAttributedString? {
         guard let identifier = message.identifier else { return nil }
         let key = cachedKey(for: identifier)
 
@@ -49,7 +49,9 @@ class MessageTextCacheManager {
             finalText.highlightMentions(mentions, username: username)
             finalText.highlightChannels(channels)
             self.cache.setObject(finalText, forKey: key)
-            asyncUpdate?()
+            DispatchQueue.main.async {
+                completion?()
+            }
         }
 
         return text
@@ -63,7 +65,7 @@ class MessageTextCacheManager {
         if let cachedVersion = cache.object(forKey: key) {
             resultText = cachedVersion
         } else {
-            if let result = update(for: message, asyncUpdate: nil) {
+            if let result = update(for: message, completion: nil) {
                 resultText = result
             } else {
                 resultText = NSAttributedString(string: message.text)

--- a/Rocket.Chat/Managers/MessageTextCacheManager.swift
+++ b/Rocket.Chat/Managers/MessageTextCacheManager.swift
@@ -26,9 +26,8 @@ class MessageTextCacheManager {
         cache.removeObject(forKey: cachedKey(for: identifier))
     }
 
-    @discardableResult func update(for message: Message) -> NSMutableAttributedString? {
+    @discardableResult func update(for message: Message, asyncUpdate: (() -> Void)?) -> NSMutableAttributedString? {
         guard let identifier = message.identifier else { return nil }
-        let resultText: NSMutableAttributedString
         let key = cachedKey(for: identifier)
 
         let text = NSMutableAttributedString(string: message.textNormalized())
@@ -41,13 +40,19 @@ class MessageTextCacheManager {
             text.setFontColor(MessageTextFontAttributes.defaultFontColor)
         }
 
-        resultText = NSMutableAttributedString(attributedString: text.transformMarkdown())
-        resultText.trimCharacters(in: .whitespaces)
-        resultText.highlightMentions(for: message)
-        resultText.highlightChannels(for: message)
+        let mentions = Array(message.mentions.flatMap { $0.username })
+        let channels = Array(message.channels.flatMap { $0.name })
+        let username = AuthManager.currentUser()?.username
+        DispatchQueue.global(qos: .background).async {
+            let finalText = NSMutableAttributedString(attributedString: text.transformMarkdown())
+            finalText.trimCharacters(in: .whitespaces)
+            finalText.highlightMentions(mentions, username: username)
+            finalText.highlightChannels(channels)
+            self.cache.setObject(finalText, forKey: key)
+            asyncUpdate?()
+        }
 
-        cache.setObject(resultText, forKey: key)
-        return resultText
+        return text
     }
 
     func message(for message: Message) -> NSMutableAttributedString? {
@@ -58,7 +63,7 @@ class MessageTextCacheManager {
         if let cachedVersion = cache.object(forKey: key) {
             resultText = cachedVersion
         } else {
-            if let result = update(for: message) {
+            if let result = update(for: message, asyncUpdate: nil) {
                 resultText = result
             } else {
                 resultText = NSAttributedString(string: message.text)

--- a/Rocket.ChatTests/Controllers/ChatDataControllerSpec.swift
+++ b/Rocket.ChatTests/Controllers/ChatDataControllerSpec.swift
@@ -48,9 +48,9 @@ class ChatDataControllerSpec: XCTestCase {
 
         controller.insert([obj2, obj1, obj3])
 
-        XCTAssertEqual(controller.indexPathOf(obj1.identifier)?.row, 1, "obj0 found in correct row")
-        XCTAssertEqual(controller.indexPathOf(obj2.identifier)?.row, 2, "obj1 found in correct row")
-        XCTAssertEqual(controller.indexPathOf(obj3.identifier)?.row, 3, "obj2 found in correct row")
+        XCTAssertEqual(controller.indexPathOf(obj1.identifier)?.row, 1, "obj1 found in correct row")
+        XCTAssertEqual(controller.indexPathOf(obj2.identifier)?.row, 2, "obj2 found in correct row")
+        XCTAssertEqual(controller.indexPathOf(obj3.identifier)?.row, 3, "obj3 found in correct row")
     }
 
     func testIndexPathOfMessage() {
@@ -141,7 +141,7 @@ class ChatDataControllerSpec: XCTestCase {
 
         message.text = "Foobar, updated"
 
-        let index = controller.update(message, asyncUpdate: nil)
+        let index = controller.update(message, completion: nil)
         XCTAssertEqual(index, 1, "indexPath is the message indexPath row")
         XCTAssertEqual(controller.data[index].message?.text, "Foobar, updated", "Message text was updated")
     }

--- a/Rocket.ChatTests/Controllers/ChatDataControllerSpec.swift
+++ b/Rocket.ChatTests/Controllers/ChatDataControllerSpec.swift
@@ -34,6 +34,47 @@ class ChatDataControllerSpec: XCTestCase {
         XCTAssertEqual(indexPaths.count, 2, "indexPaths will have two results")
     }
 
+    func testIndexPathOf() {
+        let controller = ChatDataController()
+
+        var obj2 = ChatData(type: .message, timestamp: Date())
+        obj2.timestamp = Date().addingTimeInterval(1.0)
+
+        var obj1 = ChatData(type: .message, timestamp: Date())
+        obj1.timestamp = Date()
+
+        var obj3 = ChatData(type: .message, timestamp: Date())
+        obj3.timestamp = Date().addingTimeInterval(2.0)
+
+        controller.insert([obj2, obj1, obj3])
+
+        XCTAssertEqual(controller.indexPathOf(obj1.identifier)?.row, 1, "obj0 found in correct row")
+        XCTAssertEqual(controller.indexPathOf(obj2.identifier)?.row, 2, "obj1 found in correct row")
+        XCTAssertEqual(controller.indexPathOf(obj3.identifier)?.row, 3, "obj2 found in correct row")
+    }
+
+    func testIndexPathOfMessage() {
+        let controller = ChatDataController()
+
+        let message = Message()
+        let identifier = "message"
+        message.identifier = identifier
+
+        var obj2 = ChatData(type: .message, timestamp: Date())
+        obj2.message = message
+        obj2.timestamp = Date().addingTimeInterval(1.0)
+
+        var obj1 = ChatData(type: .header, timestamp: Date())
+        obj1.timestamp = Date()
+
+        var obj3 = ChatData(type: .daySeparator, timestamp: Date())
+        obj3.timestamp = Date().addingTimeInterval(2.0)
+
+        controller.insert([obj2, obj1, obj3])
+
+        XCTAssertEqual(controller.indexPathOfMessage(identifier: identifier)?.row, 2, "message found in correct row")
+    }
+
     func testInsertMultipleObjects() {
         let controller = ChatDataController()
 
@@ -100,7 +141,7 @@ class ChatDataControllerSpec: XCTestCase {
 
         message.text = "Foobar, updated"
 
-        let index = controller.update(message)
+        let index = controller.update(message, asyncUpdate: nil)
         XCTAssertEqual(index, 1, "indexPath is the message indexPath row")
         XCTAssertEqual(controller.data[index].message?.text, "Foobar, updated", "Message text was updated")
     }

--- a/Rocket.ChatTests/Controllers/ChatDataControllerSpec.swift
+++ b/Rocket.ChatTests/Controllers/ChatDataControllerSpec.swift
@@ -48,6 +48,8 @@ class ChatDataControllerSpec: XCTestCase {
 
         controller.insert([obj2, obj1, obj3])
 
+        // We begin from 1 since a Day Separator is prepended by default
+
         XCTAssertEqual(controller.indexPathOf(obj1.identifier)?.row, 1, "obj1 found in correct row")
         XCTAssertEqual(controller.indexPathOf(obj2.identifier)?.row, 2, "obj2 found in correct row")
         XCTAssertEqual(controller.indexPathOf(obj3.identifier)?.row, 3, "obj3 found in correct row")


### PR DESCRIPTION
@RocketChat/ios

Closes #939

This improves the performance greatly by not hanging the application while the text is being parsed.

I've tested this **A LOT** in a device and in the simulator and it seems to be working fine :)

I had to modify the highlight methods to not access realm models (Message, etc)

Things to test:

* Large markdown and highlighted texts
* Editing messages (on the web)
* Sending messages
* Receiving messages

TODO:
- [x] Unit tests