### PR TITLE
[IMPROVEMENT] Interactive keyboard dismissal improved

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		14FBFF771FB267BF000D400B /* MentionsTextFieldTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FBFF761FB267BF000D400B /* MentionsTextFieldTableViewCell.swift */; };
 		14FBFF791FB267C9000D400B /* MentionsTextFieldTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 14FBFF781FB267C9000D400B /* MentionsTextFieldTableViewCell.xib */; };
 		15A2FD223558011BFDE03883 /* Pods_Rocket_ChatTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68D870A8D54F5431A14607AE /* Pods_Rocket_ChatTests.framework */; };
+		339B692B2050449700F97392 /* KeyboardFrameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339B6929205042D300F97392 /* KeyboardFrameView.swift */; };
 		35A203212022D3F900B4BE5A /* ChatMessageAttachmentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A203202022D3F900B4BE5A /* ChatMessageAttachmentView.swift */; };
 		35BCD301201A57EA00B4BE5A /* Ask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BCD300201A57EA00B4BE5A /* Ask.swift */; };
 		35BCD303201A9FB800B4BE5A /* AskSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BCD302201A9FB800B4BE5A /* AskSpec.swift */; };
@@ -530,6 +531,7 @@
 		14F8A291202E65C700175FDC /* Blue-76@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Blue-76@2x.png"; sourceTree = "<group>"; };
 		14FBFF761FB267BF000D400B /* MentionsTextFieldTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MentionsTextFieldTableViewCell.swift; sourceTree = "<group>"; };
 		14FBFF781FB267C9000D400B /* MentionsTextFieldTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MentionsTextFieldTableViewCell.xib; sourceTree = "<group>"; };
+		339B6929205042D300F97392 /* KeyboardFrameView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardFrameView.swift; sourceTree = "<group>"; };
 		35A203202022D3F900B4BE5A /* ChatMessageAttachmentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageAttachmentView.swift; sourceTree = "<group>"; };
 		35AE3FC690B1D3DC4E9DE715 /* Pods-Rocket.ChatTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rocket.ChatTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Rocket.ChatTests/Pods-Rocket.ChatTests.release.xcconfig"; sourceTree = "<group>"; };
 		35BCD300201A57EA00B4BE5A /* Ask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ask.swift; sourceTree = "<group>"; };
@@ -1750,6 +1752,7 @@
 				411498E21FC7A99C00D66542 /* ChatTitleViewModel.swift */,
 				419D84FD1DF599CA0021F034 /* ChatHeaderViewStatus.xib */,
 				419D84FF1DF599DA0021F034 /* ChatHeaderViewStatus.swift */,
+				339B6929205042D300F97392 /* KeyboardFrameView.swift */,
 				80CFB5711F8D697100FC9715 /* ReplyView.xib */,
 				80CFB5731F8DA55C00FC9715 /* ReplyView.swift */,
 				1435BFA21F9B601600FB2768 /* RCTextView.swift */,
@@ -2842,6 +2845,7 @@
 				41D4ABAB1F4CD10C00ACDDDD /* ChatCollectionViewFlowLayout.swift in Sources */,
 				4151B4541E2D1A9E00F8AA1B /* SubscriptionModelHandler.swift in Sources */,
 				80113DF81F98330C0048F2C2 /* OAuthViewController.swift in Sources */,
+				339B692B2050449700F97392 /* KeyboardFrameView.swift in Sources */,
 				0B9AB2C320444ED600ABEA05 /* LanguageViewModel.swift in Sources */,
 				41BD37E11E290F2900CBC4C2 /* UserModelMapping.swift in Sources */,
 				412BCC871E55C6B800F7F4EE /* ChatMessageTextView.swift in Sources */,

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -315,6 +315,10 @@ final class ChatViewController: SLKTextViewController {
         scrollToBottomButtonIsVisible = false
     }
 
+    internal func resetScrollToBottomButtonPosition() {
+        scrollToBottomButtonIsVisible = !chatLogIsAtBottom()
+    }
+
     func resetMessageSending() {
         textView.text = ""
 
@@ -457,10 +461,6 @@ final class ChatViewController: SLKTextViewController {
         } else {
             didPressRightButton(self)
         }
-    }
-
-    override func textViewDidBeginEditing(_ textView: UITextView) {
-        scrollToBottom(true)
     }
 
     override func textViewDidChange(_ textView: UITextView) {
@@ -1109,8 +1109,7 @@ extension ChatViewController {
                 loadMoreMessagesFrom(date: message.createdAt)
             }
         }
-
-        scrollToBottomButtonIsVisible = !chatLogIsAtBottom()
+        resetScrollToBottomButtonPosition()
     }
 }
 
@@ -1198,6 +1197,7 @@ extension ChatViewController: KeyboardFrameViewDelegate {
         if let frame = frame {
             updateKeyboardConstraints(frame: frame)
         }
+        resetScrollToBottomButtonPosition()
     }
 
     var keyboardProxyView: UIView? {

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -167,6 +167,7 @@ final class ChatViewController: SLKTextViewController {
 
         collectionView?.isPrefetchingEnabled = true
         collectionView?.keyboardDismissMode = .interactive
+        enableInteractiveKeyboardDismissal()
 
         isInverted = false
         bounces = true
@@ -181,7 +182,6 @@ final class ChatViewController: SLKTextViewController {
         setupScrollToBottomButton()
 
         NotificationCenter.default.addObserver(self, selector: #selector(reconnect), name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidChangeFrame(_:)), name: Notification.Name.UIKeyboardDidChangeFrame, object: nil)
         SocketManager.addConnectionHandler(token: socketHandlerToken, handler: self)
 
         if !SocketManager.isConnected() {
@@ -338,13 +338,18 @@ final class ChatViewController: SLKTextViewController {
     weak var keyboardHeightConstraint: NSLayoutConstraint?
     weak var textInputbarBackgroundHeightConstraint: NSLayoutConstraint?
 
-    weak var keyboardProxyView: UIView?
+    var keyboardFrame: KeyboardFrameView?
     let textInputbarBackground = UIToolbar()
     var oldTextInputbarBgIsTransparent = false
+    
+    private func enableInteractiveKeyboardDismissal() {
+        keyboardFrame = KeyboardFrameView(withDelegate: self)
+    }
 
     // Enables for the interactive keyboard dismissal.
-    // Gets called in scrollViewDidScroll and keyboardDidChangeFrame methods.
-    private func updateKeyboardConstraints() {
+    // Gets called updateKeyboardConstraints(frame:) which is a
+    // required method of the KeyboardFrameViewDelegate
+    private func updateKeyboardConstraints(frame: CGRect) {
         if keyboardHeightConstraint == nil {
             keyboardHeightConstraint = self.view.constraints.first {
                 ($0.firstItem as? UIView) == self.view &&
@@ -357,26 +362,13 @@ final class ChatViewController: SLKTextViewController {
         // with no real fix for it provided by Apple in UIKit.
         updateTextInputbarBackground()
 
-        // keyboardProxyView is stored so as to account for an edge case on the iPad
-        // when it is split screen mode, where if a text field on the other app is
-        // active, then the textInputbar gets hidden under the keyboard.
-        if keyboardProxyView == nil {
-            keyboardProxyView = textInputbar.inputAccessoryView.superview
-        }
-
-        let keyboardWindowHeight = keyboardProxyView?.window?.frame.height ?? 0.0
-        let keyboardYOriginInWindow = keyboardProxyView?.frame.origin.y ?? 0.0
-
-        var keyboardHeight = keyboardWindowHeight - keyboardYOriginInWindow
+        var keyboardHeight = frame.height
 
         if #available(iOS 11.0, *) {
             keyboardHeight = keyboardHeight > view.safeAreaInsets.bottom ? keyboardHeight : view.safeAreaInsets.bottom
         }
 
-        // The conditional check should help prevent unnecessary re-draws.
-        if let keyboardHC = keyboardHeightConstraint, keyboardHC.constant != keyboardHeight {
-            keyboardHC.constant = keyboardHeight
-        }
+        keyboardHeightConstraint?.constant = keyboardHeight
     }
 
     private func updateTextInputbarBackground() {
@@ -412,10 +404,6 @@ final class ChatViewController: SLKTextViewController {
             textInputbarBackground.topAnchor.constraint(equalTo: textInputbar.topAnchor).isActive = true
             textInputbarBackground.centerXAnchor.constraint(equalTo: textInputbar.centerXAnchor).isActive = true
         }
-    }
-
-    @objc private func keyboardDidChangeFrame(_ notification: Notification) {
-        updateKeyboardConstraints()
     }
 
     // MARK: SlackTextViewController
@@ -1116,8 +1104,6 @@ extension ChatViewController {
     override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         super.scrollViewDidScroll(scrollView)
 
-        updateKeyboardConstraints()
-
         if scrollView.contentOffset.y < -10 {
             if let message = dataController.oldestMessage() {
                 loadMoreMessagesFrom(date: message.createdAt)
@@ -1202,5 +1188,19 @@ extension ChatViewController {
         default:
             break
         }
+    }
+}
+
+// MARK: KeyboardFrameViewDelegate
+
+extension ChatViewController: KeyboardFrameViewDelegate {
+    func keyboardDidChangeFrame(frame: CGRect?) {
+        if let frame = frame {
+            updateKeyboardConstraints(frame: frame)
+        }
+    }
+
+    var keyboardProxyView: UIView? {
+        return textInputbar.inputAccessoryView.superview
     }
 }

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -341,7 +341,7 @@ final class ChatViewController: SLKTextViewController {
     var keyboardFrame: KeyboardFrameView?
     let textInputbarBackground = UIToolbar()
     var oldTextInputbarBgIsTransparent = false
-    
+
     private func enableInteractiveKeyboardDismissal() {
         keyboardFrame = KeyboardFrameView(withDelegate: self)
     }

--- a/Rocket.Chat/Views/Chat/KeyboardFrameView.swift
+++ b/Rocket.Chat/Views/Chat/KeyboardFrameView.swift
@@ -1,0 +1,65 @@
+//
+//  KeyboardFrameView.swift
+//  Rocket.Chat
+//
+//  Created by Samar Sunkaria on 3/7/18.
+//  Copyright © 2018 Rocket.Chat. All rights reserved.
+//
+
+import UIKit
+
+protocol KeyboardFrameViewDelegate: class {
+    func keyboardDidChangeFrame(frame: CGRect?)
+    var keyboardProxyView: UIView? { get }
+}
+
+class KeyboardFrameView: UIView {
+    weak var delegate: KeyboardFrameViewDelegate?
+    weak var keyboardProxyView: UIView?
+
+    init(withDelegate delegate: KeyboardFrameViewDelegate) {
+        super.init(frame: CGRect.zero)
+        self.delegate = delegate
+        registerForNotification()
+    }
+
+    func registerForNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidChangeFrameNotificationReceived), name: Notification.Name.UIKeyboardDidChangeFrame, object: nil)
+    }
+
+    @objc func keyboardDidChangeFrameNotificationReceived() {
+        delegate?.keyboardDidChangeFrame(frame: nil)
+
+        if delegate?.keyboardProxyView != keyboardProxyView {
+            keyboardProxyView = delegate?.keyboardProxyView
+            attachToKeyboardProxyView()
+        }
+    }
+
+    func attachToKeyboardProxyView() {
+        guard let keyboardProxyView = keyboardProxyView else { return }
+
+        keyboardProxyView.addSubview(self)
+        self.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            self.topAnchor.constraint(equalTo: keyboardProxyView.topAnchor),
+            self.leftAnchor.constraint(equalTo: keyboardProxyView.leftAnchor),
+            self.rightAnchor.constraint(equalTo: keyboardProxyView.rightAnchor),
+            self.bottomAnchor.constraint(equalTo: keyboardProxyView.superview?.bottomAnchor ?? keyboardProxyView.bottomAnchor)
+            ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        delegate?.keyboardDidChangeFrame(frame: self.frame)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+}

--- a/Rocket.Chat/Views/Chat/KeyboardFrameView.swift
+++ b/Rocket.Chat/Views/Chat/KeyboardFrameView.swift
@@ -52,7 +52,9 @@ class KeyboardFrameView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        delegate?.keyboardDidChangeFrame(frame: self.frame)
+        if self.frame.height > 0 || keyboardProxyView == nil {
+            delegate?.keyboardDidChangeFrame(frame: self.frame)
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
@RocketChat/ios

- The text input bar no longer lags 1 frame behind the keyboard.
- Should have better performance characteristics, since the new implementation is only called when the frame of the keyboard actually changes (unlike previously, where the method was called inside `scrollViewDidScroll`)