### PR TITLE
[IMPROVEMENT] Improve mention autocompletion

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -257,6 +257,9 @@
 		80C110891FB62F7B00205BB1 /* OAuthViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C110881FB62F7B00205BB1 /* OAuthViewControllerSpec.swift */; };
 		80CFB5721F8D697100FC9715 /* ReplyView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 80CFB5711F8D697100FC9715 /* ReplyView.xib */; };
 		80CFB5741F8DA55C00FC9715 /* ReplyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CFB5731F8DA55C00FC9715 /* ReplyView.swift */; };
+		80E99F291FD8B2B800B70B59 /* UserExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E99F281FD8B2B800B70B59 /* UserExtensions.swift */; };
+		80E99F2C1FD8B4BA00B70B59 /* APIExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E99F2B1FD8B4BA00B70B59 /* APIExtensionsSpec.swift */; };
+		80E99F2F1FD8B4F400B70B59 /* UserExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E99F2E1FD8B4F400B70B59 /* UserExtensionsSpec.swift */; };
 		890C92C31F7BDF55006144A5 /* NewRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 890C92C21F7BDF55006144A5 /* NewRoomViewController.swift */; };
 		890DA8AE1F942A35007C022B /* SubscriptionCreateRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 890DA8AD1F942A35007C022B /* SubscriptionCreateRequestSpec.swift */; };
 		897083D31F8CF08100233561 /* CheckTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897083CE1F8CF08100233561 /* CheckTableViewCell.swift */; };
@@ -434,7 +437,7 @@
 		41B554C61FBF0F9D000510B7 /* WindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WindowManager.swift; path = Managers/WindowManager.swift; sourceTree = "<group>"; };
 		41BA89231D303D8B00CBF526 /* AuthManagerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthManagerSpec.swift; path = Managers/AuthManagerSpec.swift; sourceTree = "<group>"; };
 		41BAE3E61D71B26C00C2445A /* URLExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLExtension.swift; sourceTree = "<group>"; };
-		41BAE3E81D71C15A00C2445A /* NSURLExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSURLExtensionSpec.swift; path = Extensions/NSURLExtensionSpec.swift; sourceTree = "<group>"; };
+		41BAE3E81D71C15A00C2445A /* NSURLExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLExtensionSpec.swift; sourceTree = "<group>"; };
 		41BD37D81E290D8600CBC4C2 /* ModelMappeable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ModelMappeable.swift; path = Models/Base/ModelMappeable.swift; sourceTree = "<group>"; };
 		41BD37DA1E290D9C00CBC4C2 /* ModelHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ModelHandler.swift; path = Models/Base/ModelHandler.swift; sourceTree = "<group>"; };
 		41BD37DC1E290DDB00CBC4C2 /* BaseModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BaseModel.swift; path = Models/Base/BaseModel.swift; sourceTree = "<group>"; };
@@ -459,8 +462,8 @@
 		41DC7A1A1D38454500896FC0 /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Message.swift; path = Models/Message.swift; sourceTree = "<group>"; };
 		41DC7A1C1D38471700896FC0 /* MessageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MessageManager.swift; path = Managers/Model/MessageManager.swift; sourceTree = "<group>"; };
 		41DC7A1E1D3865FE00896FC0 /* MessageManagerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MessageManagerSpec.swift; path = Managers/MessageManagerSpec.swift; sourceTree = "<group>"; };
-		41DC7A211D386B4700896FC0 /* StringExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringExtensionSpec.swift; path = Extensions/StringExtensionSpec.swift; sourceTree = "<group>"; };
-		41DC7A231D386CA800896FC0 /* DateExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DateExtensionsSpec.swift; path = Extensions/DateExtensionsSpec.swift; sourceTree = "<group>"; };
+		41DC7A211D386B4700896FC0 /* StringExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionSpec.swift; sourceTree = "<group>"; };
+		41DC7A231D386CA800896FC0 /* DateExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateExtensionsSpec.swift; sourceTree = "<group>"; };
 		41DCB8251DDC828200E1197F /* SubscriptionSearchMoreView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SubscriptionSearchMoreView.xib; sourceTree = "<group>"; };
 		41DCB8271DDC82E000E1197F /* SubscriptionSearchMoreView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionSearchMoreView.swift; sourceTree = "<group>"; };
 		41DF76DF1D2C50710028DBF8 /* Rocket.Chat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Rocket.Chat.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -507,7 +510,7 @@
 		77BA814E1F87B2BE00F295F4 /* SignupViewController+CustomFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SignupViewController+CustomFields.swift"; sourceTree = "<group>"; };
 		77BA81501F87C4CB00F295F4 /* TextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextField.swift; sourceTree = "<group>"; };
 		77C261241F97445300724A1F /* AuthSettingsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthSettingsSpec.swift; path = Models/AuthSettingsSpec.swift; sourceTree = "<group>"; };
-		77C261261F97445F00724A1F /* DictionaryExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DictionaryExtensionsSpec.swift; path = Extensions/DictionaryExtensionsSpec.swift; sourceTree = "<group>"; };
+		77C261261F97445F00724A1F /* DictionaryExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsSpec.swift; sourceTree = "<group>"; };
 		77C261291F97453600724A1F /* CustomFieldsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomFieldsSpec.swift; sourceTree = "<group>"; };
 		77C2612A1F97453600724A1F /* SelectFieldSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectFieldSpec.swift; sourceTree = "<group>"; };
 		77C2612B1F97453600724A1F /* TextFieldSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldSpec.swift; sourceTree = "<group>"; };
@@ -584,6 +587,9 @@
 		80C110881FB62F7B00205BB1 /* OAuthViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OAuthViewControllerSpec.swift; path = Controllers/OAuthViewControllerSpec.swift; sourceTree = "<group>"; };
 		80CFB5711F8D697100FC9715 /* ReplyView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReplyView.xib; sourceTree = "<group>"; };
 		80CFB5731F8DA55C00FC9715 /* ReplyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplyView.swift; sourceTree = "<group>"; };
+		80E99F281FD8B2B800B70B59 /* UserExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserExtensions.swift; sourceTree = "<group>"; };
+		80E99F2B1FD8B4BA00B70B59 /* APIExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIExtensionsSpec.swift; sourceTree = "<group>"; };
+		80E99F2E1FD8B4F400B70B59 /* UserExtensionsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserExtensionsSpec.swift; sourceTree = "<group>"; };
 		890C92C21F7BDF55006144A5 /* NewRoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewRoomViewController.swift; sourceTree = "<group>"; };
 		890DA8AD1F942A35007C022B /* SubscriptionCreateRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionCreateRequestSpec.swift; sourceTree = "<group>"; };
 		897083CE1F8CF08100233561 /* CheckTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckTableViewCell.swift; sourceTree = "<group>"; };
@@ -611,7 +617,7 @@
 		D18675E91F70A58B00406FB4 /* InfoRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoRequestSpec.swift; sourceTree = "<group>"; };
 		D18675EB1F716A0D00406FB4 /* LoginRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequest.swift; sourceTree = "<group>"; };
 		D18675ED1F716FBC00406FB4 /* LoginRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequestSpec.swift; sourceTree = "<group>"; };
-		D1A403D81F6760BC00798EDA /* NSAttributedStringExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSAttributedStringExtensionsSpec.swift; path = Extensions/NSAttributedStringExtensionsSpec.swift; sourceTree = "<group>"; };
+		D1A403D81F6760BC00798EDA /* NSAttributedStringExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensionsSpec.swift; sourceTree = "<group>"; };
 		D1C536CB1F688B2F00EBA8D9 /* MarkdownManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MarkdownManager.swift; path = Managers/MarkdownManager.swift; sourceTree = "<group>"; };
 		D1C536CD1F688B7100EBA8D9 /* UIFontExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIFontExtensions.swift; sourceTree = "<group>"; };
 		D1D535EB1F7081FA006625D2 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
@@ -695,6 +701,7 @@
 				414EFF911E54FE69004F001F /* AuthExtensions.swift */,
 				41D7CA861E644E47000F38EA /* MessageExtensions.swift */,
 				D12D34021F69C76400AED992 /* SubscriptionExtensions.swift */,
+				80E99F281FD8B2B800B70B59 /* UserExtensions.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1112,13 +1119,15 @@
 		41DC7A201D386B2C00896FC0 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				80E99F2A1FD8B4AC00B70B59 /* API */,
+				80E99F2D1FD8B4E200B70B59 /* Models */,
 				77C261261F97445F00724A1F /* DictionaryExtensionsSpec.swift */,
 				41DC7A211D386B4700896FC0 /* StringExtensionSpec.swift */,
 				41DC7A231D386CA800896FC0 /* DateExtensionsSpec.swift */,
 				41BAE3E81D71C15A00C2445A /* NSURLExtensionSpec.swift */,
 				D1A403D81F6760BC00798EDA /* NSAttributedStringExtensionsSpec.swift */,
 			);
-			name = Extensions;
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		41DF76D61D2C50710028DBF8 = {
@@ -1417,6 +1426,22 @@
 				806C59A41FBB2F4C00C32D0A /* PostMessageRequestSpec.swift */,
 			);
 			path = Message;
+			sourceTree = "<group>";
+		};
+		80E99F2A1FD8B4AC00B70B59 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				80E99F2B1FD8B4BA00B70B59 /* APIExtensionsSpec.swift */,
+			);
+			path = API;
+			sourceTree = "<group>";
+		};
+		80E99F2D1FD8B4E200B70B59 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				80E99F2E1FD8B4F400B70B59 /* UserExtensionsSpec.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		897083CC1F8CF08100233561 /* Form */ = {
@@ -2102,6 +2127,7 @@
 				D32E28241DFD86C300D6019C /* BugTrackingCoordinator.swift in Sources */,
 				D1D535EC1F7081FA006625D2 /* API.swift in Sources */,
 				41DAE93E1D318F350098E068 /* Subscription.swift in Sources */,
+				80E99F291FD8B2B800B70B59 /* UserExtensions.swift in Sources */,
 				41D4ABAB1F4CD10C00ACDDDD /* ChatCollectionViewFlowLayout.swift in Sources */,
 				4151B4541E2D1A9E00F8AA1B /* SubscriptionModelHandler.swift in Sources */,
 				80113DF81F98330C0048F2C2 /* OAuthViewController.swift in Sources */,
@@ -2241,8 +2267,10 @@
 				D1411A2A1F6777F300D6EDF7 /* ChannelSpec.swift in Sources */,
 				80A63C571F71D2E400FE5AC4 /* APISpec.swift in Sources */,
 				77C2612C1F97453600724A1F /* CustomFieldsSpec.swift in Sources */,
+				80E99F2C1FD8B4BA00B70B59 /* APIExtensionsSpec.swift in Sources */,
 				419D78871FBDCF6C005FC7A2 /* InfoRequestHandlerSpec.swift in Sources */,
 				411498E11FC7A85400D66542 /* ChatTitleViewModelSpec.swift in Sources */,
+				80E99F2F1FD8B4F400B70B59 /* UserExtensionsSpec.swift in Sources */,
 				8013F8431FD02D8F00EE1A4E /* ChatCollectionViewFlowLayoutSpec.swift in Sources */,
 				77C2612D1F97453600724A1F /* SelectFieldSpec.swift in Sources */,
 				807A8F671F9E3D4F00CC78DB /* LoginServiceSpec.swift in Sources */,

--- a/Rocket.Chat/Controllers/Chat/ChatControllerAutocomplete.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerAutocomplete.swift
@@ -10,33 +10,13 @@ import UIKit
 import RealmSwift
 
 extension ChatViewController {
-
-    fileprivate func searchUsers(by word: String, realm: Realm? = Realm.shared, preferenceUsernames: Set<String>) -> [(String, Any)] {
-        guard let realm = realm else { return [] }
-
-        var result = [(String, Any)]()
-
-        let users = (word.count > 0 ? realm.objects(User.self).filter("username CONTAINS[c] %@", word)
-            : realm.objects(User.self)).sorted(by: { user, _ in
-                guard let username = user.username else { return false }
-                return preferenceUsernames.contains(username)
-            })
-
-        (0..<min(5, users.count)).forEach {
-            guard let username = users[$0].username else { return }
-            result.append((username, users[$0]))
-        }
-
-        return result
-    }
-
     override func didChangeAutoCompletionPrefix(_ prefix: String, andWord word: String) {
         guard let realm = Realm.shared else { return }
 
         searchResult = []
 
         if prefix == "@" {
-            searchResult = searchUsers(by: word, preferenceUsernames: dataController.messagesUsernames)
+            searchResult = User.search(usernameContaining: word, preference: dataController.messagesUsernames)
 
             if "here".contains(word) || word.count == 0 {
                 searchResult.append(("here", UIImage(named: "Hashtag") as Any))

--- a/Rocket.Chat/Controllers/Chat/ChatControllerAutocomplete.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerAutocomplete.swift
@@ -16,10 +16,10 @@ extension ChatViewController {
 
         var result = [(String, Any)]()
 
-        let users = (word.count > 0 ? realm.objects(User.self).filter("username BEGINSWITH[c] %@", word)
+        let users = (word.count > 0 ? realm.objects(User.self).filter("username CONTAINS[c] %@", word)
             : realm.objects(User.self)).sorted(by: { user, _ in
                 guard let username = user.username else { return false }
-                return messagesUsernames.contains(username)
+                return preferenceUsernames.contains(username)
             })
 
         (0..<min(5, users.count)).forEach {
@@ -36,7 +36,7 @@ extension ChatViewController {
         searchResult = []
 
         if prefix == "@" {
-            searchResult = searchUsers(by: word, preferenceUsernames: messagesUsernames)
+            searchResult = searchUsers(by: word, preferenceUsernames: dataController.messagesUsernames)
 
             if "here".contains(word) || word.count == 0 {
                 searchResult.append(("here", UIImage(named: "Hashtag") as Any))

--- a/Rocket.Chat/Controllers/Chat/ChatDataController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatDataController.swift
@@ -33,7 +33,13 @@ struct ChatData {
 
 final class ChatDataController {
 
-    var data: [ChatData] = []
+    var messagesUsernames: Set<String> = []
+    var data: [ChatData] = [] {
+        didSet {
+            messagesUsernames.removeAll()
+            messagesUsernames.formUnion(data.flatMap { $0.message?.user?.username })
+        }
+    }
     var loadedAllMessages = false
 
     func clear() -> [IndexPath] {

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -56,7 +56,7 @@ final class ChatViewController: SLKTextViewController, Alerter {
 
     var dataController = ChatDataController()
 
-    var searchResult: [String: Any] = [:]
+    var searchResult: [(String, Any)] = []
 
     var closeSidebarAfterSubscriptionUpdate = false
 
@@ -68,9 +68,15 @@ final class ChatViewController: SLKTextViewController, Alerter {
     let socketHandlerToken = String.random(5)
     var messagesToken: NotificationToken!
     var messagesQuery: Results<Message>!
-    var messages: [Message] = []
+    var messages: [Message] = [] {
+        didSet {
+            messagesUsernames.formUnion(messages.map { $0.user?.username }.flatMap { $0 })
+        }
+    }
+    var messagesUsernames: Set<String> = []
     var subscription: Subscription? {
         didSet {
+            messagesUsernames.removeAll()
             subscriptionToken?.invalidate()
 
             guard

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -68,15 +68,10 @@ final class ChatViewController: SLKTextViewController, Alerter {
     let socketHandlerToken = String.random(5)
     var messagesToken: NotificationToken!
     var messagesQuery: Results<Message>!
-    var messages: [Message] = [] {
-        didSet {
-            messagesUsernames.formUnion(messages.map { $0.user?.username }.flatMap { $0 })
-        }
-    }
-    var messagesUsernames: Set<String> = []
+    var messages: [Message] = []
+
     var subscription: Subscription? {
         didSet {
-            messagesUsernames.removeAll()
             subscriptionToken?.invalidate()
 
             guard

--- a/Rocket.Chat/Extensions/Models/UserExtensions.swift
+++ b/Rocket.Chat/Extensions/Models/UserExtensions.swift
@@ -1,0 +1,30 @@
+//
+//  UserExtensions.swift
+//  Rocket.Chat
+//
+//  Created by Matheus Cardoso on 12/6/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import RealmSwift
+
+extension User {
+    static func search(usernameContaining word: String, preference: Set<String> = [], limit: Int = 5, realm: Realm? = Realm.shared) -> [(String, Any)] {
+        guard let realm = realm else { return [] }
+
+        var result = [(String, Any)]()
+
+        let users = (word.count > 0 ? realm.objects(User.self).filter("username CONTAINS[c] %@", word)
+            : realm.objects(User.self)).sorted(by: { user, _ in
+                guard let username = user.username else { return false }
+                return preference.contains(username)
+            })
+
+        (0..<min(limit, users.count)).forEach {
+            guard let username = users[$0].username else { return }
+            result.append((username, users[$0]))
+        }
+
+        return result
+    }
+}

--- a/Rocket.ChatTests/Extensions/Models/UserExtensionsSpec.swift
+++ b/Rocket.ChatTests/Extensions/Models/UserExtensionsSpec.swift
@@ -1,0 +1,46 @@
+//
+//  UserExtensionsSpec.swift
+//  Rocket.ChatTests
+//
+//  Created by Matheus Cardoso on 12/6/17.
+//  Copyright © 2017 Rocket.Chat. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+@testable import Rocket_Chat
+
+class UserExtensionsSpec: XCTestCase, RealmTestCase {
+    func testSearchUsernameContaining() {
+        let realm = testRealm()
+
+        (0..<10).forEach {
+            let user = User.testInstance()
+            user.identifier = "test_\($0)"
+            user.username = user.identifier
+            try? realm.write {
+                realm.add(user)
+            }
+        }
+
+        (0..<3).forEach {
+            let user = User.testInstance()
+            user.identifier = "testpreference_\($0)"
+            user.username = user.identifier
+            try? realm.write {
+                realm.add(user)
+            }
+        }
+
+        var users = User.search(usernameContaining: "test_", preference: [], limit: 5, realm: realm)
+        XCTAssert(users.count == 5)
+
+        users = User.search(usernameContaining: "test_", preference: [], limit: 20, realm: realm)
+        XCTAssert(users.count == 10)
+
+        users = User.search(usernameContaining: "_", preference: ["testpreference_1", "testpreference_2"], limit: 2, realm: realm)
+        XCTAssert(users.contains(where: { $0.0 == "testpreference_1" }))
+        XCTAssert(users.contains(where: { $0.0 == "testpreference_2" }))
+    }
+}


### PR DESCRIPTION
@RocketChat/ios

Now it's very close to what the web version does.

- Begin with only a '@' and limit results to 5 + here and all at the end.
- Latest message senders appear first
- Filter username by contains and not begins with

Closes #176

TODO:
- [x] Tests