### PR TITLE
[CHORE] Add more information on crash of Crashlytics

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -408,17 +408,17 @@
 		89AFF3C81F94374D00D07A30 /* NewRoomViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89AFF3C71F94374D00D07A30 /* NewRoomViewControllerSpec.swift */; };
 		9928225F204DDC8C005D2067 /* EditProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9928225E204DDC8C005D2067 /* EditProfileViewModel.swift */; };
 		993E513A1FB1E18D006403D5 /* DraftMessageManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993E51391FB1E18D006403D5 /* DraftMessageManagerSpec.swift */; };
+		994D1EDF205AB945007F29C8 /* UINavigationControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994D1EDE205AB945007F29C8 /* UINavigationControllerExtension.swift */; };
 		994DA2B020653FB600083FB8 /* WebBrowserManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994DA2AF20653FB600083FB8 /* WebBrowserManagerSpec.swift */; };
 		994DA2B32065486D00083FB8 /* WebBrowserViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994DA2B22065486D00083FB8 /* WebBrowserViewModelSpec.swift */; };
+		994EB8042050DD5D0011A9CE /* NewPasswordTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994EB8032050DD5D0011A9CE /* NewPasswordTableViewController.swift */; };
 		995FEB2F206286D9004EE38F /* WebBrowserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995FEB2E206286D9004EE38F /* WebBrowserManager.swift */; };
 		9960C8302063F0C8004A034C /* WebBrowserTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9960C82F2063F0C8004A034C /* WebBrowserTableViewController.swift */; };
-		999483EB20644CC4004F61CA /* WebBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999483EA20644CC4004F61CA /* WebBrowserViewModel.swift */; };
-		994D1EDF205AB945007F29C8 /* UINavigationControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994D1EDE205AB945007F29C8 /* UINavigationControllerExtension.swift */; };
-		994EB8042050DD5D0011A9CE /* NewPasswordTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994EB8032050DD5D0011A9CE /* NewPasswordTableViewController.swift */; };
 		996154B1205197E7009B9857 /* NewPasswordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 996154B0205197E7009B9857 /* NewPasswordViewModel.swift */; };
 		998165CA204EBBA10059D346 /* UpdateUserRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998165C9204EBBA10059D346 /* UpdateUserRequestSpec.swift */; };
 		998165CC204EDBA30059D346 /* UploadAvatarRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998165CB204EDBA30059D346 /* UploadAvatarRequestSpec.swift */; };
 		99923773204B3BD800C2D15F /* UploadAvatarRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99923772204B3BD800C2D15F /* UploadAvatarRequest.swift */; };
+		999483EB20644CC4004F61CA /* WebBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999483EA20644CC4004F61CA /* WebBrowserViewModel.swift */; };
 		99B060CE1FB1225200F471C2 /* DraftMessageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B060CD1FB1225200F471C2 /* DraftMessageManager.swift */; };
 		99D888F82045DFC500E51306 /* EditProfileTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D888F72045DFC500E51306 /* EditProfileTableViewController.swift */; };
 		99D888FB204623A900E51306 /* UpdateUserRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D888FA204623A900E51306 /* UpdateUserRequest.swift */; };
@@ -901,17 +901,17 @@
 		89AFF3C71F94374D00D07A30 /* NewRoomViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NewRoomViewControllerSpec.swift; path = Controllers/NewRoomViewControllerSpec.swift; sourceTree = "<group>"; };
 		9928225E204DDC8C005D2067 /* EditProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EditProfileViewModel.swift; path = Controllers/Settings/EditProfileViewModel.swift; sourceTree = "<group>"; };
 		993E51391FB1E18D006403D5 /* DraftMessageManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DraftMessageManagerSpec.swift; path = Managers/DraftMessageManagerSpec.swift; sourceTree = "<group>"; };
+		994D1EDE205AB945007F29C8 /* UINavigationControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationControllerExtension.swift; sourceTree = "<group>"; };
 		994DA2AF20653FB600083FB8 /* WebBrowserManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WebBrowserManagerSpec.swift; path = Managers/WebBrowserManagerSpec.swift; sourceTree = "<group>"; };
 		994DA2B22065486D00083FB8 /* WebBrowserViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WebBrowserViewModelSpec.swift; path = Settings/WebBrowserViewModelSpec.swift; sourceTree = "<group>"; };
+		994EB8032050DD5D0011A9CE /* NewPasswordTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NewPasswordTableViewController.swift; path = Controllers/Settings/NewPasswordTableViewController.swift; sourceTree = "<group>"; };
 		995FEB2E206286D9004EE38F /* WebBrowserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WebBrowserManager.swift; path = Managers/WebBrowserManager.swift; sourceTree = "<group>"; };
 		9960C82F2063F0C8004A034C /* WebBrowserTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WebBrowserTableViewController.swift; path = Controllers/Settings/WebBrowserTableViewController.swift; sourceTree = "<group>"; };
-		999483EA20644CC4004F61CA /* WebBrowserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WebBrowserViewModel.swift; path = Controllers/Settings/WebBrowserViewModel.swift; sourceTree = "<group>"; };
-		994D1EDE205AB945007F29C8 /* UINavigationControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationControllerExtension.swift; sourceTree = "<group>"; };
-		994EB8032050DD5D0011A9CE /* NewPasswordTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NewPasswordTableViewController.swift; path = Controllers/Settings/NewPasswordTableViewController.swift; sourceTree = "<group>"; };
 		996154B0205197E7009B9857 /* NewPasswordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NewPasswordViewModel.swift; path = Controllers/Settings/NewPasswordViewModel.swift; sourceTree = "<group>"; };
 		998165C9204EBBA10059D346 /* UpdateUserRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserRequestSpec.swift; sourceTree = "<group>"; };
 		998165CB204EDBA30059D346 /* UploadAvatarRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadAvatarRequestSpec.swift; sourceTree = "<group>"; };
 		99923772204B3BD800C2D15F /* UploadAvatarRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadAvatarRequest.swift; sourceTree = "<group>"; };
+		999483EA20644CC4004F61CA /* WebBrowserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WebBrowserViewModel.swift; path = Controllers/Settings/WebBrowserViewModel.swift; sourceTree = "<group>"; };
 		99B060CD1FB1225200F471C2 /* DraftMessageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DraftMessageManager.swift; path = Managers/DraftMessageManager.swift; sourceTree = "<group>"; };
 		99D888F72045DFC500E51306 /* EditProfileTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EditProfileTableViewController.swift; path = Controllers/Settings/EditProfileTableViewController.swift; sourceTree = "<group>"; };
 		99D888FA204623A900E51306 /* UpdateUserRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserRequest.swift; sourceTree = "<group>"; };
@@ -2120,6 +2120,17 @@
 			name = Preferences;
 			sourceTree = "<group>";
 		};
+		99282260204DE0AE005D2067 /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				99D888F72045DFC500E51306 /* EditProfileTableViewController.swift */,
+				9928225E204DDC8C005D2067 /* EditProfileViewModel.swift */,
+				994EB8032050DD5D0011A9CE /* NewPasswordTableViewController.swift */,
+				996154B0205197E7009B9857 /* NewPasswordViewModel.swift */,
+			);
+			name = Profile;
+			sourceTree = "<group>";
+		};
 		994DA2B12065480300083FB8 /* Web Browser */ = {
 			isa = PBXGroup;
 			children = (
@@ -2135,17 +2146,6 @@
 				999483EA20644CC4004F61CA /* WebBrowserViewModel.swift */,
 			);
 			name = "Web Browser";
-			sourceTree = "<group>";
-		};
-		99282260204DE0AE005D2067 /* Profile */ = {
-			isa = PBXGroup;
-			children = (
-				99D888F72045DFC500E51306 /* EditProfileTableViewController.swift */,
-				9928225E204DDC8C005D2067 /* EditProfileViewModel.swift */,
-				994EB8032050DD5D0011A9CE /* NewPasswordTableViewController.swift */,
-				996154B0205197E7009B9857 /* NewPasswordViewModel.swift */,
-			);
-			name = Profile;
 			sourceTree = "<group>";
 		};
 		998165C8204EBB5E0059D346 /* User */ = {

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -3403,6 +3403,7 @@
 				CODE_SIGN_ENTITLEMENTS = Rocket.Chat/Rocket.Chat.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = S6UPZG7ZR3;
 				INFOPLIST_FILE = Rocket.Chat/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;

--- a/Rocket.Chat/Controllers/Auth/AuthViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthViewController.swift
@@ -205,8 +205,9 @@ final class AuthViewController: BaseViewController {
             SocketManager.removeConnectionHandler(token: strongSelf.socketHandlerToken)
 
             if let user = result.user {
-                if user.username != nil {
+                BugTrackingCoordinator.identifyCrashReports(withUser: user)
 
+                if user.username != nil {
                     DispatchQueue.main.async {
                         strongSelf.dismiss(animated: true, completion: nil)
                         AppManager.reloadApp()

--- a/Rocket.Chat/Managers/AppManager.swift
+++ b/Rocket.Chat/Managers/AppManager.swift
@@ -96,6 +96,7 @@ extension AppManager {
                     if let currentUser = AuthManager.currentUser() {
                         BugTrackingCoordinator.identifyCrashReports(withUser: currentUser)
                     }
+
                     WindowManager.open(.chat)
                 } else {
                     WindowManager.open(.auth(serverUrl: "", credentials: nil))

--- a/Rocket.Chat/Managers/AppManager.swift
+++ b/Rocket.Chat/Managers/AppManager.swift
@@ -93,6 +93,7 @@ extension AppManager {
         SocketManager.disconnect { (_, _) in
             DispatchQueue.main.async {
                 if AuthManager.isAuthenticated() != nil {
+                    if let currentUser = AuthManager.currentUser() { BugTrackingCoordinator.identifyCrashReports(withUser: currentUser) }
                     WindowManager.open(.chat)
                 } else {
                     WindowManager.open(.auth(serverUrl: "", credentials: nil))

--- a/Rocket.Chat/Managers/AppManager.swift
+++ b/Rocket.Chat/Managers/AppManager.swift
@@ -93,7 +93,9 @@ extension AppManager {
         SocketManager.disconnect { (_, _) in
             DispatchQueue.main.async {
                 if AuthManager.isAuthenticated() != nil {
-                    if let currentUser = AuthManager.currentUser() { BugTrackingCoordinator.identifyCrashReports(withUser: currentUser) }
+                    if let currentUser = AuthManager.currentUser() {
+                        BugTrackingCoordinator.identifyCrashReports(withUser: currentUser)
+                    }
                     WindowManager.open(.chat)
                 } else {
                     WindowManager.open(.auth(serverUrl: "", credentials: nil))

--- a/Rocket.Chat/Managers/Launcher/BugTrackingCoordinator.swift
+++ b/Rocket.Chat/Managers/Launcher/BugTrackingCoordinator.swift
@@ -35,5 +35,39 @@ struct BugTrackingCoordinator: LauncherProtocol {
 
     private func launchFabric() {
         Fabric.with([Crashlytics.self])
+
+        if let currentUser = AuthManager.currentUser() {
+            BugTrackingCoordinator.identifyCrashReports(withUser: currentUser)
+        }
+    }
+
+    static func identifyCrashReports(withUser user: User) {
+        guard let id = user.identifier else {
+            return
+        }
+
+        let crashlytics = Crashlytics.sharedInstance()
+        crashlytics.setUserIdentifier(id)
+
+        if let name = user.name {
+            crashlytics.setUserName(name)
+        }
+
+        if let email = user.emails.first?.email {
+            crashlytics.setUserEmail(email)
+        }
+
+        if let serverURL = AuthManager.selectedServerInformation()?[ServerPersistKeys.serverURL] {
+            crashlytics.setValue(serverURL, forKey: ServerPersistKeys.serverURL)
+        }
+    }
+
+    static func removeUserFromCrashReports() {
+        let crashlytics = Crashlytics.sharedInstance()
+
+        crashlytics.setUserEmail(nil)
+        crashlytics.setUserName(nil)
+        crashlytics.setUserIdentifier(nil)
+        crashlytics.setValue(nil, forKey: ServerPersistKeys.serverURL)
     }
 }

--- a/Rocket.Chat/Managers/Launcher/BugTrackingCoordinator.swift
+++ b/Rocket.Chat/Managers/Launcher/BugTrackingCoordinator.swift
@@ -38,6 +38,8 @@ struct BugTrackingCoordinator: LauncherProtocol {
 
         if let currentUser = AuthManager.currentUser() {
             BugTrackingCoordinator.identifyCrashReports(withUser: currentUser)
+        } else {
+            BugTrackingCoordinator.anonymizeCrashReports()
         }
     }
 

--- a/Rocket.Chat/Managers/Launcher/BugTrackingCoordinator.swift
+++ b/Rocket.Chat/Managers/Launcher/BugTrackingCoordinator.swift
@@ -58,16 +58,16 @@ struct BugTrackingCoordinator: LauncherProtocol {
         }
 
         if let serverURL = AuthManager.selectedServerInformation()?[ServerPersistKeys.serverURL] {
-            crashlytics.setValue(serverURL, forKey: ServerPersistKeys.serverURL)
+            crashlytics.setObjectValue(serverURL, forKey: ServerPersistKeys.serverURL)
         }
     }
 
-    static func removeUserFromCrashReports() {
+    static func anonymizeCrashReports() {
         let crashlytics = Crashlytics.sharedInstance()
 
         crashlytics.setUserEmail(nil)
         crashlytics.setUserName(nil)
         crashlytics.setUserIdentifier(nil)
-        crashlytics.setValue(nil, forKey: ServerPersistKeys.serverURL)
+        crashlytics.setObjectValue(nil, forKey: ServerPersistKeys.serverURL)
     }
 }

--- a/Rocket.Chat/Managers/Model/AuthManager.swift
+++ b/Rocket.Chat/Managers/Model/AuthManager.swift
@@ -405,7 +405,7 @@ extension AuthManager {
     static func logout(completion: @escaping VoidCompletion) {
         SocketManager.disconnect { (_, _) in
             GIDSignIn.sharedInstance().signOut()
-            BugTrackingCoordinator.removeUserFromCrashReports()
+            BugTrackingCoordinator.anonymizeCrashReports()
 
             DraftMessageManager.clearServerDraftMessages()
 

--- a/Rocket.Chat/Managers/Model/AuthManager.swift
+++ b/Rocket.Chat/Managers/Model/AuthManager.swift
@@ -405,6 +405,7 @@ extension AuthManager {
     static func logout(completion: @escaping VoidCompletion) {
         SocketManager.disconnect { (_, _) in
             GIDSignIn.sharedInstance().signOut()
+            BugTrackingCoordinator.removeUserFromCrashReports()
 
             DraftMessageManager.clearServerDraftMessages()
 

--- a/Rocket.Chat/Managers/Socket/Response/SocketHandlers.swift
+++ b/Rocket.Chat/Managers/Socket/Response/SocketHandlers.swift
@@ -9,7 +9,6 @@
 import Foundation
 import Starscream
 import SwiftyJSON
-import Crashlytics
 
 extension SocketManager {
 


### PR DESCRIPTION
@RocketChat/ios

Now we can see information such as user id, real name, email and server URL on the crash report as the screen shot below shows:

![screen shot 2018-03-27 at 19 24 50](https://user-images.githubusercontent.com/6117280/37999062-8efff39c-31f7-11e8-85fe-ce71b0199980.png)

Closes #1437 
