### PR TITLE
[NEW] Interactive keyboard dismissal added to ChatViewController / [FIX] Fixed the weird scrolling behavior and layout issues on chat rooms that one hasn't joined

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -28,17 +28,17 @@ final class ChatViewController: SLKTextViewController {
     @IBOutlet weak var buttonScrollToBottom: UIButton!
     var buttonScrollToBottomMarginConstraint: NSLayoutConstraint?
 
-    var showButtonScrollToBottom: Bool = false {
+    var scrollToBottomButtonIsVisible: Bool = false {
         didSet {
             self.buttonScrollToBottom.superview?.layoutIfNeeded()
 
-            if self.showButtonScrollToBottom {
-                self.buttonScrollToBottomMarginConstraint?.constant = -self.textInputbar.frame.height - 40
+            if self.scrollToBottomButtonIsVisible {
+                self.buttonScrollToBottomMarginConstraint?.constant = (self.textInputbar.frame.origin.y - self.view.frame.height) - 40
             } else {
                 self.buttonScrollToBottomMarginConstraint?.constant = 50
             }
 
-            if showButtonScrollToBottom != oldValue {
+            if scrollToBottomButtonIsVisible != oldValue {
                 UIView.animate(withDuration: 0.5) {
                     self.buttonScrollToBottom.superview?.layoutIfNeeded()
                 }
@@ -321,7 +321,7 @@ final class ChatViewController: SLKTextViewController {
         let sizeHeight = collectionView?.contentSize.height ?? 0
         let offset = CGPoint(x: 0, y: max(sizeHeight - boundsHeight, 0))
         collectionView?.setContentOffset(offset, animated: animated)
-        showButtonScrollToBottom = false
+        scrollToBottomButtonIsVisible = false
     }
 
     func resetMessageSending() {
@@ -1097,7 +1097,7 @@ extension ChatViewController: UICollectionViewDelegateFlowLayout {
 extension ChatViewController {
     override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         super.scrollViewDidScroll(scrollView)
-        
+
         updateKeyboardConstraints()
 
         if scrollView.contentOffset.y < -10 {
@@ -1106,7 +1106,7 @@ extension ChatViewController {
             }
         }
 
-        showButtonScrollToBottom = !chatLogIsAtBottom()
+        scrollToBottomButtonIsVisible = !chatLogIsAtBottom()
     }
 }
 
@@ -1186,5 +1186,3 @@ extension ChatViewController {
         }
     }
 }
-
-

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -347,6 +347,7 @@ final class ChatViewController: SLKTextViewController {
     weak var textInputbarHC: NSLayoutConstraint?
     weak var keyboardProxyView: UIView?
     let textInputbarBackground = UIToolbar()
+    var oldTextInputbarBgIsTransparent = false
 
     // Enables for the interactive keyboard dismissal.
     // Gets called in scrollViewDidScroll and keyboardDidChangeFrame methods.
@@ -378,8 +379,11 @@ final class ChatViewController: SLKTextViewController {
         if #available(iOS 11.0, *) {
             keyboardHeight = keyboardHeight > view.safeAreaInsets.bottom ? keyboardHeight : view.safeAreaInsets.bottom
         }
-
-        keyboardHC?.constant = keyboardHeight
+        
+        // The conditional check should help prevent unnecessary re-draws.
+        if let keyboardHC = keyboardHC, keyboardHC.constant != keyboardHeight {
+            keyboardHC.constant = keyboardHeight
+        }
     }
 
     private func updateTextInputbarBackground() {
@@ -390,12 +394,16 @@ final class ChatViewController: SLKTextViewController {
 
             // Making the old background for textInputView, transparent
             // after the safeAreaInsets are set. (Initially zero)
-            if view.safeAreaInsets.bottom > 0 {
+            // This helps improve the translucency effect of the bar.
+            if oldTextInputbarBgIsTransparent, view.safeAreaInsets.bottom > 0 {
                 textInputbar.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
                 textInputbar.backgroundColor = UIColor.clear
+                oldTextInputbarBgIsTransparent = true
             }
 
-            textInputbarHC?.constant = view.safeAreaInsets.bottom
+            if let textInputbarHC = textInputbarHC, textInputbarHC.constant != view.safeAreaInsets.bottom {
+                textInputbarHC.constant = view.safeAreaInsets.bottom
+            }
         }
     }
 

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -341,10 +341,12 @@ final class ChatViewController: SLKTextViewController {
         dataController.lastSeen = subscription?.lastSeen ?? Date()
     }
 
-    // MARK: Handeling Keyboard
+    // MARK: Handling Keyboard
 
-    weak var keyboardHC: NSLayoutConstraint?
-    weak var textInputbarHC: NSLayoutConstraint?
+    // keyboardHeightConstraint is the same as keyboardHC in SLKTextViewController
+    weak var keyboardHeightConstraint: NSLayoutConstraint?
+    weak var textInputbarBackgroundHeightConstraint: NSLayoutConstraint?
+
     weak var keyboardProxyView: UIView?
     let textInputbarBackground = UIToolbar()
     var oldTextInputbarBgIsTransparent = false
@@ -352,8 +354,8 @@ final class ChatViewController: SLKTextViewController {
     // Enables for the interactive keyboard dismissal.
     // Gets called in scrollViewDidScroll and keyboardDidChangeFrame methods.
     private func updateKeyboardConstraints() {
-        if keyboardHC == nil {
-            keyboardHC = self.view.constraints.first {
+        if keyboardHeightConstraint == nil {
+            keyboardHeightConstraint = self.view.constraints.first {
                 ($0.firstItem as? UIView) == self.view &&
                     ($0.secondItem as? SLKTextInputbar) == self.textInputbar
             }
@@ -381,7 +383,7 @@ final class ChatViewController: SLKTextViewController {
         }
 
         // The conditional check should help prevent unnecessary re-draws.
-        if let keyboardHC = keyboardHC, keyboardHC.constant != keyboardHeight {
+        if let keyboardHC = keyboardHeightConstraint, keyboardHC.constant != keyboardHeight {
             keyboardHC.constant = keyboardHeight
         }
     }
@@ -401,7 +403,7 @@ final class ChatViewController: SLKTextViewController {
                 oldTextInputbarBgIsTransparent = true
             }
 
-            if let textInputbarHC = textInputbarHC, textInputbarHC.constant != view.safeAreaInsets.bottom {
+            if let textInputbarHC = textInputbarBackgroundHeightConstraint, textInputbarHC.constant != view.safeAreaInsets.bottom {
                 textInputbarHC.constant = view.safeAreaInsets.bottom
             }
         }
@@ -412,8 +414,8 @@ final class ChatViewController: SLKTextViewController {
             textInputbar.insertSubview(textInputbarBackground, at: 0)
             textInputbarBackground.translatesAutoresizingMaskIntoConstraints = false
 
-            textInputbarHC = textInputbarBackground.heightAnchor.constraint(equalTo: textInputbar.heightAnchor, multiplier: 1, constant: view.safeAreaInsets.bottom)
-            textInputbarHC?.isActive = true
+            textInputbarBackgroundHeightConstraint = textInputbarBackground.heightAnchor.constraint(equalTo: textInputbar.heightAnchor, multiplier: 1, constant: view.safeAreaInsets.bottom)
+            textInputbarBackgroundHeightConstraint?.isActive = true
 
             textInputbarBackground.widthAnchor.constraint(equalTo: textInputbar.widthAnchor).isActive = true
             textInputbarBackground.topAnchor.constraint(equalTo: textInputbar.topAnchor).isActive = true

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -379,7 +379,7 @@ final class ChatViewController: SLKTextViewController {
         if #available(iOS 11.0, *) {
             keyboardHeight = keyboardHeight > view.safeAreaInsets.bottom ? keyboardHeight : view.safeAreaInsets.bottom
         }
-        
+
         // The conditional check should help prevent unnecessary re-draws.
         if let keyboardHC = keyboardHC, keyboardHC.constant != keyboardHeight {
             keyboardHC.constant = keyboardHeight
@@ -395,7 +395,7 @@ final class ChatViewController: SLKTextViewController {
             // Making the old background for textInputView, transparent
             // after the safeAreaInsets are set. (Initially zero)
             // This helps improve the translucency effect of the bar.
-            if oldTextInputbarBgIsTransparent, view.safeAreaInsets.bottom > 0 {
+            if !oldTextInputbarBgIsTransparent, view.safeAreaInsets.bottom > 0 {
                 textInputbar.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
                 textInputbar.backgroundColor = UIColor.clear
                 oldTextInputbarBgIsTransparent = true

--- a/Rocket.Chat/Views/Cells/Subscription/ChatPreviewModeView.swift
+++ b/Rocket.Chat/Views/Cells/Subscription/ChatPreviewModeView.swift
@@ -46,4 +46,15 @@ final class ChatPreviewModeView: UIView {
         }
     }
 
+    @IBOutlet weak var bottomConstraint: NSLayoutConstraint!
+    private let requiredBottomInset: CGFloat = 10
+
+    var bottomInset: CGFloat {
+        get {
+            return bottomConstraint.constant - requiredBottomInset
+        }
+        set {
+            bottomConstraint.constant = newValue + requiredBottomInset
+        }
+    }
 }

--- a/Rocket.Chat/Views/Cells/Subscription/ChatPreviewModeView.xib
+++ b/Rocket.Chat/Views/Cells/Subscription/ChatPreviewModeView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -63,14 +63,16 @@
                 <constraint firstAttribute="trailing" secondItem="4KQ-U2-uYG" secondAttribute="trailing" constant="10" id="ddX-vu-gcU"/>
                 <constraint firstAttribute="trailing" secondItem="lWX-ee-yg5" secondAttribute="trailing" constant="10" id="j93-uT-D1R"/>
                 <constraint firstItem="ZQ7-XJ-wRD" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="lBh-Lv-dE0"/>
+                <constraint firstItem="ZQ7-XJ-wRD" firstAttribute="centerY" secondItem="4KQ-U2-uYG" secondAttribute="centerY" id="nos-Pz-z3i"/>
                 <constraint firstItem="lWX-ee-yg5" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="6" id="rLV-4I-ia8"/>
-                <constraint firstAttribute="bottom" secondItem="ZQ7-XJ-wRD" secondAttribute="bottom" constant="22" id="voc-iO-tGd"/>
+                <constraint firstItem="4KQ-U2-uYG" firstAttribute="top" secondItem="lWX-ee-yg5" secondAttribute="bottom" constant="8" id="srq-QQ-Hm3"/>
                 <constraint firstAttribute="bottom" secondItem="4KQ-U2-uYG" secondAttribute="bottom" constant="10" id="y2R-bk-Z3r"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="activityIndicator" destination="ZQ7-XJ-wRD" id="w4m-lO-Oah"/>
+                <outlet property="bottomConstraint" destination="y2R-bk-Z3r" id="3fb-qo-WCS"/>
                 <outlet property="buttonJoin" destination="4KQ-U2-uYG" id="5YM-Hf-Kyb"/>
                 <outlet property="labelTitle" destination="lWX-ee-yg5" id="jyd-at-M3c"/>
             </connections>


### PR DESCRIPTION
@RocketChat/ios

![out](https://user-images.githubusercontent.com/7317008/36960332-91d18884-206c-11e8-9d2a-6984460df85b.gif)

- Interactive keyboard dismissal added to ChatViewController.
- Minor refactoring.

Since the Input Accessory View is tightly coupled with the SlackTextViewController, implementing the text bar as an Input Accessory View would require major modifications to the SlackTextViewController dependency. Until the dependency gets updated this is possibly the best way to get an interactive keyboard slide out.

- Fixed the weird scrolling behavior on chat rooms that one hasn't joined. 
- Fixed the layout issue of the chat preview view on devices with safe area insets. (iPhone X)

Closes #1378