### PR TITLE
[NEW] Allow replying in notification (Quick Reply)

### DIFF
--- a/Rocket.Chat/Managers/PushManager.swift
+++ b/Rocket.Chat/Managers/PushManager.swift
@@ -32,8 +32,8 @@ final class PushManager {
                 "token": ["apn": deviceToken],
                 "appName": Bundle.main.bundleIdentifier ?? "main",
                 "metadata": [:]
-                ]]
-            ] as [String: Any]
+            ]]
+        ] as [String: Any]
 
         SocketManager.send(request)
     }
@@ -44,7 +44,7 @@ final class PushManager {
             "method": "raix:push-setuser",
             "userId": userIdentifier,
             "params": [getOrCreatePushId()]
-            ] as [String: Any]
+        ] as [String: Any]
 
         SocketManager.send(request)
     }
@@ -84,7 +84,7 @@ struct PushNotification {
             let username = json["sender"]?["username"].string,
             let roomType = json["type"]?.string,
             let roomId = json["rid"]?.string
-            else {
+        else {
                 return nil
         }
 
@@ -101,7 +101,7 @@ extension UNNotificationAction {
     static var reply: UNNotificationAction {
         return UNTextInputNotificationAction(
             identifier: "REPLY",
-            title: "Repla",
+            title: "Reply",
             options: .authenticationRequired
         )
     }

--- a/Rocket.Chat/Managers/PushManager.swift
+++ b/Rocket.Chat/Managers/PushManager.swift
@@ -191,4 +191,3 @@ class UserNotificationCenterDelegate: NSObject, UNUserNotificationCenterDelegate
                                        reply: (response as? UNTextInputNotificationResponse)?.userText)
     }
 }
-

--- a/Rocket.Chat/Managers/PushManager.swift
+++ b/Rocket.Chat/Managers/PushManager.swift
@@ -156,8 +156,8 @@ extension PushManager {
 
         // side effect: needed for Subscription.notificationSubscription()
         lastNotificationRoomId = notification.roomId
-        guard let subscription = Subscription.notificationSubscription() else { return false }
 
+        let subscription: Subscription? = .notificationSubscription()
         if index != DatabaseManager.selectedIndex {
             AppManager.changeSelectedServer(index: index)
         } else {
@@ -165,7 +165,7 @@ extension PushManager {
         }
 
         if let reply = reply {
-            let appendage = subscription.type == .directMessage ? "" : " @\(notification.username)"
+            let appendage = notification.roomType == .directMessage ? "" : " @\(notification.username)"
 
             let message = Message()
             message.subscription = subscription

--- a/Rocket.Chat/Managers/PushManager.swift
+++ b/Rocket.Chat/Managers/PushManager.swift
@@ -32,8 +32,8 @@ final class PushManager {
                 "token": ["apn": deviceToken],
                 "appName": Bundle.main.bundleIdentifier ?? "main",
                 "metadata": [:]
-            ]]
-        ] as [String: Any]
+                ]]
+            ] as [String: Any]
 
         SocketManager.send(request)
     }
@@ -44,7 +44,7 @@ final class PushManager {
             "method": "raix:push-setuser",
             "userId": userIdentifier,
             "params": [getOrCreatePushId()]
-        ] as [String: Any]
+            ] as [String: Any]
 
         SocketManager.send(request)
     }
@@ -80,12 +80,44 @@ struct PushNotification {
             let json = JSON(parseJSON: (raw["ejson"] as? String) ?? "").dictionary,
             let host = json["host"]?.string,
             let roomId = json["rid"]?.string
-        else {
-            return nil
+            else {
+                return nil
         }
 
         self.host = host
         self.roomId = roomId
+    }
+}
+
+// MARK: Categories
+
+extension UNNotificationAction {
+    static var reply: UNNotificationAction {
+        return UNTextInputNotificationAction(
+            identifier: "REPLY",
+            title: "Repla",
+            options: .authenticationRequired
+        )
+    }
+}
+
+extension UNNotificationCategory {
+    static var message: UNNotificationCategory {
+        return UNNotificationCategory(
+            identifier: "MESSAGE",
+            actions: [.reply],
+            intentIdentifiers: [],
+            options: []
+        )
+    }
+
+    static var messageNoReply: UNNotificationCategory {
+        return UNNotificationCategory(
+            identifier: "REPLY",
+            actions: [.reply],
+            intentIdentifiers: [],
+            options: []
+        )
     }
 }
 
@@ -94,12 +126,13 @@ extension PushManager {
         let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.delegate = PushManager.delegate
         notificationCenter.requestAuthorization(options: [.alert, .sound, .badge]) { (_, _) in }
+        notificationCenter.setNotificationCategories([.message, .messageNoReply])
     }
 
     @discardableResult
-    static func handleNotification(raw: [AnyHashable: Any]) -> Bool {
+    static func handleNotification(raw: [AnyHashable: Any], reply: String? = nil) -> Bool {
         guard let notification = PushNotification(raw: raw) else { return false }
-        return handleNotification(notification)
+        return handleNotification(notification, reply: reply)
     }
 
     fileprivate static func hostToServerUrl(_ host: String) -> String? {
@@ -107,21 +140,33 @@ extension PushManager {
     }
 
     @discardableResult
-    static func handleNotification(_ notification: PushNotification) -> Bool {
+    static func handleNotification(_ notification: PushNotification, reply: String? = nil) -> Bool {
         guard
             let serverUrl = hostToServerUrl(notification.host),
             let index = DatabaseManager.serverIndexForUrl(serverUrl)
-        else {
-            return false
+            else {
+                return false
         }
 
         // side effect: needed for Subscription.notificationSubscription()
         lastNotificationRoomId = notification.roomId
+        guard let subscription = Subscription.notificationSubscription() else { return false }
 
         if index != DatabaseManager.selectedIndex {
             AppManager.changeSelectedServer(index: index)
         } else {
-            ChatViewController.shared?.subscription = Subscription.notificationSubscription()
+            ChatViewController.shared?.subscription = subscription
+        }
+
+        if let reply = reply {
+            let message = Message()
+            message.subscription = subscription
+            message.text = reply
+
+            let backgroundTask = UIApplication.shared.beginBackgroundTask(expirationHandler: nil)
+            API.shared.fetch(PostMessageRequest(message: message), { _ in
+                UIApplication.shared.endBackgroundTask(backgroundTask)
+            })
         }
 
         return true
@@ -134,6 +179,8 @@ class UserNotificationCenterDelegate: NSObject, UNUserNotificationCenterDelegate
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        PushManager.handleNotification(raw: response.notification.request.content.userInfo)
+        PushManager.handleNotification(raw: response.notification.request.content.userInfo,
+                                       reply: (response as? UNTextInputNotificationResponse)?.userText)
     }
 }
+

--- a/Rocket.Chat/Managers/PushManager.swift
+++ b/Rocket.Chat/Managers/PushManager.swift
@@ -85,7 +85,7 @@ struct PushNotification {
             let roomType = json["type"]?.string,
             let roomId = json["rid"]?.string
         else {
-                return nil
+            return nil
         }
 
         self.host = host
@@ -150,8 +150,8 @@ extension PushManager {
         guard
             let serverUrl = hostToServerUrl(notification.host),
             let index = DatabaseManager.serverIndexForUrl(serverUrl)
-            else {
-                return false
+        else {
+            return false
         }
 
         // side effect: needed for Subscription.notificationSubscription()
@@ -187,7 +187,9 @@ class UserNotificationCenterDelegate: NSObject, UNUserNotificationCenterDelegate
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        PushManager.handleNotification(raw: response.notification.request.content.userInfo,
-                                       reply: (response as? UNTextInputNotificationResponse)?.userText)
+        PushManager.handleNotification(
+            raw: response.notification.request.content.userInfo,
+            reply: (response as? UNTextInputNotificationResponse)?.userText
+        )
     }
 }

--- a/Rocket.ChatTests/Managers/PushManagerSpec.swift
+++ b/Rocket.ChatTests/Managers/PushManagerSpec.swift
@@ -54,10 +54,10 @@ class PushManagerSpec: XCTestCase {
         DatabaseManager.setupTestServers()
 
         XCTAssertFalse(PushManager.handleNotification(raw: PushNotification.testRawInvalid()))
-        XCTAssert(PushManager.handleNotification(raw: PushNotification.testRaw()))
+        XCTAssert(PushManager.handleNotification(raw: PushNotification.testRaw(), reply: "test"))
 
         AppManager.changeSelectedServer(index: 1)
-        XCTAssert(PushManager.handleNotification(raw: PushNotification.testRaw()))
+        XCTAssert(PushManager.handleNotification(raw: PushNotification.testRaw(), reply: "test"))
     }
 }
 


### PR DESCRIPTION
@RocketChat/ios

# Description

This feature allows the user to reply to a message from a notification without having to enter the App. (iOS 10 capability)

Will only work in Rocket.Chat servers with 0.60.0 or above.
Here's an instance for testing: https://unstable.rocket.chat

Closes #831 

## Preview

![](https://i.imgur.com/NVDcBMt.png)

## Progress

- [x] Add reply action to eligible notifications
- [x] Reply using REST API
- [x] Mention user if it's not a DM
- [x] Tests