### PR TITLE
[CHORE] Improve the performance of the app, reducing calls on main-thread and the number of reutilization of the cells

### DIFF
--- a/Rocket.Chat/API/Clients/MessagesClient.swift
+++ b/Rocket.Chat/API/Clients/MessagesClient.swift
@@ -15,7 +15,7 @@ struct MessagesClient: APIClient {
     func sendMessage(text: String, subscription: Subscription, id: String = String.random(18), user: User? = AuthManager.currentUser(), realm: Realm? = Realm.shared) {
         let message = Message()
         message.internalType = ""
-        message.updatedAt = Date.serverDate
+        message.updatedAt = Date.serverDate.addingTimeInterval(-1000)
         message.createdAt = Date.serverDate
         message.text = text
         message.subscription = subscription

--- a/Rocket.Chat/API/Clients/MessagesClient.swift
+++ b/Rocket.Chat/API/Clients/MessagesClient.swift
@@ -15,6 +15,7 @@ struct MessagesClient: APIClient {
     func sendMessage(text: String, subscription: Subscription, id: String = String.random(18), user: User? = AuthManager.currentUser(), realm: Realm? = Realm.shared) {
         let message = Message()
         message.internalType = ""
+        message.updatedAt = Date.serverDate
         message.createdAt = Date.serverDate
         message.text = text
         message.subscription = subscription

--- a/Rocket.Chat/API/Clients/MessagesClient.swift
+++ b/Rocket.Chat/API/Clients/MessagesClient.swift
@@ -34,7 +34,7 @@ struct MessagesClient: APIClient {
                     realm?.add(message, update: true)
                 }
 
-                MessageTextCacheManager.shared.update(for: message, completion: nil)
+                MessageTextCacheManager.shared.update(for: message)
             }
         }
 

--- a/Rocket.Chat/Controllers/Chat/ChatDataController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatDataController.swift
@@ -203,11 +203,15 @@ final class ChatDataController {
         return (indexPaths, removedIndexPaths)
     }
 
-    func update(_ message: Message, completion: (() -> Void)?) -> Int {
+    func update(_ message: Message) -> Int {
         for (idx, obj) in data.enumerated()
             where obj.message?.identifier == message.identifier {
+                if obj.message?.updatedAt?.timeIntervalSince1970 == message.updatedAt?.timeIntervalSince1970 {
+                    return -1
+                }
+
                 if obj.message?.text != message.text {
-                    MessageTextCacheManager.shared.update(for: message, completion: completion)
+                    MessageTextCacheManager.shared.update(for: message)
                 }
 
                 data[idx].message = message

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -949,7 +949,7 @@ extension ChatViewController: ChatPreviewModeViewProtocol {
         guard let auth = AuthManager.isAuthenticated() else { return }
         guard let subscription = self.subscription else { return }
 
-        Realm.executeOnMainThread({ _ in
+        Realm.execute({ _ in
             subscription.auth = auth
         })
 

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -535,32 +535,25 @@ final class ChatViewController: SLKTextViewController, Alerter {
                 })
             }
 
-            if modifications.count == 0 {
-                return
-            }
-
             if modifications.count > 0 {
-                DispatchQueue.main.async {
-                    let isAtBottom = self.chatLogIsAtBottom()
+                let isAtBottom = self.chatLogIsAtBottom()
 
+                var indexPathModifications: [Int] = []
+
+                for modified in modifications {
+                    guard modified < self.messagesQuery.count else { continue }
+
+                    let message = Message(value: self.messagesQuery[modified])
+                    let index = self.dataController.update(message)
+
+                    if index >= 0 && !indexPathModifications.contains(index) {
+                        indexPathModifications.append(index)
+                    }
+                }
+
+                if indexPathModifications.count > 0 {
                     UIView.performWithoutAnimation {
                         self.collectionView?.performBatchUpdates({
-                            var indexPathModifications: [Int] = []
-
-                            for modified in modifications {
-                                guard modified < self.messagesQuery.count else { continue }
-
-                                let message = Message(value: self.messagesQuery[modified])
-                                let identifier = message.identifier
-                                let index = self.dataController.update(message, completion: { [weak self] in
-                                    guard let identifier = identifier else { return }
-                                    self?.updateCellForMessage(identifier: identifier)
-                                })
-                                if index >= 0 && !indexPathModifications.contains(index) {
-                                    indexPathModifications.append(index)
-                                }
-                            }
-
                             self.collectionView?.reloadItems(at: indexPathModifications.map { IndexPath(row: $0, section: 0) })
                         }, completion: { _ in
                             if isAtBottom {

--- a/Rocket.Chat/Helpers/ChatCollectionViewFlowLayout.swift
+++ b/Rocket.Chat/Helpers/ChatCollectionViewFlowLayout.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 class ChatCollectionViewFlowLayout: UICollectionViewFlowLayout {
+
     var heightOfInsertedItems: CGFloat = 0.0
 
     override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint {
@@ -43,4 +44,5 @@ class ChatCollectionViewFlowLayout: UICollectionViewFlowLayout {
     override func finalizeCollectionViewUpdates() {
         CATransaction.commit()
     }
+
 }

--- a/Rocket.Chat/Info.plist
+++ b/Rocket.Chat/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>128</string>
+	<string>129</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/Rocket.Chat/Info.plist
+++ b/Rocket.Chat/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>127</string>
+	<string>128</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/Rocket.Chat/Managers/MessageTextCacheManager.swift
+++ b/Rocket.Chat/Managers/MessageTextCacheManager.swift
@@ -26,7 +26,7 @@ class MessageTextCacheManager {
         cache.removeObject(forKey: cachedKey(for: identifier))
     }
 
-    @discardableResult func update(for message: Message, completion: (() -> Void)?) -> NSMutableAttributedString? {
+    @discardableResult func update(for message: Message) -> NSMutableAttributedString? {
         guard let identifier = message.identifier else { return nil }
         let key = cachedKey(for: identifier)
 
@@ -44,18 +44,14 @@ class MessageTextCacheManager {
         let mentions = Array(message.mentions.flatMap { $0.username })
         let channels = Array(message.channels.flatMap { $0.name })
         let username = AuthManager.currentUser()?.username
-        DispatchQueue.global(qos: .background).async {
-            let finalText = NSMutableAttributedString(attributedString: text.transformMarkdown())
-            finalText.trimCharacters(in: .whitespaces)
-            finalText.highlightMentions(mentions, username: username)
-            finalText.highlightChannels(channels)
-            self.cache.setObject(finalText, forKey: key)
-            DispatchQueue.main.async {
-                completion?()
-            }
-        }
 
-        return text
+        let finalText = NSMutableAttributedString(attributedString: text.transformMarkdown())
+        finalText.trimCharacters(in: .whitespaces)
+        finalText.highlightMentions(mentions, username: username)
+        finalText.highlightChannels(channels)
+        self.cache.setObject(finalText, forKey: key)
+
+        return finalText
     }
 
     func message(for message: Message) -> NSMutableAttributedString? {
@@ -66,7 +62,7 @@ class MessageTextCacheManager {
         if let cachedVersion = cache.object(forKey: key) {
             resultText = cachedVersion
         } else {
-            if let result = update(for: message, completion: nil) {
+            if let result = update(for: message) {
                 resultText = result
             } else {
                 resultText = NSAttributedString(string: message.text)

--- a/Rocket.Chat/Managers/Model/AuthSettingsManager.swift
+++ b/Rocket.Chat/Managers/Model/AuthSettingsManager.swift
@@ -38,7 +38,7 @@ final class AuthSettingsManager {
                 return
             }
 
-            Realm.executeOnMainThread({ realm in
+            Realm.execute({ realm in
                 let settings = AuthManager.isAuthenticated()?.settings ?? AuthSettings()
                 settings.map(response.result["result"], realm: realm)
                 realm.add(settings, update: true)

--- a/Rocket.Chat/Managers/Model/MessageManager.swift
+++ b/Rocket.Chat/Managers/Model/MessageManager.swift
@@ -54,6 +54,15 @@ extension MessageManager {
                 guard let detachedSubscription = realm.object(ofType: Subscription.self, forPrimaryKey: subscriptionIdentifier ?? "") else { return }
 
                 list?.forEach { object in
+                    let mockNewMessage = Message()
+                    mockNewMessage.map(object, realm: realm)
+
+                    if let existingMessage = realm.object(ofType: Message.self, forPrimaryKey: object["identifier"].stringValue) {
+                        if existingMessage.updatedAt?.timeIntervalSince1970 == mockNewMessage.updatedAt?.timeIntervalSince1970 {
+                            return
+                        }
+                    }
+                    
                     let message = Message.getOrCreate(realm: realm, values: object, updates: { (object) in
                         object?.subscription = detachedSubscription
                     })

--- a/Rocket.Chat/Managers/Model/MessageManager.swift
+++ b/Rocket.Chat/Managers/Model/MessageManager.swift
@@ -62,7 +62,7 @@ extension MessageManager {
                             return
                         }
                     }
-                    
+
                     let message = Message.getOrCreate(realm: realm, values: object, updates: { (object) in
                         object?.subscription = detachedSubscription
                     })

--- a/Rocket.Chat/Managers/Model/SubscriptionManager.swift
+++ b/Rocket.Chat/Managers/Model/SubscriptionManager.swift
@@ -282,7 +282,7 @@ extension SubscriptionManager {
             }, completion: {
                 var detachedSubscriptions = [Subscription]()
 
-                Realm.executeOnMainThread({ (realm) in
+                Realm.execute({ (realm) in
                     for identifier in identifiers {
                         if let subscription = realm.object(ofType: Subscription.self, forPrimaryKey: identifier) {
                             detachedSubscriptions.append(subscription)

--- a/Rocket.Chat/Models/Base/ModelMappeable.swift
+++ b/Rocket.Chat/Models/Base/ModelMappeable.swift
@@ -18,6 +18,7 @@ protocol ModelMappeable {
 }
 
 extension ModelMappeable where Self: BaseModel {
+
     static func getOrCreate(realm: Realm, values: JSON, updates: UpdateBlock<Self>?) -> Self {
         var object: Self!
 
@@ -35,4 +36,5 @@ extension ModelMappeable where Self: BaseModel {
         updates?(object)
         return object
     }
+
 }

--- a/Rocket.Chat/Models/Subscription.swift
+++ b/Rocket.Chat/Models/Subscription.swift
@@ -92,7 +92,7 @@ extension Subscription {
                 guard !response.isError() else { return }
 
                 let result = response.result["result"]
-                Realm.executeOnMainThread({ realm in
+                Realm.execute({ realm in
                     if let obj = self {
                         obj.update(result, realm: realm)
                         realm.add(obj, update: true)
@@ -107,7 +107,7 @@ extension Subscription {
                 guard !response.isError() else { return }
 
                 let rid = response.result["result"]["rid"].stringValue
-                Realm.executeOnMainThread({ realm in
+                Realm.execute({ realm in
                     if let obj = self {
                         obj.rid = rid
                         realm.add(obj, update: true)
@@ -148,7 +148,7 @@ extension Subscription {
     }
 
     func updateFavorite(_ favorite: Bool) {
-        Realm.executeOnMainThread({ _ in
+        Realm.execute({ _ in
             self.favorite = favorite
         })
     }

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -27,8 +27,16 @@ final class ChatMessageCell: UICollectionViewCell {
             labelText.delegate = delegate
         }
     }
+
     var message: Message! {
         didSet {
+            if oldValue != nil && oldValue.identifier == message?.identifier {
+                if oldValue.updatedAt?.timeIntervalSince1970 == message.updatedAt?.timeIntervalSince1970 {
+                    Log.debug("message is cached")
+                    return
+                }
+            }
+
             updateMessage()
         }
     }
@@ -110,6 +118,7 @@ final class ChatMessageCell: UICollectionViewCell {
         labelText.message = nil
         labelDate.text = ""
         sequential = false
+        message = nil
 
         for view in mediaViews.arrangedSubviews {
             view.removeFromSuperview()
@@ -243,14 +252,18 @@ final class ChatMessageCell: UICollectionViewCell {
     }
 
     fileprivate func updateMessage() {
-        guard delegate != nil else { return }
+        guard
+            delegate != nil,
+            message != nil
+        else {
+            return
+        }
 
         if !sequential {
             updateMessageHeader()
         }
 
         updateMessageContent()
-
         insertGesturesIfNeeded()
         insertAttachments()
     }
@@ -276,6 +289,7 @@ extension ChatMessageCell: UIGestureRecognizerDelegate {
 // MARK: Accessibility
 
 extension ChatMessageCell {
+
     override func awakeFromNib() {
         isAccessibilityElement = true
     }
@@ -294,4 +308,5 @@ extension ChatMessageCell {
         get { return message?.accessibilityValue }
         set { }
     }
+
 }

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageImageView.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageImageView.swift
@@ -20,6 +20,11 @@ final class ChatMessageImageView: UIView {
     weak var delegate: ChatMessageImageViewProtocol?
     var attachment: Attachment! {
         didSet {
+            if oldValue != nil && oldValue.identifier == attachment.identifier {
+                Log.debug("attachment is cached")
+                return
+            }
+
             updateMessageInformation()
         }
     }

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageTextViewModel.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageTextViewModel.swift
@@ -43,9 +43,9 @@ final class ChatMessageTextViewModel {
         self.attachment = attachment
     }
 
-    func toggleCollpase() {
+    func toggleCollpase(_ completion: VoidCompletion? = nil) {
         Realm.execute({ _ in
             self.attachment.collapsed = !self.attachment.collapsed
-        })
+        }, completion: completion)
     }
 }

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageTextViewModel.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageTextViewModel.swift
@@ -44,7 +44,7 @@ final class ChatMessageTextViewModel {
     }
 
     func toggleCollpase() {
-        Realm.executeOnMainThread({ _ in
+        Realm.execute({ _ in
             self.attachment.collapsed = !self.attachment.collapsed
         })
     }

--- a/Rocket.ChatTests/Controllers/ChatDataControllerSpec.swift
+++ b/Rocket.ChatTests/Controllers/ChatDataControllerSpec.swift
@@ -139,6 +139,7 @@ class ChatDataControllerSpec: XCTestCase {
         let controller = ChatDataController()
 
         let message = Message()
+        message.updatedAt = Date().addingTimeInterval(-1000)
         message.identifier = "update-1"
         message.text = "Foobar"
 
@@ -149,9 +150,12 @@ class ChatDataControllerSpec: XCTestCase {
         XCTAssertNotNil(indexPaths, "indexPaths can't be nil")
         XCTAssertEqual(indexPaths.count, 2, "indexPaths will have three results")
 
-        message.text = "Foobar, updated"
+        let newMessage = Message()
+        newMessage.identifier = "update-1"
+        newMessage.updatedAt = Date()
+        newMessage.text = "Foobar, updated"
 
-        let index = controller.update(message, completion: nil)
+        let index = controller.update(newMessage)
         XCTAssertEqual(index, 1, "indexPath is the message indexPath row")
         XCTAssertEqual(controller.data[index].message?.text, "Foobar, updated", "Message text was updated")
     }

--- a/Rocket.ChatTests/Views/Chat/ChatMessageTextViewModelSpec.swift
+++ b/Rocket.ChatTests/Views/Chat/ChatMessageTextViewModelSpec.swift
@@ -102,7 +102,13 @@ class ChatMessageTextViewModelSpec: XCTestCase {
     func testToggleCollpased() {
         let attachment = Attachment()
         let model = ChatMessageTextViewModel(withAttachment: attachment)
-        model.toggleCollpase()
+
+        let expectation = XCTestExpectation(description: "toggle value change")
+        model.toggleCollpase {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2)
+
         XCTAssertTrue(model.collapsed)
     }
 }


### PR DESCRIPTION
@RocketChat/ios

Closes #1064 

## Description

This PR fixes a few performance and bugs in the app:

1. ImageView flickering on the messages list;
2. Cell was being reused hundreds of times on any Message update call from Realm;
3. Moved the Markdown processing to the main thread again, to avoid weird behaviors;