### PR TITLE
[NEW] List of blocked users + unblock users

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - 1PasswordExtension (1.8.5)
-  - Crashlytics (3.9.3):
-    - Fabric (~> 1.7.2)
-  - Fabric (1.7.2)
+  - Crashlytics (3.10.0):
+    - Fabric (~> 1.7.3)
+  - Fabric (1.7.3)
   - FLAnimatedImage (1.0.12)
   - FLEX (2.4.0)
-  - GoogleSignIn (4.1.1):
+  - GoogleSignIn (4.1.2):
     - GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)
     - GoogleToolboxForMac/NSString+URLArguments (~> 2.1)
     - GTMOAuth2 (~> 1.0)
@@ -20,30 +20,30 @@ PODS:
   - GoogleToolboxForMac/NSString+URLArguments (2.1.3)
   - GTMOAuth2 (1.1.6):
     - GTMSessionFetcher (~> 1.1)
-  - GTMSessionFetcher (1.1.12):
-    - GTMSessionFetcher/Full (= 1.1.12)
-  - GTMSessionFetcher/Core (1.1.12)
-  - GTMSessionFetcher/Full (1.1.12):
-    - GTMSessionFetcher/Core (= 1.1.12)
-  - Instabug (7.8):
-    - Instabug/Instabug (= 7.8)
-    - Instabug/InstabugCore (= 7.8)
-  - Instabug/Instabug (7.8):
+  - GTMSessionFetcher (1.1.13):
+    - GTMSessionFetcher/Full (= 1.1.13)
+  - GTMSessionFetcher/Core (1.1.13)
+  - GTMSessionFetcher/Full (1.1.13):
+    - GTMSessionFetcher/Core (= 1.1.13)
+  - Instabug (7.9.2):
+    - Instabug/Instabug (= 7.9.2)
+    - Instabug/InstabugCore (= 7.9.2)
+  - Instabug/Instabug (7.9.2):
     - Instabug/InstabugCore
-  - Instabug/InstabugCore (7.8)
+  - Instabug/InstabugCore (7.9.2)
   - MobilePlayer (1.2.0)
   - OAuthSwift (1.2.0)
   - RCMarkdownParser (3.0.4)
   - ReachabilitySwift (4.1.0)
-  - Realm (3.1.0):
-    - Realm/Headers (= 3.1.0)
-  - Realm/Headers (3.1.0)
-  - RealmSwift (3.1.0):
-    - Realm (= 3.1.0)
-  - SDWebImage (4.2.3):
-    - SDWebImage/Core (= 4.2.3)
-  - SDWebImage/Core (4.2.3)
-  - SDWebImage/GIF (4.2.3):
+  - Realm (3.1.1):
+    - Realm/Headers (= 3.1.1)
+  - Realm/Headers (3.1.1)
+  - RealmSwift (3.1.1):
+    - Realm (= 3.1.1)
+  - SDWebImage (4.3.0):
+    - SDWebImage/Core (= 4.3.0)
+  - SDWebImage/Core (4.3.0)
+  - SDWebImage/GIF (4.3.0):
     - FLAnimatedImage (~> 1.0)
     - SDWebImage/Core
   - SearchTextField (1.2.0)
@@ -54,7 +54,7 @@ PODS:
     - SDWebImage/GIF
   - SlackTextViewController (1.9.6)
   - Starscream (3.0.4)
-  - SwiftLint (0.24.2)
+  - SwiftLint (0.25.0)
   - SwiftyJSON (4.0.0)
   - TagListView (1.3.0)
 
@@ -114,29 +114,29 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
-  Crashlytics: dbb07d01876c171c5ccbdf7826410380189e452c
-  Fabric: 9cd6a848efcf1b8b07497e0b6a2e7d336353ba15
+  Crashlytics: a989ef242b66605577a425733797f810bd2725eb
+  Fabric: bb495bb9a7a7677c6d03a1f8b83d95bc49b47e41
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
   FLEX: bd1a39e55b56bb413b6f1b34b3c10a0dc44ef079
-  GoogleSignIn: 3fdaa34a2ba04dbd7a25d7db39aecb0da98d5bdc
+  GoogleSignIn: d9ef55b10f0aa401a5de2747f59b725e4b9732ac
   GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
   GTMOAuth2: c77fe325e4acd453837e72d91e3b5f13116857b2
-  GTMSessionFetcher: ebaa1f79a5366922c1735f1566901f50beba23b7
-  Instabug: 51b8f0502289c3ec3e2e66672a988d3fe6ab563a
+  GTMSessionFetcher: 5bb1eae636127de695590f50e7d248483eb891e6
+  Instabug: 03f1498c234f8b22ae2acf10b34140e9030c2b71
   MobilePlayer: 069b13482499f14c25b6ce53f63a91e17975b073
   OAuthSwift: 7fd6855b8e4d58eb5a30d156ea9bed7a8aecd1ca
   RCMarkdownParser: db98166953cad4d0045d28f627d93330b36eb7ff
   ReachabilitySwift: 6849231cd4e06559f3b9ef4a97a0a0f96d41e09f
-  Realm: 09513d7c054678d65cd02ce09871f805b0d758ac
-  RealmSwift: e868fee9b10e5490ad94b6b6ecd9027944da1824
-  SDWebImage: 791bb72962b3492327ddcac4b1880bd1b5458431
+  Realm: 42d1c38a5b1bbcc828b48a7ce702cb86fc68adf4
+  RealmSwift: d31937ca6a6ee54acde64ec839523c0a3c04924b
+  SDWebImage: 6da6c8bca115addc4de8613362e1b15f66333825
   SearchTextField: a5bb7e4c33affadb115afdbe8100d84ef10a8024
   semver: df3895a55a097c7a819a80e7375e95b29e136157
   SideMenuController: 44670bc1e1c58d9460fc028e246926227edefec0
   SimpleImageViewer: 329a155b04fcb93c5da0e296044250ad113c3158
   SlackTextViewController: b854e62c1c156336bc4fd409c6ca79b5773e8f9d
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
-  SwiftLint: 2aa21b96c8d13396a051bc1cb659d2ce1e0075b0
+  SwiftLint: e14651157288e9e01d6e1a71db7014fb5744a8ea
   SwiftyJSON: 070dabdcb1beb81b247c65ffa3a79dbbfb3b48aa
   TagListView: 669f7d4455003c877655875d34829731c4191528
 

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 		993E513A1FB1E18D006403D5 /* DraftMessageManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993E51391FB1E18D006403D5 /* DraftMessageManagerSpec.swift */; };
 		99B060CE1FB1225200F471C2 /* DraftMessageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B060CD1FB1225200F471C2 /* DraftMessageManager.swift */; };
 		A0FFC1611E8A9D8D00A1B5EA /* TintedTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0FFC1601E8A9D8D00A1B5EA /* TintedTextField.swift */; };
+		A64D90942044952F00A63BF7 /* BlockedUsersListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64D90932044952F00A63BF7 /* BlockedUsersListViewController.swift */; };
 		B5893BF41F6C4A5F00365768 /* UserReviewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5893BF31F6C4A5E00365768 /* UserReviewManager.swift */; };
 		B5893BF61F6C4B1D00365768 /* UserReviewManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5893BF51F6C4B1D00365768 /* UserReviewManagerSpec.swift */; };
 		D10E9C1A1F643457007F1796 /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10E9C191F643457007F1796 /* Channel.swift */; };
@@ -830,6 +831,7 @@
 		993E51391FB1E18D006403D5 /* DraftMessageManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DraftMessageManagerSpec.swift; path = Managers/DraftMessageManagerSpec.swift; sourceTree = "<group>"; };
 		99B060CD1FB1225200F471C2 /* DraftMessageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DraftMessageManager.swift; path = Managers/DraftMessageManager.swift; sourceTree = "<group>"; };
 		A0FFC1601E8A9D8D00A1B5EA /* TintedTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TintedTextField.swift; sourceTree = "<group>"; };
+		A64D90932044952F00A63BF7 /* BlockedUsersListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersListViewController.swift; sourceTree = "<group>"; };
 		AAC8D92081FF042E089F3063 /* Pods-Rocket.Chat.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rocket.Chat.beta.xcconfig"; path = "Pods/Target Support Files/Pods-Rocket.Chat/Pods-Rocket.Chat.beta.xcconfig"; sourceTree = "<group>"; };
 		B5893BF31F6C4A5E00365768 /* UserReviewManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserReviewManager.swift; path = Managers/UserReviewManager.swift; sourceTree = "<group>"; };
 		B5893BF51F6C4B1D00365768 /* UserReviewManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UserReviewManagerSpec.swift; path = Managers/UserReviewManagerSpec.swift; sourceTree = "<group>"; };
@@ -903,6 +905,7 @@
 				0B3A9763202C692D0019CA92 /* ChangeAppIconViewController.swift */,
 				0B3A9765202C738E0019CA92 /* ChangeAppIconViewModel.swift */,
 				0B3A9768202C76080019CA92 /* ChangeAppIconCell.swift */,
+				A64D90932044952F00A63BF7 /* BlockedUsersListViewController.swift */,
 			);
 			name = ChangeAppIcon;
 			sourceTree = "<group>";
@@ -2666,6 +2669,7 @@
 				7798B4151F852B720074B2F4 /* SelectField.swift in Sources */,
 				805DEC351FFC03380033151B /* CustomEmojiManager.swift in Sources */,
 				35E892C8201CDD1600B4BE5A /* NewRoomViewController.swift in Sources */,
+				A64D90942044952F00A63BF7 /* BlockedUsersListViewController.swift in Sources */,
 				416133321D46CA4E00E09DA2 /* ChatMessageCell.swift in Sources */,
 				8041C0422028C7EF007E21FA /* ReactorListView.swift in Sources */,
 				41DC7A1B1D38454500896FC0 /* Message.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -2143,7 +2143,6 @@
 				TargetAttributes = {
 					41DF76DE1D2C50710028DBF8 = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = S6UPZG7ZR3;
 						LastSwiftMigration = 0900;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -3133,7 +3132,7 @@
 				CODE_SIGN_ENTITLEMENTS = Rocket.Chat/Rocket.Chat.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = S6UPZG7ZR3;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Rocket.Chat/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -3155,7 +3154,7 @@
 				CODE_SIGN_ENTITLEMENTS = Rocket.Chat/Rocket.Chat.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = S6UPZG7ZR3;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Rocket.Chat/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -3294,7 +3293,7 @@
 				CODE_SIGN_ENTITLEMENTS = Rocket.Chat/Rocket.Chat.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = S6UPZG7ZR3;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Rocket.Chat/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Rocket.Chat/BlockedUsersListViewController.swift
+++ b/Rocket.Chat/BlockedUsersListViewController.swift
@@ -1,5 +1,5 @@
 //
-//  blockedUsersListViewController.swift
+//  BlockedUsersListViewController.swift
 //  Rocket.Chat
 //
 //  Created by Hrayr Yeghiazaryan on 26.02.2018.

--- a/Rocket.Chat/BlockedUsersListViewController.swift
+++ b/Rocket.Chat/BlockedUsersListViewController.swift
@@ -28,6 +28,7 @@ extension BlockedUsersListViewController {
     override func viewDidLoad() {
         registerCells()
         self.labelEmptyList.text = localized("blocked.list.empty.title")
+        title = localized("blocked.users.title")
     }
 
     func registerCells() {

--- a/Rocket.Chat/BlockedUsersListViewController.swift
+++ b/Rocket.Chat/BlockedUsersListViewController.swift
@@ -1,0 +1,141 @@
+//
+//  blockedUsersListViewController.swift
+//  Rocket.Chat
+//
+//  Created by Hrayr Yeghiazaryan on 26.02.2018.
+//  Copyright © 2018 Rocket.Chat. All rights reserved.
+//
+
+import UIKit
+import RealmSwift
+
+class BlockedUsersListViewController: BaseViewController {
+
+    fileprivate let memberCellHeight: CGFloat = 50
+
+    // UI-elements
+
+    @IBOutlet weak var membersTableView: UITableView!
+    @IBOutlet weak var viewEmptyList: UIView!
+    @IBOutlet weak var labelEmptyList: UILabel!
+
+    var realm: Realm? = Realm.shared
+}
+
+// MARK: ViewController
+
+extension BlockedUsersListViewController {
+    override func viewDidLoad() {
+        registerCells()
+        self.labelEmptyList.text = localized("blocked.list.empty.title")
+    }
+
+    func registerCells() {
+        membersTableView.register(UINib(
+            nibName: "MemberCell",
+            bundle: Bundle.main
+        ), forCellReuseIdentifier: MemberCell.identifier)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        manageEmptyView()
+    }
+}
+
+// MARK: TableViewDataSourse
+
+extension BlockedUsersListViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return MessageManager.blockedUsersList.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+
+        if let cell = tableView.dequeueReusableCell(withIdentifier: MemberCell.identifier) as? MemberCell {
+
+            guard let user = findUser(userIdentifire: MessageManager.blockedUsersList[indexPath.row], realm: self.realm) else { return cell }
+            cell.data = MemberCellData(member: user)
+            return cell
+        }
+
+        return UITableViewCell()
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return memberCellHeight
+    }
+}
+
+// MARK: TableViewDelegate
+
+extension BlockedUsersListViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard let user = findUser(userIdentifire: MessageManager.blockedUsersList[indexPath.row], realm: self.realm) else { return }
+        guard let username = user.username else { return }
+        blockedUserActions(username, user)
+    }
+
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+        guard let user = findUser(userIdentifire: MessageManager.blockedUsersList[indexPath.row], realm: self.realm) else { return }
+        if editingStyle == .delete {
+            MessageManager.unblockMessagesFrom(user, completion: {
+                UIView.performWithoutAnimation {
+                    self.manageEmptyView()
+                    self.membersTableView?.reloadData()
+                }
+            })
+        }
+    }
+}
+
+// MARK: Blocked users' actions
+
+extension BlockedUsersListViewController {
+    func blockedUserActions(_ username: String, _ user: User) {
+        if AuthManager.isAuthenticated()?.canUnblockUser(user) == .allowed {
+            let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+            alert.addAction(UIAlertAction(title: localized("chat.member.open.profile.title"), style: .default, handler: { _ in
+                AppManager.openDirectMessage(username: username) {
+                    self.dismiss(animated: true, completion: nil)
+                }
+            }))
+            alert.addAction(UIAlertAction(title: localized("chat.member.unblock.title"), style: .destructive, handler: { _ in
+                MessageManager.unblockMessagesFrom(user, completion: {
+                    UIView.performWithoutAnimation {
+                        self.manageEmptyView()
+                        self.membersTableView?.reloadData()
+                    }
+                })
+            }))
+            alert.addAction(UIAlertAction(title: localized("global.cancel"), style: .cancel, handler: nil))
+
+            if let presenter = alert.popoverPresentationController {
+                presenter.sourceView = view
+                presenter.sourceRect = view.bounds
+            }
+            present(alert, animated: true, completion: nil)
+        }
+    }
+
+    func findUser(userIdentifire: String, realm: Realm? = Realm.shared) -> User! {
+        guard
+            let realm = realm,
+            let user = realm.object(ofType: User.self, forPrimaryKey: userIdentifire)
+            else {
+                return nil
+        }
+        return user
+    }
+
+    // If we don't have blocked users the emptyView won't be hidden
+
+    func manageEmptyView() {
+        if MessageManager.blockedUsersList.count == 0 {
+            self.viewEmptyList.isHidden = false
+        } else {
+            self.viewEmptyList.isHidden = true
+        }
+    }
+}

--- a/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
@@ -195,8 +195,7 @@ extension MembersListViewController: UITableViewDelegate {
 
 extension MembersListViewController {
     func checkUserBlockState(_ user: User) {
-        let isBlocked = MessageManager.blockedUsersList.contains(user.identifier!)
-        if isBlocked == true {
+        if AuthManager.isAuthenticated()?.canUnblockUser(user) == .allowed {
             let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
             alert.addAction(UIAlertAction(title: "Open Profile", style: .default, handler: { [weak self] _ in
                 self?.delegate?.membersList(self!, didSelectUser: user)
@@ -214,7 +213,7 @@ extension MembersListViewController {
             }
             present(alert, animated: true, completion: nil)
         } else {
-            delegate?.membersList(self, didSelectUser: user)
+            delegate?.membersList(self, didSelectUser: user);
         }
     }
 }

--- a/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
@@ -197,10 +197,10 @@ extension MembersListViewController {
     func checkUserBlockState(_ user: User) {
         if AuthManager.isAuthenticated()?.canUnblockUser(user) == .allowed {
             let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-            alert.addAction(UIAlertAction(title: "Open Profile", style: .default, handler: { [weak self] _ in
+            alert.addAction(UIAlertAction(title: localized("chat.member.unblock.title"), style: .default, handler: { [weak self] _ in
                 self?.delegate?.membersList(self!, didSelectUser: user)
             }))
-            alert.addAction(UIAlertAction(title: "Unblock", style: .destructive, handler: { _ in
+            alert.addAction(UIAlertAction(title: localized("chat.member.open.profile.title"), style: .destructive, handler: { _ in
                 MessageManager.unblockMessagesFrom(user, completion: {
                     //Do nothing
                 })

--- a/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
@@ -183,12 +183,40 @@ extension MembersListViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
 
         let user = data.member(at: indexPath.row)
-        delegate?.membersList(self, didSelectUser: user)
+        self.checkUserBlockState(user)
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if indexPath.row == data.members.count - data.pageSize/2 {
             loadMoreMembers()
+        }
+    }
+}
+
+extension MembersListViewController {
+    func checkUserBlockState(_ user: User) {
+        let isBlocked = MessageManager.blockedUsersList.contains(user.identifier!)
+        if isBlocked == true {
+            let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+            alert.addAction(UIAlertAction(title: "Open Profile", style: .default, handler: { [weak self] _ in
+                self?.delegate?.membersList(self!, didSelectUser: user)
+            }))
+            alert.addAction(UIAlertAction(title: "Unblock", style: .destructive, handler: { _ in
+                MessageManager.unblockMessagesFrom(user, completion: {
+                    //Do nothing
+                })
+            }))
+            alert.addAction(UIAlertAction(title: localized("global.cancel"), style: .cancel, handler: nil))
+
+            if let presenter = alert.popoverPresentationController {
+                presenter.sourceView = view
+                presenter.sourceRect = view.bounds
+            }
+
+            present(alert, animated: true, completion: nil)
+        } else {
+            delegate?.membersList(self, didSelectUser: user)
         }
     }
 }

--- a/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
@@ -213,7 +213,7 @@ extension MembersListViewController {
             }
             present(alert, animated: true, completion: nil)
         } else {
-            delegate?.membersList(self, didSelectUser: user);
+            delegate?.membersList(self, didSelectUser: user)
         }
     }
 }

--- a/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
@@ -198,7 +198,6 @@ extension MembersListViewController {
         let isBlocked = MessageManager.blockedUsersList.contains(user.identifier!)
         if isBlocked == true {
             let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-
             alert.addAction(UIAlertAction(title: "Open Profile", style: .default, handler: { [weak self] _ in
                 self?.delegate?.membersList(self!, didSelectUser: user)
             }))
@@ -213,7 +212,6 @@ extension MembersListViewController {
                 presenter.sourceView = view
                 presenter.sourceRect = view.bounds
             }
-
             present(alert, animated: true, completion: nil)
         } else {
             delegate?.membersList(self, didSelectUser: user)

--- a/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
@@ -183,37 +183,12 @@ extension MembersListViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
 
         let user = data.member(at: indexPath.row)
-        self.checkUserBlockState(user)
+        self.delegate?.membersList(self, didSelectUser: user)
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if indexPath.row == data.members.count - data.pageSize/2 {
             loadMoreMembers()
-        }
-    }
-}
-
-extension MembersListViewController {
-    func checkUserBlockState(_ user: User) {
-        if AuthManager.isAuthenticated()?.canUnblockUser(user) == .allowed {
-            let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-            alert.addAction(UIAlertAction(title: localized("chat.member.unblock.title"), style: .default, handler: { [weak self] _ in
-                self?.delegate?.membersList(self!, didSelectUser: user)
-            }))
-            alert.addAction(UIAlertAction(title: localized("chat.member.open.profile.title"), style: .destructive, handler: { _ in
-                MessageManager.unblockMessagesFrom(user, completion: {
-                    //Do nothing
-                })
-            }))
-            alert.addAction(UIAlertAction(title: localized("global.cancel"), style: .cancel, handler: nil))
-
-            if let presenter = alert.popoverPresentationController {
-                presenter.sourceView = view
-                presenter.sourceRect = view.bounds
-            }
-            present(alert, animated: true, completion: nil)
-        } else {
-            delegate?.membersList(self, didSelectUser: user)
         }
     }
 }

--- a/Rocket.Chat/Controllers/Settings/SettingsViewController.swift
+++ b/Rocket.Chat/Controllers/Settings/SettingsViewController.swift
@@ -18,6 +18,11 @@ final class SettingsViewController: UITableViewController {
 
     private let viewModel = SettingsViewModel()
 
+    @IBOutlet weak var labelBlockedUsers: UILabel! {
+        didSet {
+            labelBlockedUsers.text = viewModel.blockedUsersList
+        }
+    }
     @IBOutlet weak var labelContactUs: UILabel! {
         didSet {
             labelContactUs.text = viewModel.contactus
@@ -83,15 +88,16 @@ final class SettingsViewController: UITableViewController {
         performSegue(withIdentifier: "AppIcon", sender: nil)
     }
 
+
     // MARK: UITableViewDelegate
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if indexPath.section == 0 {
-            if indexPath.row == 0 {
+            if indexPath.row == 1 {
                 cellContactDidPressed()
-            } else if indexPath.row == 1 {
+            } else if indexPath.row == 2 {
                 cellTermsOfServiceDidPressed()
-            } else if indexPath.row == 3 {
+            } else if indexPath.row == 4 {
                 cellAppIconDidPressed()
             }
         }

--- a/Rocket.Chat/Controllers/Settings/SettingsViewModel.swift
+++ b/Rocket.Chat/Controllers/Settings/SettingsViewModel.swift
@@ -19,6 +19,10 @@ final class SettingsViewModel {
         return localized("myaccount.settings.title")
     }
 
+    internal var blockedUsersList: String {
+        return "Blocked Users"
+    }
+
     internal var contactus: String {
         return localized("myaccount.settings.contactus")
     }

--- a/Rocket.Chat/Controllers/Settings/SettingsViewModel.swift
+++ b/Rocket.Chat/Controllers/Settings/SettingsViewModel.swift
@@ -20,7 +20,7 @@ final class SettingsViewModel {
     }
 
     internal var blockedUsersList: String {
-        return "Blocked Users"
+        return localized("blocked.users.title")
     }
 
     internal var contactus: String {

--- a/Rocket.Chat/Managers/Model/MessageManager.swift
+++ b/Rocket.Chat/Managers/Model/MessageManager.swift
@@ -199,5 +199,25 @@ extension MessageManager {
             }
         })
     }
+    
+    static func unblockMessagesFrom(_ user: User, completion: @escaping VoidCompletion) {
+        guard let userIdentifier = user.identifier else { return }
+        var blockedUsers: [String] = UserDefaults.standard.value(forKey: kBlockedUsersIndentifiers) as? [String] ?? []
+        blockedUsers.remove(object: userIdentifier)
+        UserDefaults.standard.setValue(blockedUsers, forKey: kBlockedUsersIndentifiers)
+        self.blockedUsersList = blockedUsers
+
+        Realm.execute({ (realm) in
+            let messages = realm.objects(Message.self).filter("user.identifier = '\(userIdentifier)'")
+
+            for message in messages {
+                message.userBlocked = false
+            }
+
+            DispatchQueue.main.async {
+                completion()
+            }
+        })
+    }
 
 }

--- a/Rocket.Chat/Managers/Model/MessageManager.swift
+++ b/Rocket.Chat/Managers/Model/MessageManager.swift
@@ -199,7 +199,7 @@ extension MessageManager {
             }
         })
     }
-    
+
     static func unblockMessagesFrom(_ user: User, completion: @escaping VoidCompletion) {
         guard let userIdentifier = user.identifier else { return }
         var blockedUsers: [String] = UserDefaults.standard.value(forKey: kBlockedUsersIndentifiers) as? [String] ?? []

--- a/Rocket.Chat/Models/Auth.swift
+++ b/Rocket.Chat/Models/Auth.swift
@@ -172,10 +172,12 @@ extension Auth {
     enum CanUnblockUserResult {
         case allowed
         case notActionable
+        case unknown
     }
 
     func canUnblockUser(_ user: User) -> CanUnblockUserResult {
-        let isBlocked = MessageManager.blockedUsersList.contains(user.identifier!)
+        guard let userIdentifire = user.identifier else { return .unknown }
+        let isBlocked = MessageManager.blockedUsersList.contains(userIdentifire)
         if !isBlocked {
             return .notActionable
         }

--- a/Rocket.Chat/Models/Auth.swift
+++ b/Rocket.Chat/Models/Auth.swift
@@ -167,3 +167,18 @@ extension Auth {
         return .allowed
     }
 }
+
+extension Auth {
+    enum CanUnblockUserResult {
+        case allowed
+        case notActionable
+    }
+
+    func canUnblockUser(_ user: User) -> CanUnblockUserResult {
+        let isBlocked = MessageManager.blockedUsersList.contains(user.identifier!)
+        if !isBlocked {
+            return .notActionable
+        }
+        return .allowed
+    }
+}

--- a/Rocket.Chat/Resources/cs.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/cs.lproj/Localizable.strings
@@ -184,6 +184,8 @@
 
 // Members List
 "chat.members.list.title" = "Členové";
+"chat.member.unblock.title" = "Odblokovat";
+"chat.member.open.profile.title" = "Otevřít profil";
 
 // Messages List
 "chat.messages.list.title" = "Zprávy";

--- a/Rocket.Chat/Resources/cs.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/cs.lproj/Localizable.strings
@@ -200,6 +200,7 @@
 "myaccount.settings.appicon" = "Application Icon"; // TODO:
 "myaccount.settings.version" = "Version: %@ (%@)";
 "blocked.list.empty.title" = "Prázdný";
+"blocked.users.title" = "Blokovaní uživatelé";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Choose Icon"; // TODO:

--- a/Rocket.Chat/Resources/cs.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/cs.lproj/Localizable.strings
@@ -199,6 +199,7 @@
 "myaccount.settings.license" = "License";
 "myaccount.settings.appicon" = "Application Icon"; // TODO:
 "myaccount.settings.version" = "Version: %@ (%@)";
+"blocked.list.empty.title" = "Prázdný";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Choose Icon"; // TODO:

--- a/Rocket.Chat/Resources/de.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/de.lproj/Localizable.strings
@@ -199,6 +199,7 @@
 "myaccount.settings.license" = "Lizenz";
 "myaccount.settings.appicon" = "App Icon"; // TODO:
 "myaccount.settings.version" = "Version: %@ (%@)";
+"blocked.list.empty.title" = "Leer";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Icon auswählen";

--- a/Rocket.Chat/Resources/de.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/de.lproj/Localizable.strings
@@ -200,6 +200,7 @@
 "myaccount.settings.appicon" = "App Icon"; // TODO:
 "myaccount.settings.version" = "Version: %@ (%@)";
 "blocked.list.empty.title" = "Leer";
+"blocked.users.title" = "Blockierte Benutzer";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Icon auswählen";

--- a/Rocket.Chat/Resources/de.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/de.lproj/Localizable.strings
@@ -184,6 +184,8 @@
 
 // Members List
 "chat.members.list.title" = "Mitglieder";
+"chat.member.unblock.title" = "Entsperren";
+"chat.member.open.profile.title" = "Profil öffnen";
 
 // Messages List
 "chat.messages.list.title" = "Nachrichten";

--- a/Rocket.Chat/Resources/en.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/en.lproj/Localizable.strings
@@ -184,6 +184,8 @@
 
 // Members List
 "chat.members.list.title" = "Members";
+"chat.member.unblock.title" = "Unblock";
+"chat.member.open.profile.title" = "Open Profile";
 
 // Messages List
 "chat.messages.list.title" = "Messages";

--- a/Rocket.Chat/Resources/en.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/en.lproj/Localizable.strings
@@ -200,6 +200,7 @@
 "myaccount.settings.appicon" = "Application Icon";
 "myaccount.settings.version" = "Version: %@ (%@)";
 "blocked.list.empty.title" = "Empty";
+"blocked.users.title" = "Blocked Users";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Choose Icon";

--- a/Rocket.Chat/Resources/en.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/en.lproj/Localizable.strings
@@ -199,6 +199,7 @@
 "myaccount.settings.license" = "License";
 "myaccount.settings.appicon" = "Application Icon";
 "myaccount.settings.version" = "Version: %@ (%@)";
+"blocked.list.empty.title" = "Empty";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Choose Icon";

--- a/Rocket.Chat/Resources/fr.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/fr.lproj/Localizable.strings
@@ -199,6 +199,7 @@
 "myaccount.settings.license" = "Licence";
 "myaccount.settings.appicon" = "Application Icon"; // TODO:
 "myaccount.settings.version" = "Version : %@ (%@)";
+"blocked.list.empty.title" = "Vide";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Choose Icon"; // TODO:

--- a/Rocket.Chat/Resources/fr.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/fr.lproj/Localizable.strings
@@ -184,6 +184,8 @@
 
 // Members List
 "chat.members.list.title" = "Membres";
+"chat.member.unblock.title" = "Débloquer";
+"chat.member.open.profile.title" = "Ouvrir le profil";
 
 // Messages List
 "chat.messages.list.title" = "Messages";

--- a/Rocket.Chat/Resources/fr.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/fr.lproj/Localizable.strings
@@ -200,6 +200,7 @@
 "myaccount.settings.appicon" = "Application Icon"; // TODO:
 "myaccount.settings.version" = "Version : %@ (%@)";
 "blocked.list.empty.title" = "Vide";
+"blocked.users.title" = "Utilisateurs bloqués";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Choose Icon"; // TODO:

--- a/Rocket.Chat/Resources/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pl.lproj/Localizable.strings
@@ -199,6 +199,7 @@
 "myaccount.settings.license" = "Licencja";
 "myaccount.settings.appicon" = "Ikona aplikacji";
 "myaccount.settings.version" = "Wersja: %@ (%@)";
+"blocked.list.empty.title" = "Pusty";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Wybierz ikonę";

--- a/Rocket.Chat/Resources/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pl.lproj/Localizable.strings
@@ -184,7 +184,7 @@
 
 // Members List
 "chat.members.list.title" = "Członkowie";
-"chat.member.unblock.title" = "Odblokować";
+"chat.member.unblock.title" = "Odblokuj";
 "chat.member.open.profile.title" = "Otwórz profil";
 
 // Messages List

--- a/Rocket.Chat/Resources/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pl.lproj/Localizable.strings
@@ -200,6 +200,7 @@
 "myaccount.settings.appicon" = "Ikona aplikacji";
 "myaccount.settings.version" = "Wersja: %@ (%@)";
 "blocked.list.empty.title" = "Pusty";
+"blocked.users.title" = "Zablokowani użytkownicy";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Wybierz ikonę";

--- a/Rocket.Chat/Resources/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pl.lproj/Localizable.strings
@@ -184,6 +184,8 @@
 
 // Members List
 "chat.members.list.title" = "Członkowie";
+"chat.member.unblock.title" = "Odblokować";
+"chat.member.open.profile.title" = "Otwórz profil";
 
 // Messages List
 "chat.messages.list.title" = "Wiadomości";

--- a/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
@@ -184,6 +184,8 @@
 
 // Members List
 "chat.members.list.title" = "Membros";
+"chat.member.unblock.title" = "Desbloquear";
+"chat.member.open.profile.title" = "Perfil aberto";
 
 // Messages List
 "chat.messages.list.title" = "Mensagens";

--- a/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
@@ -199,6 +199,7 @@
 "myaccount.settings.license" = "Licença";
 "myaccount.settings.appicon" = "Ícone do App";
 "myaccount.settings.version" = "Versão: %@ (%@)";
+"blocked.list.empty.title" = "Vazio";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Escolher Ícone";

--- a/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
@@ -200,6 +200,7 @@
 "myaccount.settings.appicon" = "Ícone do App";
 "myaccount.settings.version" = "Versão: %@ (%@)";
 "blocked.list.empty.title" = "Vazio";
+"blocked.users.title" = "Usuários bloqueados";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Escolher Ícone";

--- a/Rocket.Chat/Storyboards/Settings.storyboard
+++ b/Rocket.Chat/Storyboards/Settings.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="bDT-Aq-lo9">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="bDT-Aq-lo9">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,8 +21,31 @@
                         <sections>
                             <tableViewSection headerTitle="" id="rV1-jP-rln">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="SsA-Jk-og1" style="IBUITableViewCellStyleDefault" id="HgJ-cu-Kpu">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="izS-7n-lNJ">
                                         <rect key="frame" x="0.0" y="35" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="izS-7n-lNJ" id="NrY-tu-9pf">
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blocked Users" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W3h-g9-wyL">
+                                                    <rect key="frame" x="16" y="12" width="110.5" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="W3h-g9-wyL" firstAttribute="leading" secondItem="NrY-tu-9pf" secondAttribute="leading" constant="16" id="h8q-K4-xZq"/>
+                                                <constraint firstItem="W3h-g9-wyL" firstAttribute="top" secondItem="NrY-tu-9pf" secondAttribute="top" constant="12" id="skL-UR-HiC"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="DM9-Aa-1h2" kind="show" id="uv6-dU-a2q"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="SsA-Jk-og1" style="IBUITableViewCellStyleDefault" id="HgJ-cu-Kpu">
+                                        <rect key="frame" x="0.0" y="79" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="HgJ-cu-Kpu" id="4Yv-ei-dlx">
                                             <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
@@ -39,7 +62,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="kCF-5t-4W3" style="IBUITableViewCellStyleDefault" id="63z-0h-dAR">
-                                        <rect key="frame" x="0.0" y="79" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="123" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="63z-0h-dAR" id="Q2E-Ak-LhM">
                                             <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
@@ -56,7 +79,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="vOz-GO-Ifh" style="IBUITableViewCellStyleDefault" id="wKh-tm-uOE">
-                                        <rect key="frame" x="0.0" y="123" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="167" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="wKh-tm-uOE" id="aJM-SI-xul">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -73,7 +96,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Lk4-H3-Y3R" style="IBUITableViewCellStyleDefault" id="lxd-VJ-cx9">
-                                        <rect key="frame" x="0.0" y="167" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="211" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lxd-VJ-cx9" id="qDS-Nm-GOO">
                                             <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
@@ -94,7 +117,7 @@
                             <tableViewSection headerTitle="" id="zht-D2-Ukj">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="oil-aF-gql" style="IBUITableViewCellStyleDefault" id="yhE-s9-IkN">
-                                        <rect key="frame" x="0.0" y="247" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="291" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="yhE-s9-IkN" id="G20-Xa-L7g">
                                             <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
@@ -127,6 +150,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="labelApp" destination="Lk4-H3-Y3R" id="jIL-6y-wNg"/>
+                        <outlet property="labelBlockedUsers" destination="W3h-g9-wyL" id="Fzo-fp-Jab"/>
                         <outlet property="labelContactUs" destination="SsA-Jk-og1" id="BZe-mM-eck"/>
                         <outlet property="labelLicense" destination="kCF-5t-4W3" id="bt0-I5-0WI"/>
                         <outlet property="labelVersion" destination="vOz-GO-Ifh" id="14X-a4-dRc"/>
@@ -135,7 +159,66 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="O5x-0L-i2I" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="281" y="2"/>
+            <point key="canvasLocation" x="280.80000000000001" y="1.3493253373313345"/>
+        </scene>
+        <!--Blocked Users List View Controller-->
+        <scene sceneID="iUD-cG-GOY">
+            <objects>
+                <viewController id="DM9-Aa-1h2" customClass="BlockedUsersListViewController" customModule="Rocket_Chat" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="6gh-9W-xeY"/>
+                        <viewControllerLayoutGuide type="bottom" id="GZX-m5-M9A"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="WMP-g1-gZk">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="eF0-vL-R4Q">
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="DM9-Aa-1h2" id="x7I-OX-sJt"/>
+                                    <outlet property="delegate" destination="DM9-Aa-1h2" id="IWP-dd-HQt"/>
+                                </connections>
+                            </tableView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9WK-MC-3ED">
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SKn-ym-i0o">
+                                        <rect key="frame" x="166" y="291.5" width="42" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="SKn-ym-i0o" firstAttribute="centerX" secondItem="9WK-MC-3ED" secondAttribute="centerX" id="4ww-3W-Jko"/>
+                                    <constraint firstItem="SKn-ym-i0o" firstAttribute="centerY" secondItem="9WK-MC-3ED" secondAttribute="centerY" id="AtB-et-MFk"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="eF0-vL-R4Q" secondAttribute="trailing" id="Q1t-Ws-2A4"/>
+                            <constraint firstAttribute="trailing" secondItem="9WK-MC-3ED" secondAttribute="trailing" id="WpE-RS-4mA"/>
+                            <constraint firstItem="eF0-vL-R4Q" firstAttribute="top" secondItem="6gh-9W-xeY" secondAttribute="bottom" id="b5q-Fi-uM5"/>
+                            <constraint firstItem="eF0-vL-R4Q" firstAttribute="leading" secondItem="WMP-g1-gZk" secondAttribute="leading" id="lkt-m9-Ltz"/>
+                            <constraint firstItem="GZX-m5-M9A" firstAttribute="top" secondItem="9WK-MC-3ED" secondAttribute="bottom" id="m2E-8v-ylY"/>
+                            <constraint firstItem="GZX-m5-M9A" firstAttribute="top" secondItem="eF0-vL-R4Q" secondAttribute="bottom" id="mov-vU-A4d"/>
+                            <constraint firstItem="9WK-MC-3ED" firstAttribute="leading" secondItem="WMP-g1-gZk" secondAttribute="leading" id="qJ4-tv-03t"/>
+                            <constraint firstItem="9WK-MC-3ED" firstAttribute="top" secondItem="6gh-9W-xeY" secondAttribute="bottom" id="rlg-UX-1CN"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="labelEmptyList" destination="SKn-ym-i0o" id="lT8-L5-Un8"/>
+                        <outlet property="membersTableView" destination="eF0-vL-R4Q" id="Pfd-rk-3aV"/>
+                        <outlet property="viewEmptyList" destination="9WK-MC-3ED" id="DSM-W7-9au"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6pB-t1-7M2" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1157.5999999999999" y="-681.40929535232385"/>
         </scene>
         <!--Change App Icon View Controller-->
         <scene sceneID="PDd-r9-Apx">

--- a/Rocket.ChatTests/Extensions/DateExtensionsSpec.swift
+++ b/Rocket.ChatTests/Extensions/DateExtensionsSpec.swift
@@ -40,7 +40,7 @@ class DateExtension: XCTestCase {
 
         XCTAssertEqual(date.year, "2017", "Year is correct")
         XCTAssertEqual(date.month, "04", "Month is correct")
-        XCTAssertEqual(date.day, "27", "Day is correct")
+        XCTAssertEqual(date.day, "26", "Day is correct")
     }
 
     func testSameDayAs() {

--- a/Rocket.ChatTests/Extensions/DateExtensionsSpec.swift
+++ b/Rocket.ChatTests/Extensions/DateExtensionsSpec.swift
@@ -40,7 +40,7 @@ class DateExtension: XCTestCase {
 
         XCTAssertEqual(date.year, "2017", "Year is correct")
         XCTAssertEqual(date.month, "04", "Month is correct")
-        XCTAssertEqual(date.day, "26", "Day is correct")
+        XCTAssertEqual(date.day, "27", "Day is correct")
     }
 
     func testSameDayAs() {

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -342,15 +342,7 @@ class AuthSpec: XCTestCase, RealmTestCase {
             realm.add(user2)
         }
 
-        XCTAssert(auth.canUnblockUser(message) == .allowed)
-
-        // my own message
-
-        try? realm.write {
-            message.user = user1
-        }
-
-        XCTAssert(auth.canUnblockUser(message) == .myOwn)
+        XCTAssert(auth.canUnblockUser(message.user!) == .allowed)
 
         // non actionable message type
 
@@ -359,6 +351,6 @@ class AuthSpec: XCTestCase, RealmTestCase {
             message.internalType = MessageType.userJoined.rawValue
         }
 
-        XCTAssert(auth.canUnblockUser(message) == .notActionable)
+        XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
     }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -334,7 +334,7 @@ class AuthSpec: XCTestCase, RealmTestCase {
         message.identifier = "mid"
         message.user = user2
         message.userBlocked = false
-        // unblock-user
+        // user state is "unblocked"
 
         try? realm.write {
             realm.add(auth)
@@ -343,5 +343,11 @@ class AuthSpec: XCTestCase, RealmTestCase {
         }
 
         XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
+
+        // user state is "blocked"
+
+        MessageManager.blockedUsersList.append(message.user!.identifier!)
+        XCTAssert(auth.canUnblockUser(message.user!) == .allowed)
+        MessageManager.blockedUsersList.remove(object: message.user!.identifier!)
     }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -317,4 +317,48 @@ class AuthSpec: XCTestCase, RealmTestCase {
         XCTAssert(auth.canBlockMessage(message) == .notActionable)
 
     }
+
+    func testCanUnblockUser() {
+        let realm = testRealm()
+
+        let user1 = User.testInstance()
+        user1.identifier = "uid1"
+
+        let user2 = User.testInstance()
+        user2.identifier = "uid2"
+
+        let auth = Auth.testInstance()
+        auth.userId = user1.identifier
+
+        let message = Message.testInstance()
+        message.identifier = "mid"
+        message.user = user2
+
+        // block-message
+
+        try? realm.write {
+            realm.add(auth)
+            realm.add(user1)
+            realm.add(user2)
+        }
+
+        XCTAssert(auth.canUnblockUser(message) == .allowed)
+
+        // my own message
+
+        try? realm.write {
+            message.user = user1
+        }
+
+        XCTAssert(auth.canUnblockUser(message) == .myOwn)
+
+        // non actionable message type
+
+        try? realm.write {
+            message.createdAt = Date()
+            message.internalType = MessageType.userJoined.rawValue
+        }
+
+        XCTAssert(auth.canUnblockUser(message) == .notActionable)
+    }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -319,6 +319,29 @@ class AuthSpec: XCTestCase, RealmTestCase {
     }
 
     func testCanUnblockUser() {
-        
+        let realm = testRealm()
+
+        let user1 = User.testInstance()
+        user1.identifier = "uid1"
+
+        let user2 = User.testInstance()
+        user2.identifier = "uid2"
+
+        let auth = Auth.testInstance()
+        auth.userId = user1.identifier
+
+        let message = Message.testInstance()
+        message.identifier = "mid"
+        message.user = user2
+        message.userBlocked = false
+        // unblock-user
+
+        try? realm.write {
+            realm.add(auth)
+            realm.add(user1)
+            realm.add(user2)
+        }
+
+        XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
     }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -342,7 +342,15 @@ class AuthSpec: XCTestCase, RealmTestCase {
             realm.add(user2)
         }
 
-        XCTAssert(auth.canUnblockUser(message.user!) == .allowed)
+        XCTAssert(auth.canBlockMessage(message) == .allowed)
+
+        // my own message
+
+        try? realm.write {
+            message.user = user1
+        }
+
+        XCTAssert(auth.canBlockMessage(message) == .myOwn)
 
         // non actionable message type
 
@@ -351,6 +359,6 @@ class AuthSpec: XCTestCase, RealmTestCase {
             message.internalType = MessageType.userJoined.rawValue
         }
 
-        XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
+        XCTAssert(auth.canBlockMessage(message) == .notActionable)
     }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -319,36 +319,6 @@ class AuthSpec: XCTestCase, RealmTestCase {
     }
 
     func testCanUnblockUser() {
-        let realm = testRealm()
-
-        let user = User.testInstance()
-        user.identifier = "uid1"
-
-        let auth = Auth.testInstance()
-        auth.userId = user.identifier
-
-        let message = Message.testInstance()
-        message.identifier = "mid"
-        message.user = user
-        message.userBlocked = true
-
-        // block-user
-
-        try? realm.write {
-            realm.add(auth)
-            realm.add(user)
-        }
-
-        XCTAssert(auth.canUnblockUser(message.user!) == .allowed)
-
-        // non actionable user status
-
-        try? realm.write {
-            message.createdAt = Date()
-            message.internalType = MessageType.userJoined.rawValue
-            message.userBlocked = false;
-        }
-
-        XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
+        
     }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -331,5 +331,24 @@ class AuthSpec: XCTestCase, RealmTestCase {
         message.identifier = "mid"
         message.user = user
         message.userBlocked = true
+
+        // block-user
+
+        try? realm.write {
+            realm.add(auth)
+            realm.add(user)
+        }
+
+        XCTAssert(auth.canUnblockUser(message.user!) == .allowed)
+
+        // non actionable user status
+
+        try? realm.write {
+            message.createdAt = Date()
+            message.internalType = MessageType.userJoined.rawValue
+            message.userBlocked = false;
+        }
+
+        XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
     }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -331,22 +331,5 @@ class AuthSpec: XCTestCase, RealmTestCase {
         message.identifier = "mid"
         message.user = user
         message.userBlocked = true
-
-        // block-user
-
-        try? realm.write {
-            realm.add(auth)
-            realm.add(user)
-        }
-
-        XCTAssert(auth.canUnblockUser(message.user!) == .allowed)
-
-        // non actionable user status
-
-        try? realm.write {
-            message.userBlocked = false;
-        }
-
-        XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
     }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -321,44 +321,32 @@ class AuthSpec: XCTestCase, RealmTestCase {
     func testCanUnblockUser() {
         let realm = testRealm()
 
-        let user1 = User.testInstance()
-        user1.identifier = "uid1"
-
-        let user2 = User.testInstance()
-        user2.identifier = "uid2"
+        let user = User.testInstance()
+        user.identifier = "uid1"
 
         let auth = Auth.testInstance()
-        auth.userId = user1.identifier
+        auth.userId = user.identifier
 
         let message = Message.testInstance()
         message.identifier = "mid"
-        message.user = user2
+        message.user = user
+        message.userBlocked = true
 
-        // block-message
+        // block-user
 
         try? realm.write {
             realm.add(auth)
-            realm.add(user1)
-            realm.add(user2)
+            realm.add(user)
         }
 
-        XCTAssert(auth.canBlockMessage(message) == .allowed)
+        XCTAssert(auth.canUnblockUser(message.user!) == .allowed)
 
-        // my own message
+        // non actionable user status
 
         try? realm.write {
-            message.user = user1
+            message.userBlocked = false;
         }
 
-        XCTAssert(auth.canBlockMessage(message) == .myOwn)
-
-        // non actionable message type
-
-        try? realm.write {
-            message.createdAt = Date()
-            message.internalType = MessageType.userJoined.rawValue
-        }
-
-        XCTAssert(auth.canBlockMessage(message) == .notActionable)
+        XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
     }
 }

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -342,12 +342,15 @@ class AuthSpec: XCTestCase, RealmTestCase {
             realm.add(user2)
         }
 
-        XCTAssert(auth.canUnblockUser(message.user!) == .notActionable)
+        guard let user = message.user else { return }
+        XCTAssert(auth.canUnblockUser(user) == .notActionable)
 
         // user state is "blocked"
 
-        MessageManager.blockedUsersList.append(message.user!.identifier!)
-        XCTAssert(auth.canUnblockUser(message.user!) == .allowed)
-        MessageManager.blockedUsersList.remove(object: message.user!.identifier!)
+        guard let userIdentifire = user.identifier else { return }
+
+        MessageManager.blockedUsersList.append(userIdentifire)
+        XCTAssert(auth.canUnblockUser(user) == .allowed)
+        MessageManager.blockedUsersList.remove(object: userIdentifire)
     }
 }


### PR DESCRIPTION
@RocketChat/ios 

I've added the new page in Settings - "Blocked Users".

Now we can tap on member cell in Blocked Users page and see Action Sheet with actions "Open Profile", "Unblock" and "Cancel".

- 'Open Profile' opens the info page
- 'Unblock action' calls the method unblockMessagesFrom from MessageManager
- Also we show the "empty view" if our blocked users' list is empty

![2018-02-28 0 23 00](https://user-images.githubusercontent.com/16138494/36752812-a37f57d0-1c1d-11e8-8a78-9c12b1d57de1.png)

![2018-02-28 0 52 37](https://user-images.githubusercontent.com/16138494/36754183-c2dcdf18-1c21-11e8-85e3-9d61e298adac.png)

![2018-02-28 0 52 45](https://user-images.githubusercontent.com/16138494/36754184-c3ee993c-1c21-11e8-9e68-a42a4923b9f0.png)

![2018-02-28 0 54 22](https://user-images.githubusercontent.com/16138494/36754260-f14a7928-1c21-11e8-847f-24155cac3d2d.png)