### PR TITLE
[WIP][NEW] Allow user to see all attachments in a channel/group/DM

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChannelInfoViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChannelInfoViewController.swift
@@ -25,7 +25,8 @@ class ChannelInfoViewController: BaseViewController {
             let channelInfoData = [
                 ChannelInfoDetailCellData(title: localized("chat.info.item.members"), detail: "", action: showMembersList),
                 ChannelInfoDetailCellData(title: localized("chat.info.item.pinned"), detail: "", action: showPinnedList),
-                ChannelInfoDetailCellData(title: localized("chat.info.item.starred"), detail: "", action: showStarredList)
+                ChannelInfoDetailCellData(title: localized("chat.info.item.starred"), detail: "", action: showStarredList),
+                ChannelInfoDetailCellData(title: "Files list", detail: "", action: showFilesList)
             ]
 
             if subscription.type == .directMessage {
@@ -100,6 +101,10 @@ class ChannelInfoViewController: BaseViewController {
 
         let data = ListSegueData(title: localized("chat.messages.starred.list.title"), query: "{\"starred._id\":{\"$in\":[\"\(userId)\"]}}")
         self.performSegue(withIdentifier: "toMessagesList", sender: data)
+    }
+
+    func showFilesList() {
+        //Do nothing
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {


### PR DESCRIPTION
@RocketChat/ios

I've started this feature, but I need more information for creating correct and successful structure. What classes should I use? How can I get info from backend about channels, groups and DM?
I guess, that new page with files should be Collection View, what is your opinion?

![2018-02-25 20 23 04](https://user-images.githubusercontent.com/16138494/36644095-be339f56-1a6e-11e8-8e1d-6595495bde45.png)
