### PR TITLE
[HOTFIX] Some layout fixes for reactions

### DIFF
--- a/Rocket.Chat/Models/Mapping/MessageModelMapping.swift
+++ b/Rocket.Chat/Models/Mapping/MessageModelMapping.swift
@@ -102,9 +102,8 @@ extension Message: ModelMappeable {
         }
 
         // Reactions
+        self.reactions.removeAll()
         if let reactions = values["reactions"].dictionary {
-            self.reactions.removeAll()
-
             reactions.enumerated().flatMap {
                 let reaction = MessageReaction()
                 reaction.map(emoji: $1.key, json: $1.value)

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -263,8 +263,6 @@ final class ChatMessageCell: UICollectionViewCell {
     fileprivate func updateReactions() {
         let username = AuthManager.currentUser()?.username
 
-        reactionsListViewConstraint.constant = message.reactions.count > 0 ? 24 : 0
-
         let models = Array(message.reactions.map { reaction -> ReactionViewModel in
             let highlight: Bool
             if let username = username {
@@ -281,6 +279,14 @@ final class ChatMessageCell: UICollectionViewCell {
         })
 
         reactionsListView.model = ReactionListViewModel(reactionViewModels: models)
+
+        if message.reactions.count > 0 {
+            reactionsListView.isHidden = false
+            reactionsListViewConstraint.constant = 24
+        } else {
+            reactionsListView.isHidden = true
+            reactionsListViewConstraint.constant = 0
+        }
     }
 
     fileprivate func updateMessage() {

--- a/Rocket.Chat/Views/Reactions/ReactionListView.swift
+++ b/Rocket.Chat/Views/Reactions/ReactionListView.swift
@@ -17,13 +17,12 @@ struct ReactionListViewModel {
 }
 
 class ReactionListView: UIView {
-    @IBOutlet var contentView: UIView! {
+    @IBOutlet var scrollView: UIScrollView! {
         didSet {
-            setupContentView()
+            setupScrollView()
         }
     }
     @IBOutlet weak var reactionsStack: UIStackView!
-    @IBOutlet weak var fixedStack: UIStackView!
 
     var model = ReactionListViewModel() {
         didSet {
@@ -70,18 +69,18 @@ extension ReactionListView {
         Bundle.main.loadNibNamed("ReactionListView", owner: self, options: nil)
     }
 
-    private func setupContentView() {
-        addSubview(contentView)
-        contentView.translatesAutoresizingMaskIntoConstraints = false
+    private func setupScrollView() {
+        addSubview(scrollView)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
 
         addConstraints(
             NSLayoutConstraint.constraints(
-                withVisualFormat: "|-0-[view]-0-|", options: [], metrics: nil, views: ["view": contentView]
+                withVisualFormat: "|-0-[view]-0-|", options: [], metrics: nil, views: ["view": scrollView]
             )
         )
         addConstraints(
             NSLayoutConstraint.constraints(
-                withVisualFormat: "V:|-0-[view]-0-|", options: [], metrics: nil, views: ["view": contentView]
+                withVisualFormat: "V:|-0-[view]-0-|", options: [], metrics: nil, views: ["view": scrollView]
             )
         )
     }

--- a/Rocket.Chat/Views/Reactions/ReactionListView.swift
+++ b/Rocket.Chat/Views/Reactions/ReactionListView.swift
@@ -17,12 +17,13 @@ struct ReactionListViewModel {
 }
 
 class ReactionListView: UIView {
-    @IBOutlet var scrollView: UIScrollView! {
+    @IBOutlet var contentView: UIView! {
         didSet {
-            setupScrollView()
+            setupContentView()
         }
     }
     @IBOutlet weak var reactionsStack: UIStackView!
+    @IBOutlet weak var fixedStack: UIStackView!
 
     var model = ReactionListViewModel() {
         didSet {
@@ -66,21 +67,18 @@ extension ReactionListView {
         Bundle.main.loadNibNamed("ReactionListView", owner: self, options: nil)
     }
 
-    private func setupScrollView() {
-        addSubview(scrollView)
+    private func setupContentView() {
+        addSubview(contentView)
 
         addConstraints(
             NSLayoutConstraint.constraints(
-                withVisualFormat: "|-0-[view]-0-|", options: [], metrics: nil, views: ["view": scrollView]
+                withVisualFormat: "|-0-[view]-0-|", options: [], metrics: nil, views: ["view": contentView]
             )
         )
         addConstraints(
             NSLayoutConstraint.constraints(
-                withVisualFormat: "V:|-0-[view]-0-|", options: [], metrics: nil, views: ["view": scrollView]
+                withVisualFormat: "V:|-0-[view]-0-|", options: [], metrics: nil, views: ["view": contentView]
             )
         )
-
-        scrollView.showsVerticalScrollIndicator = false
-        scrollView.showsHorizontalScrollIndicator = false
     }
 }

--- a/Rocket.Chat/Views/Reactions/ReactionListView.swift
+++ b/Rocket.Chat/Views/Reactions/ReactionListView.swift
@@ -40,7 +40,10 @@ class ReactionListView: UIView {
             return view
         }
 
-        reactionsStack.arrangedSubviews.forEach(reactionsStack.removeArrangedSubview)
+        reactionsStack.arrangedSubviews.forEach {
+            reactionsStack.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
 
         views.forEach { view in
             reactionsStack.addArrangedSubview(view)
@@ -69,6 +72,7 @@ extension ReactionListView {
 
     private func setupContentView() {
         addSubview(contentView)
+        contentView.translatesAutoresizingMaskIntoConstraints = false
 
         addConstraints(
             NSLayoutConstraint.constraints(

--- a/Rocket.Chat/Views/Reactions/ReactionListView.xib
+++ b/Rocket.Chat/Views/Reactions/ReactionListView.xib
@@ -7,33 +7,65 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReactionListView" customModule="Rocket_Chat" customModuleProvider="target">
             <connections>
+                <outlet property="contentView" destination="x3N-yb-VYD" id="Cpt-HA-zhm"/>
+                <outlet property="fixedStack" destination="qq3-So-nNU" id="d2E-AV-bSw"/>
                 <outlet property="reactionsStack" destination="Bp4-sy-uGs" id="uEV-LB-epe"/>
-                <outlet property="scrollView" destination="vUh-ZA-FsI" id="jA3-bt-1uD"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vUh-ZA-FsI">
-            <rect key="frame" x="0.0" y="0.0" width="567" height="46"/>
+        <view contentMode="scaleToFill" id="x3N-yb-VYD">
+            <rect key="frame" x="0.0" y="0.0" width="293" height="24"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Bp4-sy-uGs">
-                    <rect key="frame" x="0.0" y="0.0" width="50" height="46"/>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vUh-ZA-FsI">
+                    <rect key="frame" x="0.0" y="0.0" width="271" height="24"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Bp4-sy-uGs">
+                            <rect key="frame" x="0.0" y="0.0" width="46" height="24"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xsi-I6-DeZ">
+                                    <rect key="frame" x="0.0" y="0.0" width="46" height="24"/>
+                                    <state key="normal" title="Button"/>
+                                </button>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="Bp4-sy-uGs" firstAttribute="leading" secondItem="vUh-ZA-FsI" secondAttribute="leading" id="4Sx-bI-RnH"/>
+                        <constraint firstItem="Bp4-sy-uGs" firstAttribute="bottom" secondItem="vUh-ZA-FsI" secondAttribute="bottom" id="Cmk-Dq-PRC"/>
+                        <constraint firstItem="Bp4-sy-uGs" firstAttribute="height" secondItem="vUh-ZA-FsI" secondAttribute="height" id="ZEt-Lz-RmV"/>
+                        <constraint firstAttribute="trailing" secondItem="Bp4-sy-uGs" secondAttribute="trailing" id="qk2-Vg-GiD"/>
+                        <constraint firstItem="Bp4-sy-uGs" firstAttribute="top" secondItem="vUh-ZA-FsI" secondAttribute="top" id="rtK-Sd-fTK"/>
+                    </constraints>
+                </scrollView>
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="qq3-So-nNU">
+                    <rect key="frame" x="271" y="0.0" width="22" height="24"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="detailDisclosure" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="krd-Ha-lhQ">
+                            <rect key="frame" x="0.0" y="1" width="22" height="22"/>
+                        </button>
+                    </subviews>
                 </stackView>
             </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstItem="Bp4-sy-uGs" firstAttribute="trailing" secondItem="vUh-ZA-FsI" secondAttribute="trailing" id="0yg-TW-kaq"/>
-                <constraint firstItem="Bp4-sy-uGs" firstAttribute="leading" secondItem="vUh-ZA-FsI" secondAttribute="leading" id="4Sx-bI-RnH"/>
-                <constraint firstItem="Bp4-sy-uGs" firstAttribute="bottom" secondItem="vUh-ZA-FsI" secondAttribute="bottom" id="Cmk-Dq-PRC"/>
-                <constraint firstItem="Bp4-sy-uGs" firstAttribute="height" secondItem="vUh-ZA-FsI" secondAttribute="height" id="ZEt-Lz-RmV"/>
-                <constraint firstItem="Bp4-sy-uGs" firstAttribute="top" secondItem="vUh-ZA-FsI" secondAttribute="top" id="rtK-Sd-fTK"/>
+                <constraint firstItem="vUh-ZA-FsI" firstAttribute="top" secondItem="deX-xy-GKB" secondAttribute="top" id="1d3-Yi-E4A"/>
+                <constraint firstItem="qq3-So-nNU" firstAttribute="centerY" secondItem="deX-xy-GKB" secondAttribute="centerY" id="DOe-1C-Zfb"/>
+                <constraint firstItem="qq3-So-nNU" firstAttribute="leading" secondItem="vUh-ZA-FsI" secondAttribute="trailing" id="KU5-Gz-2sa"/>
+                <constraint firstItem="vUh-ZA-FsI" firstAttribute="leading" secondItem="x3N-yb-VYD" secondAttribute="leading" id="NBF-hi-kbs"/>
+                <constraint firstItem="qq3-So-nNU" firstAttribute="height" secondItem="x3N-yb-VYD" secondAttribute="height" id="VCx-PM-PUr"/>
+                <constraint firstItem="deX-xy-GKB" firstAttribute="trailing" secondItem="qq3-So-nNU" secondAttribute="trailing" id="vtg-gI-7fI"/>
+                <constraint firstItem="vUh-ZA-FsI" firstAttribute="bottom" secondItem="deX-xy-GKB" secondAttribute="bottom" id="y7R-zZ-TUi"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="2LA-wb-v0m"/>
-            <point key="canvasLocation" x="278.5" y="-686"/>
-        </scrollView>
+            <viewLayoutGuide key="safeArea" id="deX-xy-GKB"/>
+            <point key="canvasLocation" x="386.5" y="-405"/>
+        </view>
     </objects>
 </document>

--- a/Rocket.Chat/Views/Reactions/ReactionListView.xib
+++ b/Rocket.Chat/Views/Reactions/ReactionListView.xib
@@ -13,7 +13,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReactionListView" customModule="Rocket_Chat" customModuleProvider="target">
             <connections>
-                <outlet property="contentView" destination="x3N-yb-VYD" id="Cpt-HA-zhm"/>
+                <outlet property="contentView" destination="x3N-yb-VYD" id="igk-MZ-hbC"/>
                 <outlet property="fixedStack" destination="qq3-So-nNU" id="d2E-AV-bSw"/>
                 <outlet property="reactionsStack" destination="Bp4-sy-uGs" id="uEV-LB-epe"/>
             </connections>

--- a/Rocket.Chat/Views/Reactions/ReactionListView.xib
+++ b/Rocket.Chat/Views/Reactions/ReactionListView.xib
@@ -7,65 +7,39 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReactionListView" customModule="Rocket_Chat" customModuleProvider="target">
             <connections>
-                <outlet property="contentView" destination="x3N-yb-VYD" id="igk-MZ-hbC"/>
-                <outlet property="fixedStack" destination="qq3-So-nNU" id="d2E-AV-bSw"/>
                 <outlet property="reactionsStack" destination="Bp4-sy-uGs" id="uEV-LB-epe"/>
+                <outlet property="scrollView" destination="vUh-ZA-FsI" id="jA3-bt-1uD"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="x3N-yb-VYD">
-            <rect key="frame" x="0.0" y="0.0" width="293" height="24"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vUh-ZA-FsI">
+            <rect key="frame" x="0.0" y="0.0" width="567" height="46"/>
             <subviews>
-                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vUh-ZA-FsI">
-                    <rect key="frame" x="0.0" y="0.0" width="271" height="24"/>
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Bp4-sy-uGs">
+                    <rect key="frame" x="0.0" y="0.0" width="68" height="46"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Bp4-sy-uGs">
-                            <rect key="frame" x="0.0" y="0.0" width="46" height="24"/>
-                            <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xsi-I6-DeZ">
-                                    <rect key="frame" x="0.0" y="0.0" width="46" height="24"/>
-                                    <state key="normal" title="Button"/>
-                                </button>
-                            </subviews>
-                        </stackView>
-                    </subviews>
-                    <constraints>
-                        <constraint firstItem="Bp4-sy-uGs" firstAttribute="leading" secondItem="vUh-ZA-FsI" secondAttribute="leading" id="4Sx-bI-RnH"/>
-                        <constraint firstItem="Bp4-sy-uGs" firstAttribute="bottom" secondItem="vUh-ZA-FsI" secondAttribute="bottom" id="Cmk-Dq-PRC"/>
-                        <constraint firstItem="Bp4-sy-uGs" firstAttribute="height" secondItem="vUh-ZA-FsI" secondAttribute="height" id="ZEt-Lz-RmV"/>
-                        <constraint firstAttribute="trailing" secondItem="Bp4-sy-uGs" secondAttribute="trailing" id="qk2-Vg-GiD"/>
-                        <constraint firstItem="Bp4-sy-uGs" firstAttribute="top" secondItem="vUh-ZA-FsI" secondAttribute="top" id="rtK-Sd-fTK"/>
-                    </constraints>
-                </scrollView>
-                <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="qq3-So-nNU">
-                    <rect key="frame" x="271" y="0.0" width="22" height="24"/>
-                    <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="detailDisclosure" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="krd-Ha-lhQ">
-                            <rect key="frame" x="0.0" y="1" width="22" height="22"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jH5-CI-tIQ">
+                            <rect key="frame" x="0.0" y="0.0" width="68" height="46"/>
+                            <state key="normal" title="Reactions"/>
                         </button>
                     </subviews>
                 </stackView>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstItem="vUh-ZA-FsI" firstAttribute="top" secondItem="deX-xy-GKB" secondAttribute="top" id="1d3-Yi-E4A"/>
-                <constraint firstItem="qq3-So-nNU" firstAttribute="centerY" secondItem="deX-xy-GKB" secondAttribute="centerY" id="DOe-1C-Zfb"/>
-                <constraint firstItem="qq3-So-nNU" firstAttribute="leading" secondItem="vUh-ZA-FsI" secondAttribute="trailing" id="KU5-Gz-2sa"/>
-                <constraint firstItem="vUh-ZA-FsI" firstAttribute="leading" secondItem="x3N-yb-VYD" secondAttribute="leading" id="NBF-hi-kbs"/>
-                <constraint firstItem="qq3-So-nNU" firstAttribute="height" secondItem="x3N-yb-VYD" secondAttribute="height" id="VCx-PM-PUr"/>
-                <constraint firstItem="deX-xy-GKB" firstAttribute="trailing" secondItem="qq3-So-nNU" secondAttribute="trailing" id="vtg-gI-7fI"/>
-                <constraint firstItem="vUh-ZA-FsI" firstAttribute="bottom" secondItem="deX-xy-GKB" secondAttribute="bottom" id="y7R-zZ-TUi"/>
+                <constraint firstItem="Bp4-sy-uGs" firstAttribute="trailing" secondItem="vUh-ZA-FsI" secondAttribute="trailing" id="0yg-TW-kaq"/>
+                <constraint firstItem="Bp4-sy-uGs" firstAttribute="leading" secondItem="vUh-ZA-FsI" secondAttribute="leading" id="4Sx-bI-RnH"/>
+                <constraint firstItem="Bp4-sy-uGs" firstAttribute="bottom" secondItem="vUh-ZA-FsI" secondAttribute="bottom" id="Cmk-Dq-PRC"/>
+                <constraint firstItem="Bp4-sy-uGs" firstAttribute="height" secondItem="vUh-ZA-FsI" secondAttribute="height" id="ZEt-Lz-RmV"/>
+                <constraint firstItem="Bp4-sy-uGs" firstAttribute="top" secondItem="vUh-ZA-FsI" secondAttribute="top" id="rtK-Sd-fTK"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="deX-xy-GKB"/>
-            <point key="canvasLocation" x="386.5" y="-405"/>
-        </view>
+            <viewLayoutGuide key="safeArea" id="2LA-wb-v0m"/>
+            <point key="canvasLocation" x="278.5" y="-686"/>
+        </scrollView>
     </objects>
 </document>


### PR DESCRIPTION
@RocketChat/ios

Hotfix: this only happens on testflight

Fixes:
- reaction views not being removed from superview
- last reaction not clearing from message object when all reactions are removed
