### PR TITLE
[WIP] List of blocked users + unblock users

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - 1PasswordExtension (1.8.5)
-  - Crashlytics (3.9.3):
-    - Fabric (~> 1.7.2)
-  - Fabric (1.7.2)
+  - Crashlytics (3.10.0):
+    - Fabric (~> 1.7.3)
+  - Fabric (1.7.3)
   - FLAnimatedImage (1.0.12)
   - FLEX (2.4.0)
-  - GoogleSignIn (4.1.1):
+  - GoogleSignIn (4.1.2):
     - GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)
     - GoogleToolboxForMac/NSString+URLArguments (~> 2.1)
     - GTMOAuth2 (~> 1.0)
@@ -20,30 +20,30 @@ PODS:
   - GoogleToolboxForMac/NSString+URLArguments (2.1.3)
   - GTMOAuth2 (1.1.6):
     - GTMSessionFetcher (~> 1.1)
-  - GTMSessionFetcher (1.1.12):
-    - GTMSessionFetcher/Full (= 1.1.12)
-  - GTMSessionFetcher/Core (1.1.12)
-  - GTMSessionFetcher/Full (1.1.12):
-    - GTMSessionFetcher/Core (= 1.1.12)
-  - Instabug (7.8):
-    - Instabug/Instabug (= 7.8)
-    - Instabug/InstabugCore (= 7.8)
-  - Instabug/Instabug (7.8):
+  - GTMSessionFetcher (1.1.13):
+    - GTMSessionFetcher/Full (= 1.1.13)
+  - GTMSessionFetcher/Core (1.1.13)
+  - GTMSessionFetcher/Full (1.1.13):
+    - GTMSessionFetcher/Core (= 1.1.13)
+  - Instabug (7.9.2):
+    - Instabug/Instabug (= 7.9.2)
+    - Instabug/InstabugCore (= 7.9.2)
+  - Instabug/Instabug (7.9.2):
     - Instabug/InstabugCore
-  - Instabug/InstabugCore (7.8)
+  - Instabug/InstabugCore (7.9.2)
   - MobilePlayer (1.2.0)
   - OAuthSwift (1.2.0)
   - RCMarkdownParser (3.0.4)
   - ReachabilitySwift (4.1.0)
-  - Realm (3.1.0):
-    - Realm/Headers (= 3.1.0)
-  - Realm/Headers (3.1.0)
-  - RealmSwift (3.1.0):
-    - Realm (= 3.1.0)
-  - SDWebImage (4.2.3):
-    - SDWebImage/Core (= 4.2.3)
-  - SDWebImage/Core (4.2.3)
-  - SDWebImage/GIF (4.2.3):
+  - Realm (3.1.1):
+    - Realm/Headers (= 3.1.1)
+  - Realm/Headers (3.1.1)
+  - RealmSwift (3.1.1):
+    - Realm (= 3.1.1)
+  - SDWebImage (4.3.0):
+    - SDWebImage/Core (= 4.3.0)
+  - SDWebImage/Core (4.3.0)
+  - SDWebImage/GIF (4.3.0):
     - FLAnimatedImage (~> 1.0)
     - SDWebImage/Core
   - SearchTextField (1.2.0)
@@ -54,7 +54,7 @@ PODS:
     - SDWebImage/GIF
   - SlackTextViewController (1.9.6)
   - Starscream (3.0.4)
-  - SwiftLint (0.24.2)
+  - SwiftLint (0.25.0)
   - SwiftyJSON (4.0.0)
   - TagListView (1.3.0)
 
@@ -114,29 +114,29 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
-  Crashlytics: dbb07d01876c171c5ccbdf7826410380189e452c
-  Fabric: 9cd6a848efcf1b8b07497e0b6a2e7d336353ba15
+  Crashlytics: a989ef242b66605577a425733797f810bd2725eb
+  Fabric: bb495bb9a7a7677c6d03a1f8b83d95bc49b47e41
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
   FLEX: bd1a39e55b56bb413b6f1b34b3c10a0dc44ef079
-  GoogleSignIn: 3fdaa34a2ba04dbd7a25d7db39aecb0da98d5bdc
+  GoogleSignIn: d9ef55b10f0aa401a5de2747f59b725e4b9732ac
   GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
   GTMOAuth2: c77fe325e4acd453837e72d91e3b5f13116857b2
-  GTMSessionFetcher: ebaa1f79a5366922c1735f1566901f50beba23b7
-  Instabug: 51b8f0502289c3ec3e2e66672a988d3fe6ab563a
+  GTMSessionFetcher: 5bb1eae636127de695590f50e7d248483eb891e6
+  Instabug: 03f1498c234f8b22ae2acf10b34140e9030c2b71
   MobilePlayer: 069b13482499f14c25b6ce53f63a91e17975b073
   OAuthSwift: 7fd6855b8e4d58eb5a30d156ea9bed7a8aecd1ca
   RCMarkdownParser: db98166953cad4d0045d28f627d93330b36eb7ff
   ReachabilitySwift: 6849231cd4e06559f3b9ef4a97a0a0f96d41e09f
-  Realm: 09513d7c054678d65cd02ce09871f805b0d758ac
-  RealmSwift: e868fee9b10e5490ad94b6b6ecd9027944da1824
-  SDWebImage: 791bb72962b3492327ddcac4b1880bd1b5458431
+  Realm: 42d1c38a5b1bbcc828b48a7ce702cb86fc68adf4
+  RealmSwift: d31937ca6a6ee54acde64ec839523c0a3c04924b
+  SDWebImage: 6da6c8bca115addc4de8613362e1b15f66333825
   SearchTextField: a5bb7e4c33affadb115afdbe8100d84ef10a8024
   semver: df3895a55a097c7a819a80e7375e95b29e136157
   SideMenuController: 44670bc1e1c58d9460fc028e246926227edefec0
   SimpleImageViewer: 329a155b04fcb93c5da0e296044250ad113c3158
   SlackTextViewController: b854e62c1c156336bc4fd409c6ca79b5773e8f9d
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
-  SwiftLint: 2aa21b96c8d13396a051bc1cb659d2ce1e0075b0
+  SwiftLint: e14651157288e9e01d6e1a71db7014fb5744a8ea
   SwiftyJSON: 070dabdcb1beb81b247c65ffa3a79dbbfb3b48aa
   TagListView: 669f7d4455003c877655875d34829731c4191528
 

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -2143,7 +2143,6 @@
 				TargetAttributes = {
 					41DF76DE1D2C50710028DBF8 = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = S6UPZG7ZR3;
 						LastSwiftMigration = 0900;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -3133,7 +3132,7 @@
 				CODE_SIGN_ENTITLEMENTS = Rocket.Chat/Rocket.Chat.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = S6UPZG7ZR3;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Rocket.Chat/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -3155,7 +3154,7 @@
 				CODE_SIGN_ENTITLEMENTS = Rocket.Chat/Rocket.Chat.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = S6UPZG7ZR3;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Rocket.Chat/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -3294,7 +3293,7 @@
 				CODE_SIGN_ENTITLEMENTS = Rocket.Chat/Rocket.Chat.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = S6UPZG7ZR3;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Rocket.Chat/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
@@ -195,8 +195,7 @@ extension MembersListViewController: UITableViewDelegate {
 
 extension MembersListViewController {
     func checkUserBlockState(_ user: User) {
-        let isBlocked = MessageManager.blockedUsersList.contains(user.identifier!)
-        if isBlocked == true {
+        if AuthManager.isAuthenticated()?.canUnblockUser(user) == .allowed {
             let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
             alert.addAction(UIAlertAction(title: "Open Profile", style: .default, handler: { [weak self] _ in
                 self?.delegate?.membersList(self!, didSelectUser: user)
@@ -214,7 +213,7 @@ extension MembersListViewController {
             }
             present(alert, animated: true, completion: nil)
         } else {
-            delegate?.membersList(self, didSelectUser: user)
+            delegate?.membersList(self, didSelectUser: user);
         }
     }
 }

--- a/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
@@ -183,12 +183,40 @@ extension MembersListViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
 
         let user = data.member(at: indexPath.row)
-        delegate?.membersList(self, didSelectUser: user)
+        self.checkUserBlockState(user)
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if indexPath.row == data.members.count - data.pageSize/2 {
             loadMoreMembers()
+        }
+    }
+}
+
+extension MembersListViewController {
+    func checkUserBlockState(_ user: User) {
+        let isBlocked = MessageManager.blockedUsersList.contains(user.identifier!)
+        if isBlocked == true {
+            let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+            alert.addAction(UIAlertAction(title: "Open Profile", style: .default, handler: { [weak self] _ in
+                self?.delegate?.membersList(self!, didSelectUser: user)
+            }))
+            alert.addAction(UIAlertAction(title: "Unblock", style: .destructive, handler: { _ in
+                MessageManager.unblockMessagesFrom(user, completion: {
+                    //Do nothing
+                })
+            }))
+            alert.addAction(UIAlertAction(title: localized("global.cancel"), style: .cancel, handler: nil))
+
+            if let presenter = alert.popoverPresentationController {
+                presenter.sourceView = view
+                presenter.sourceRect = view.bounds
+            }
+
+            present(alert, animated: true, completion: nil)
+        } else {
+            delegate?.membersList(self, didSelectUser: user)
         }
     }
 }

--- a/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
@@ -198,7 +198,6 @@ extension MembersListViewController {
         let isBlocked = MessageManager.blockedUsersList.contains(user.identifier!)
         if isBlocked == true {
             let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-
             alert.addAction(UIAlertAction(title: "Open Profile", style: .default, handler: { [weak self] _ in
                 self?.delegate?.membersList(self!, didSelectUser: user)
             }))
@@ -213,7 +212,6 @@ extension MembersListViewController {
                 presenter.sourceView = view
                 presenter.sourceRect = view.bounds
             }
-
             present(alert, animated: true, completion: nil)
         } else {
             delegate?.membersList(self, didSelectUser: user)

--- a/Rocket.Chat/Managers/Model/MessageManager.swift
+++ b/Rocket.Chat/Managers/Model/MessageManager.swift
@@ -199,5 +199,25 @@ extension MessageManager {
             }
         })
     }
+    
+    static func unblockMessagesFrom(_ user: User, completion: @escaping VoidCompletion) {
+        guard let userIdentifier = user.identifier else { return }
+        var blockedUsers: [String] = UserDefaults.standard.value(forKey: kBlockedUsersIndentifiers) as? [String] ?? []
+        blockedUsers.remove(object: userIdentifier)
+        UserDefaults.standard.setValue(blockedUsers, forKey: kBlockedUsersIndentifiers)
+        self.blockedUsersList = blockedUsers
+
+        Realm.execute({ (realm) in
+            let messages = realm.objects(Message.self).filter("user.identifier = '\(userIdentifier)'")
+
+            for message in messages {
+                message.userBlocked = false
+            }
+
+            DispatchQueue.main.async {
+                completion()
+            }
+        })
+    }
 
 }

--- a/Rocket.Chat/Models/Auth.swift
+++ b/Rocket.Chat/Models/Auth.swift
@@ -167,3 +167,18 @@ extension Auth {
         return .allowed
     }
 }
+
+extension Auth {
+    enum CanUnblockUserResult {
+        case allowed
+        case notActionable
+    }
+
+    func canUnblockUser(_ user: User) -> CanUnblockUserResult {
+        let isBlocked = MessageManager.blockedUsersList.contains(user.identifier!)
+        if !isBlocked {
+            return .notActionable
+        }
+        return .allowed
+    }
+}

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -342,15 +342,7 @@ class AuthSpec: XCTestCase, RealmTestCase {
             realm.add(user2)
         }
 
-        XCTAssert(auth.canUnblockUser(message) == .allowed)
-
-        // my own message
-
-        try? realm.write {
-            message.user = user1
-        }
-
-        XCTAssert(auth.canUnblockUser(message) == .myOwn)
+        XCTAssert(auth.canUnblockUser(message.user!) == .allowed)
 
         // non actionable message type
 
@@ -359,6 +351,6 @@ class AuthSpec: XCTestCase, RealmTestCase {
             message.internalType = MessageType.userJoined.rawValue
         }
 
-        XCTAssert(auth.canUnblockUser(message) == .notActionable)
+        XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
     }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -317,4 +317,48 @@ class AuthSpec: XCTestCase, RealmTestCase {
         XCTAssert(auth.canBlockMessage(message) == .notActionable)
 
     }
+
+    func testCanUnblockUser() {
+        let realm = testRealm()
+
+        let user1 = User.testInstance()
+        user1.identifier = "uid1"
+
+        let user2 = User.testInstance()
+        user2.identifier = "uid2"
+
+        let auth = Auth.testInstance()
+        auth.userId = user1.identifier
+
+        let message = Message.testInstance()
+        message.identifier = "mid"
+        message.user = user2
+
+        // block-message
+
+        try? realm.write {
+            realm.add(auth)
+            realm.add(user1)
+            realm.add(user2)
+        }
+
+        XCTAssert(auth.canUnblockUser(message) == .allowed)
+
+        // my own message
+
+        try? realm.write {
+            message.user = user1
+        }
+
+        XCTAssert(auth.canUnblockUser(message) == .myOwn)
+
+        // non actionable message type
+
+        try? realm.write {
+            message.createdAt = Date()
+            message.internalType = MessageType.userJoined.rawValue
+        }
+
+        XCTAssert(auth.canUnblockUser(message) == .notActionable)
+    }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -342,7 +342,15 @@ class AuthSpec: XCTestCase, RealmTestCase {
             realm.add(user2)
         }
 
-        XCTAssert(auth.canUnblockUser(message.user!) == .allowed)
+        XCTAssert(auth.canBlockMessage(message) == .allowed)
+
+        // my own message
+
+        try? realm.write {
+            message.user = user1
+        }
+
+        XCTAssert(auth.canBlockMessage(message) == .myOwn)
 
         // non actionable message type
 
@@ -351,6 +359,6 @@ class AuthSpec: XCTestCase, RealmTestCase {
             message.internalType = MessageType.userJoined.rawValue
         }
 
-        XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
+        XCTAssert(auth.canBlockMessage(message) == .notActionable)
     }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -331,22 +331,5 @@ class AuthSpec: XCTestCase, RealmTestCase {
         message.identifier = "mid"
         message.user = user
         message.userBlocked = true
-
-        // block-user
-
-        try? realm.write {
-            realm.add(auth)
-            realm.add(user)
-        }
-
-        XCTAssert(auth.canUnblockUser(message.user!) == .allowed)
-
-        // non actionable user status
-
-        try? realm.write {
-            message.userBlocked = false;
-        }
-
-        XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
     }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -321,44 +321,32 @@ class AuthSpec: XCTestCase, RealmTestCase {
     func testCanUnblockUser() {
         let realm = testRealm()
 
-        let user1 = User.testInstance()
-        user1.identifier = "uid1"
-
-        let user2 = User.testInstance()
-        user2.identifier = "uid2"
+        let user = User.testInstance()
+        user.identifier = "uid1"
 
         let auth = Auth.testInstance()
-        auth.userId = user1.identifier
+        auth.userId = user.identifier
 
         let message = Message.testInstance()
         message.identifier = "mid"
-        message.user = user2
+        message.user = user
+        message.userBlocked = true
 
-        // block-message
+        // block-user
 
         try? realm.write {
             realm.add(auth)
-            realm.add(user1)
-            realm.add(user2)
+            realm.add(user)
         }
 
-        XCTAssert(auth.canBlockMessage(message) == .allowed)
+        XCTAssert(auth.canUnblockUser(message.user!) == .allowed)
 
-        // my own message
+        // non actionable user status
 
         try? realm.write {
-            message.user = user1
+            message.userBlocked = false;
         }
 
-        XCTAssert(auth.canBlockMessage(message) == .myOwn)
-
-        // non actionable message type
-
-        try? realm.write {
-            message.createdAt = Date()
-            message.internalType = MessageType.userJoined.rawValue
-        }
-
-        XCTAssert(auth.canBlockMessage(message) == .notActionable)
+        XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
     }
 }


### PR DESCRIPTION
@RocketChat/ios

I've added the method "unblockMessagesFrom" in MessageManager.
Now we can tap on member cell and see Action Sheet with actions "Open Profile", "Unblock" and "Cancel".

'Open Profile' opens the info page (Need add localization for "Open Profile")
'Unblock action' calls the method unblockMessagesFrom from MessageManager (Need add localization for "Unblock")
I think we shouldn't use long press gesture for this action, because there is a case:
User can forget who was blocked and don't use long press for more information about member. Therefore Action Sheet was added to didSelectRowAtIndexPath method. In this case, the user always knows about member's "unblock state".

Please review my code. I know, there are some changes which should be added
I can use translator for localization, if you don't mind.

P.S. I've created new PR, because the old one had a lot of issues

![2018-02-20 3 37 01](https://user-images.githubusercontent.com/16138494/36503576-feb29010-1766-11e8-96b0-3268418323e8.png)