### PR TITLE
[HOTFIX] Escape regex characters in emoji shortnames before parsing

### DIFF
--- a/Rocket.Chat/External/RCEmojiKit/Emojione.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Emojione.swift
@@ -23,7 +23,7 @@ struct Emojione {
     }
 
     static var regex: String = {
-        Emojione.values.keys.reduce("") { $0.isEmpty ? ":\($1):" : "\($0)|:\($1):" }
+        Emojione.values.keys.flatMap { $0.escapingRegex() }.reduce("") { $0.isEmpty ? ":\($1):" : "\($0)|:\($1):" }
     }()
 
     static let values = [

--- a/Rocket.Chat/External/RCEmojiKit/NSAttributedString+CustomEmojis.swift
+++ b/Rocket.Chat/External/RCEmojiKit/NSAttributedString+CustomEmojis.swift
@@ -1,5 +1,5 @@
 //
-//  NSAttributedString+Extensions.swift
+//  NSAttributedString+CustomEmojis.swift
 //  Rocket.Chat
 //
 //  Created by Matheus Cardoso on 1/5/18.
@@ -18,7 +18,7 @@ extension NSAttributedString {
 
             let alternates = emoji.alternates.filter { !$0.isEmpty }
 
-            let regexPattern = ":\(emoji.shortname):" + (alternates.isEmpty ? "" : "|:\(alternates.joined(separator: ":|:")):")
+            let regexPattern = ([emoji.shortname] + alternates).flatMap { $0.escapingRegex() }.reduce("") { $0.isEmpty ? ":\($1):" : "\($0)|:\($1):" }
 
             guard let regex = try? NSRegularExpression(pattern: regexPattern, options: []) else { return attributedString }
 
@@ -68,5 +68,13 @@ extension String {
         }
 
         return filteredRanges
+    }
+
+    func escapingRegex() -> String? {
+        var escaped = self
+        ["[", "]", "(", ")", "*", "+", "?", ".", "^", "$", "|"].forEach {
+            escaped = escaped.replacingOccurrences(of: $0, with: "\\\($0)")
+        }
+        return escaped
     }
 }

--- a/Rocket.ChatTests/External/RCEmojiKit/EmojioneSpec.swift
+++ b/Rocket.ChatTests/External/RCEmojiKit/EmojioneSpec.swift
@@ -23,7 +23,7 @@ class EmojioneSpec: XCTestCase {
         Meow <- :cat:
         :dog: -> Woof
 
-        :family_mwg:
+        :family_mwg: :+1_tone1:
 
         ```
         Meow <- :cat:
@@ -43,7 +43,7 @@ class EmojioneSpec: XCTestCase {
             Meow <- 🐱
             🐶 -> Woof
 
-            👨‍👩‍👧
+            👨‍👩‍👧 👍🏻
 
             ```
             Meow <- :cat:


### PR DESCRIPTION
@RocketChat/ios 

This was preventing emoji shortnames like : +1 : from being parsed correctly.