### PR TITLE
[IMPROVEMENT] Optimize the emojis list picker

### DIFF
--- a/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.swift
@@ -284,19 +284,18 @@ extension EmojiPicker: UICollectionViewDelegateFlowLayout {
 
 extension EmojiPicker: UITabBarDelegate {
     func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
-        if !self.emojisCollectionView.isDragging {
-            guard let index = tabBar.items?.index(of: item) else { return }
+        guard self.emojisCollectionView.isDragging else { return }
+        guard let index = tabBar.items?.index(of: item) else { return }
 
-            searchBar.resignFirstResponder()
-            searchBar.text = ""
+        searchBar.resignFirstResponder()
+        searchBar.text = ""
 
-            emojisCollectionView.reloadData()
-            emojisCollectionView.layoutIfNeeded()
+        emojisCollectionView.reloadData()
+        emojisCollectionView.layoutIfNeeded()
 
-            let indexPath = IndexPath(row: 1, section: index)
-            emojisCollectionView.scrollToItem(at: indexPath, at: .top, animated: false)
-            emojisCollectionView.setContentOffset(emojisCollectionView.contentOffset.applying(CGAffineTransform(translationX: 0.0, y: -36.0)), animated: false)
-        }
+        let indexPath = IndexPath(row: 1, section: index)
+        emojisCollectionView.scrollToItem(at: indexPath, at: .top, animated: false)
+        emojisCollectionView.setContentOffset(emojisCollectionView.contentOffset.applying(CGAffineTransform(translationX: 0.0, y: -36.0)), animated: false)
     }
 }
 

--- a/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.swift
@@ -284,18 +284,20 @@ extension EmojiPicker: UICollectionViewDelegateFlowLayout {
 
 extension EmojiPicker: UITabBarDelegate {
     func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
-        guard self.emojisCollectionView.isDragging else { return }
-        guard let index = tabBar.items?.index(of: item) else { return }
+        guard self.emojisCollectionView.isDragging else {
+            guard let index = tabBar.items?.index(of: item) else { return }
 
-        searchBar.resignFirstResponder()
-        searchBar.text = ""
+            searchBar.resignFirstResponder()
+            searchBar.text = ""
 
-        emojisCollectionView.reloadData()
-        emojisCollectionView.layoutIfNeeded()
+            emojisCollectionView.reloadData()
+            emojisCollectionView.layoutIfNeeded()
 
-        let indexPath = IndexPath(row: 1, section: index)
-        emojisCollectionView.scrollToItem(at: indexPath, at: .top, animated: false)
-        emojisCollectionView.setContentOffset(emojisCollectionView.contentOffset.applying(CGAffineTransform(translationX: 0.0, y: -36.0)), animated: false)
+            let indexPath = IndexPath(row: 1, section: index)
+            emojisCollectionView.scrollToItem(at: indexPath, at: .top, animated: false)
+            emojisCollectionView.setContentOffset(emojisCollectionView.contentOffset.applying(CGAffineTransform(translationX: 0.0, y: -36.0)), animated: false)
+            return
+        }
     }
 }
 

--- a/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.swift
@@ -284,17 +284,19 @@ extension EmojiPicker: UICollectionViewDelegateFlowLayout {
 
 extension EmojiPicker: UITabBarDelegate {
     func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
-        guard let index = tabBar.items?.index(of: item) else { return }
+        if !self.emojisCollectionView.isDragging {
+            guard let index = tabBar.items?.index(of: item) else { return }
 
-        searchBar.resignFirstResponder()
-        searchBar.text = ""
+            searchBar.resignFirstResponder()
+            searchBar.text = ""
 
-        emojisCollectionView.reloadData()
-        emojisCollectionView.layoutIfNeeded()
+            emojisCollectionView.reloadData()
+            emojisCollectionView.layoutIfNeeded()
 
-        let indexPath = IndexPath(row: 1, section: index)
-        emojisCollectionView.scrollToItem(at: indexPath, at: .top, animated: false)
-        emojisCollectionView.setContentOffset(emojisCollectionView.contentOffset.applying(CGAffineTransform(translationX: 0.0, y: -36.0)), animated: false)
+            let indexPath = IndexPath(row: 1, section: index)
+            emojisCollectionView.scrollToItem(at: indexPath, at: .top, animated: false)
+            emojisCollectionView.setContentOffset(emojisCollectionView.contentOffset.applying(CGAffineTransform(translationX: 0.0, y: -36.0)), animated: false)
+        }
     }
 }
 

--- a/Rocket.Chat/External/RCEmojiKit/Views/EmojiView.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/EmojiView.swift
@@ -55,5 +55,7 @@ class EmojiCollectionViewCell: UICollectionViewCell {
         self.emojiView.emojiLabel.text = ""
         self.emojiView.emojiImageView.image = nil
         self.emojiView.emojiImageView.animatedImage = nil
+        self.layer.shouldRasterize = true
+        self.layer.rasterizationScale = UIScreen.main.scale
     }
 }


### PR DESCRIPTION
@RocketChat/ios

During scrolling the CPU usage reach to 96-98 percents, therefore we see bad performance and finally we see the deadlock.

I guess the problem is TabBar for emojis' sections. During scrolling we tap on one of the sections and call reload method for collectionView. I prevent the reload during scrolling. Also I've added some configurations for cell's layers in prepareForReuse. It should decrease CPU usage.

Any ideas?) Maybe I'm not right and there is another reason for deadlock. But after my changes I cannot reproduce the deadlock. Please test it on real device, because often simulator cannot show the real performance problems

Closes #1316 
