### PR TITLE
[FIX] Some dates showing as UTC

### DIFF
--- a/Rocket.Chat/Extensions/DateExtension.swift
+++ b/Rocket.Chat/Extensions/DateExtension.swift
@@ -14,7 +14,7 @@ extension Date {
         return Date(timeIntervalSince1970: interval / 1000)
     }
 
-    public static func dateFromString(_ string: String, format: String = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") -> Date? {
+    public static func dateFromString(_ string: String, format: String = "yyyy-MM-dd'T'HH:mm:ss.SSSZ") -> Date? {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = format
         return dateFormatter.date(from: string)

--- a/Rocket.ChatTests/API/Clients/CommandsClientSpec.swift
+++ b/Rocket.ChatTests/API/Clients/CommandsClientSpec.swift
@@ -38,7 +38,7 @@ class CommandsClientSpec: XCTestCase, RealmTestCase {
                 expectation.fulfill()
             }
         })
-        wait(for: [expectation], timeout: 1.1)
+        wait(for: [expectation], timeout: 1.2)
     }
 
     func testRunCommand() {


### PR DESCRIPTION
@RocketChat/ios

Just a formatting problem.

Fixes every message that comes from REST API:
Pinned and starred messages, sent messages in 0.60.0

Closes #1059 
