### PR TITLE
[FIX] Crashing with certain messages with custom emojis

### DIFF
--- a/Rocket.Chat/External/RCEmojiKit/NSAttributedString+CustomEmojis.swift
+++ b/Rocket.Chat/External/RCEmojiKit/NSAttributedString+CustomEmojis.swift
@@ -16,7 +16,9 @@ extension NSAttributedString {
         return emojis.reduce(mutableSelf) { attributedString, emoji in
             guard case let .custom(imageUrl) = emoji.type else { return attributedString }
 
-            let regexPattern = ":\(emoji.shortname):|:\(emoji.alternates.joined(separator: ":|:")):"
+            let alternates = emoji.alternates.filter { !$0.isEmpty }
+
+            let regexPattern = ":\(emoji.shortname):" + (alternates.isEmpty ? "" : "|:\(alternates.joined(separator: ":|:")):")
 
             guard let regex = try? NSRegularExpression(pattern: regexPattern, options: []) else { return attributedString }
 


### PR DESCRIPTION
@RocketChat/ios

You can reproduce the crash on open with ":party_parrot: ::::"

I'm not sure if it's the same crash, because XCode doesn't report the same callstack, but it's pretty bad too.

Closes #1289 
