### PR TITLE
[i18n] Remove unused localize string

### DIFF
--- a/Rocket.Chat/Resources/cs.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/cs.lproj/Localizable.strings
@@ -118,7 +118,6 @@
 "chat.channel.start_conversation" = "Toto je začátek konverzace %@";
 "chat.read_only" = "Tato místnost je pouze pro čtení";
 "chat.muted" = "You have been muted";
-"chat.edit_mode" = "Upravit zprávu. Blízko zrušit.";
 "chat.loading_messages" = "Loading messages..."; //TODO
 
 // Chat Message Actions

--- a/Rocket.Chat/Resources/de.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/de.lproj/Localizable.strings
@@ -118,7 +118,6 @@
 "chat.channel.start_conversation" = "Dies ist der Beginn der Konversation auf %@";
 "chat.read_only" = "Dieser Raum ist schreibgeschützt";
 "chat.muted" = "Du wurdest stummgeschaltet";
-"chat.edit_mode" = "Nachricht bearbeiten. Schließen um abzubrechen.";
 "chat.loading_messages" = "Nachrichten werden geladen...";
 
 // Chat Message Actions

--- a/Rocket.Chat/Resources/en.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/en.lproj/Localizable.strings
@@ -118,7 +118,6 @@
 "chat.channel.start_conversation" = "This is the start of the conversation on %@";
 "chat.read_only" = "This room is read only";
 "chat.muted" = "You have been muted";
-"chat.edit_mode" = "Edit message. Close to cancel.";
 "chat.loading_messages" = "Loading messages...";
 
 // Chat Message Actions

--- a/Rocket.Chat/Resources/fr.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/fr.lproj/Localizable.strings
@@ -118,7 +118,6 @@
 "chat.channel.start_conversation" = "Ceci est le début de votre conversation sur %@";
 "chat.read_only" = "Cette pièce est en lecture seule";
 "chat.muted" = "Vous avez été mis en sourdine";
-"chat.edit_mode" = "Modifier le message. Fermer pour annuler.";
 "chat.loading_messages" = "Chargement des messages...";
 
 // Chat Message Actions

--- a/Rocket.Chat/Resources/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pl.lproj/Localizable.strings
@@ -118,7 +118,6 @@
 "chat.channel.start_conversation" = "To początek rozmowy na kanale %@";
 "chat.read_only" = "Ten kanał jest tylko do odczytu";
 "chat.muted" = "Zostałeś wyciszony na tym kanale";
-"chat.edit_mode" = "Edytuj wiadomość. Blisko, aby anulować.";
 "chat.loading_messages" = "Ładowanie wiadomości...";
 
 // Chat Message Actions

--- a/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
@@ -118,7 +118,6 @@
 "chat.channel.start_conversation" = "Este é o começo da conversa em %@";
 "chat.read_only" = "Este canal é somente leitura";
 "chat.muted" = "Você foi silenciado";
-"chat.edit_mode" = "Editando mensagem. Feche para cancelar.";
 "chat.loading_messages" = "Carregando mensagens...";
 
 // Chat Message Actions


### PR DESCRIPTION
@RocketChat/ios

`chat.edit_mode` is not used anywhere