### PR TITLE
[FIX] Hide Back Button if a Multiserver Support is disabled

### DIFF
--- a/Rocket.Chat/Controllers/Auth/AuthViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthViewController.swift
@@ -66,6 +66,10 @@ final class AuthViewController: BaseViewController {
         if let registrationForm = AuthSettingsManager.shared.settings?.registrationForm {
            buttonRegister.isHidden = registrationForm != .isPublic
         }
+        
+        if !AppManager.supportsMultiServer {
+            self.navigationItem.hidesBackButton = true
+        }
 
         self.updateAuthenticationMethods()
 

--- a/Rocket.Chat/Controllers/Auth/AuthViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthViewController.swift
@@ -66,7 +66,7 @@ final class AuthViewController: BaseViewController {
         if let registrationForm = AuthSettingsManager.shared.settings?.registrationForm {
            buttonRegister.isHidden = registrationForm != .isPublic
         }
-        
+
         if !AppManager.supportsMultiServer {
             self.navigationItem.hidesBackButton = true
         }


### PR DESCRIPTION
@RocketChat/ios
This PR removes the back button in case Multiserver Support is disabled.

Closes #1021