### PR TITLE
[FIX] Reaction size on iOS 10.x

### DIFF
--- a/Rocket.Chat/External/RCEmojiKit/Views/Reaction/ReactionListView.xib
+++ b/Rocket.Chat/External/RCEmojiKit/Views/Reaction/ReactionListView.xib
@@ -21,20 +21,22 @@
             <rect key="frame" x="0.0" y="0.0" width="567" height="47"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Bp4-sy-uGs">
-                    <rect key="frame" x="0.0" y="8" width="68" height="31"/>
+                    <rect key="frame" x="0.0" y="8" width="68" height="30"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jH5-CI-tIQ">
-                            <rect key="frame" x="0.0" y="0.0" width="68" height="31"/>
+                            <rect key="frame" x="0.0" y="0.0" width="68" height="30"/>
                             <state key="normal" title="Reactions"/>
                         </button>
                     </subviews>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="30" id="3Q1-SR-Qac"/>
+                    </constraints>
                 </stackView>
             </subviews>
             <constraints>
-                <constraint firstItem="Bp4-sy-uGs" firstAttribute="top" secondItem="2LA-wb-v0m" secondAttribute="top" constant="8" id="0EL-pZ-Fme"/>
                 <constraint firstItem="Bp4-sy-uGs" firstAttribute="trailing" secondItem="vUh-ZA-FsI" secondAttribute="trailing" id="0yg-TW-kaq"/>
                 <constraint firstItem="Bp4-sy-uGs" firstAttribute="leading" secondItem="vUh-ZA-FsI" secondAttribute="leading" id="4Sx-bI-RnH"/>
-                <constraint firstItem="2LA-wb-v0m" firstAttribute="bottom" secondItem="Bp4-sy-uGs" secondAttribute="bottom" constant="8" id="xHd-L3-V0X"/>
+                <constraint firstItem="Bp4-sy-uGs" firstAttribute="centerY" secondItem="vUh-ZA-FsI" secondAttribute="centerY" id="lE6-qp-L1L"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="2LA-wb-v0m"/>


### PR DESCRIPTION
@RocketChat/ios

Closes #1181

The bug was happening because the constraints were using Safe Area and for some reason the iOS 10 wasn't making fallback... so I changed the constraints to a fixed height (30px) and centred vertically.

### iOS 10.x iPhone
![2018-02-16 02 25 19](https://user-images.githubusercontent.com/551004/36293450-15911770-12c1-11e8-9546-56463baa7195.gif)

### iOS 11.x iPhone
![2018-02-16 02 28 07](https://user-images.githubusercontent.com/551004/36293452-1a461676-12c1-11e8-933a-7cef879f81dd.gif)

### iOS 10.x iPad
![2018-02-16 02 30 16](https://user-images.githubusercontent.com/551004/36293487-62059c84-12c1-11e8-972f-6a5e269c5816.gif)

### iOS 11.x iPad
![2018-02-16 02 32 07](https://user-images.githubusercontent.com/551004/36293536-9fb1a69a-12c1-11e8-9f4b-60ba16b9c55c.gif)
