### PR TITLE
[I18N] Translate quick reply

### DIFF
--- a/Rocket.Chat/Managers/PushManager.swift
+++ b/Rocket.Chat/Managers/PushManager.swift
@@ -101,7 +101,7 @@ extension UNNotificationAction {
     static var reply: UNNotificationAction {
         return UNTextInputNotificationAction(
             identifier: "REPLY",
-            title: localized("Reply"),
+            title: localized("notifications.action.reply"),
             options: .authenticationRequired
         )
     }

--- a/Rocket.Chat/Managers/PushManager.swift
+++ b/Rocket.Chat/Managers/PushManager.swift
@@ -101,7 +101,7 @@ extension UNNotificationAction {
     static var reply: UNNotificationAction {
         return UNTextInputNotificationAction(
             identifier: "REPLY",
-            title: "Reply",
+            title: localized("Reply"),
             options: .authenticationRequired
         )
     }

--- a/Rocket.Chat/cs.lproj/Localizable.strings
+++ b/Rocket.Chat/cs.lproj/Localizable.strings
@@ -91,6 +91,9 @@
 "new_room.group.invite_users" = "Invite users";
 "new_room.cell.invite_users.placeholder" = "Usernames";
 
+// Notifications
+"notifications.action.reply" = "Reply";
+
 // Chat
 "chat.channel_preview_view.title" = "Toto je náhled kanálu #%@";
 "chat.channel_preview_view.join" = "Připojit se do kanálu";

--- a/Rocket.Chat/de.lproj/Localizable.strings
+++ b/Rocket.Chat/de.lproj/Localizable.strings
@@ -91,6 +91,9 @@
 "new_room.group.invite_users" = "Benutzer einladen";
 "new_room.cell.invite_users.placeholder" = "Benutzernamen";
 
+// Notifications
+"notifications.action.reply" = "Antworten";
+
 // Chat
 "chat.channel_preview_view.title" = "Das ist eine Vorschau von #%@";
 "chat.channel_preview_view.join" = "Kanal beitreten";

--- a/Rocket.Chat/en.lproj/Localizable.strings
+++ b/Rocket.Chat/en.lproj/Localizable.strings
@@ -91,6 +91,9 @@
 "new_room.group.invite_users" = "Invite users";
 "new_room.cell.invite_users.placeholder" = "Usernames";
 
+// Notifications
+"notifications.action.reply" = "Reply";
+
 // Chat
 "chat.channel_preview_view.title" = "This is a preview of #%@";
 "chat.channel_preview_view.join" = "Join Channel";

--- a/Rocket.Chat/fr.lproj/Localizable.strings
+++ b/Rocket.Chat/fr.lproj/Localizable.strings
@@ -91,6 +91,9 @@
 "new_room.group.invite_users" = "Inviter des utilisateurs";
 "new_room.cell.invite_users.placeholder" = "Noms d'utilisateur";
 
+// Notifications
+"notifications.action.reply" = "Réspondre";
+
 // Chat
 "chat.channel_preview_view.title" = "Ceci est un aperçu de #%@";
 "chat.channel_preview_view.join" = "Rejoindre le canal";

--- a/Rocket.Chat/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/pl.lproj/Localizable.strings
@@ -91,6 +91,9 @@
 "new_room.group.invite_users" = "Zaproś użytkowników";
 "new_room.cell.invite_users.placeholder" = "Nazwy użytkowników";
 
+// Notifications
+"notifications.action.reply" = "Reply";
+
 // Chat
 "chat.channel_preview_view.title" = "Jest to podgląd kanału #%@";
 "chat.channel_preview_view.join" = "Dołącz do kanału";

--- a/Rocket.Chat/pt-BR.lproj/Localizable.strings
+++ b/Rocket.Chat/pt-BR.lproj/Localizable.strings
@@ -91,6 +91,9 @@
 "new_room.group.invite_users" = "Invite users";
 "new_room.cell.invite_users.placeholder" = "Usernames";
 
+// Notifications
+"notifications.action.reply" = "Reply";
+
 // Chat
 "chat.channel_preview_view.title" = "Esta é uma pré-visualização de #%@";
 "chat.channel_preview_view.join" = "Entrar";


### PR DESCRIPTION
@RocketChat/ios

Although we have no other option on mobile and thus just show the keyboard to reply instantly, on Watch we see the "Reply" action button