### PR TITLE
[I18N] Shorter ssl required expression

### DIFF
--- a/Rocket.Chat/de.lproj/Localizable.strings
+++ b/Rocket.Chat/de.lproj/Localizable.strings
@@ -61,7 +61,7 @@
 
 // Auth
 "auth.connect.button_connect" = "Verbinden";
-"auth.connect.ssl_required" = "Es ist erforderlich, dass Ihr Server SSL unterstützt";
+"auth.connect.ssl_required" = "Der Server muss SSL unterstützen";
 "auth.connect.connecting" = "Verbindung läuft. Warte kurz!";
 
 // Subscriptions


### PR DESCRIPTION
Old label overflowed the width, so some characters were cut off. We need no word by word match of the translations, so this message should be sufficient: "The server must support SSL"

@rafaelks suggested a multiline label and adjusting the width of the label to fit the `textFieldServerURL`.

@RocketChat/ios
