### PR TITLE
[FIX] Crash when alternating servers 

### DIFF
--- a/Rocket.Chat/API/Clients/CommandsClient.swift
+++ b/Rocket.Chat/API/Clients/CommandsClient.swift
@@ -11,7 +11,7 @@ import RealmSwift
 struct CommandsClient: APIClient {
     let api: AnyAPIFetcher
 
-    func fetchCommands(realm: Realm? = Realm.shared) {
+    func fetchCommands(realm: Realm? = Realm.current) {
         api.fetch(CommandsRequest(), succeeded: { result in
             DispatchQueue.main.async {
                 result.commands?.forEach { command in

--- a/Rocket.Chat/API/Clients/InfoClient.swift
+++ b/Rocket.Chat/API/Clients/InfoClient.swift
@@ -11,7 +11,7 @@ import RealmSwift
 struct InfoClient: APIClient {
     let api: AnyAPIFetcher
 
-    func fetchInfo(realm: Realm? = Realm.shared) {
+    func fetchInfo(realm: Realm? = Realm.current) {
         api.fetch(InfoRequest(), succeeded: { result in
             realm?.execute({ realm in
                 AuthManager.isAuthenticated(realm: realm)?.serverVersion = result.version ?? ""

--- a/Rocket.Chat/API/Clients/MessagesClient.swift
+++ b/Rocket.Chat/API/Clients/MessagesClient.swift
@@ -12,7 +12,7 @@ import SwiftyJSON
 struct MessagesClient: APIClient {
     let api: AnyAPIFetcher
 
-    func sendMessage(_ message: Message, subscription: Subscription, realm: Realm? = Realm.shared) {
+    func sendMessage(_ message: Message, subscription: Subscription, realm: Realm? = Realm.current) {
         guard let id = message.identifier else { return }
 
         try? realm?.write {
@@ -68,7 +68,7 @@ struct MessagesClient: APIClient {
         })
     }
 
-    func sendMessage(text: String, subscription: Subscription, id: String = String.random(18), user: User? = AuthManager.currentUser(), realm: Realm? = Realm.shared) {
+    func sendMessage(text: String, subscription: Subscription, id: String = String.random(18), user: User? = AuthManager.currentUser(), realm: Realm? = Realm.current) {
         let message = Message()
         message.internalType = ""
         message.updatedAt = nil
@@ -83,7 +83,7 @@ struct MessagesClient: APIClient {
     }
 
     @discardableResult
-    func deleteMessage(_ message: Message, asUser: Bool, realm: Realm? = Realm.shared) -> Bool {
+    func deleteMessage(_ message: Message, asUser: Bool, realm: Realm? = Realm.current) -> Bool {
         guard
             let id = message.identifier,
             !message.rid.isEmpty
@@ -98,7 +98,7 @@ struct MessagesClient: APIClient {
     }
 
     @discardableResult
-    func updateMessage(_ message: Message, text: String, realm: Realm? = Realm.shared) -> Bool {
+    func updateMessage(_ message: Message, text: String, realm: Realm? = Realm.current) -> Bool {
         guard
             let id = message.identifier,
             !message.rid.isEmpty

--- a/Rocket.Chat/Controllers/Auth/AuthViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthViewController.swift
@@ -425,7 +425,7 @@ extension AuthViewController {
     @objc func loginServiceButtonDidPress(_ button: UIButton) {
         guard
             let service = customAuthButtons.filter({ $0.value == button }).keys.first,
-            let realm = Realm.shared,
+            let realm = Realm.current,
             let loginService = LoginService.find(service: service, realm: realm)
         else {
             return

--- a/Rocket.Chat/Controllers/Chat/ChatControllerAutocomplete.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerAutocomplete.swift
@@ -11,7 +11,7 @@ import RealmSwift
 
 extension ChatViewController {
     override func didChangeAutoCompletionPrefix(_ prefix: String, andWord word: String) {
-        guard let realm = Realm.shared else { return }
+        guard let realm = Realm.current else { return }
 
         searchResult = []
         searchWord = word

--- a/Rocket.Chat/Controllers/Chat/MessagesListViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesListViewController.swift
@@ -13,7 +13,7 @@ extension APIResult where T == SubscriptionMessagesRequest {
     func getMessages() -> [Message?]? {
         return raw?["messages"].arrayValue.map { json in
             let message = Message()
-            message.map(json, realm: Realm.shared)
+            message.map(json, realm: Realm.current)
             return message
         }
     }

--- a/Rocket.Chat/Controllers/Subscriptions/NewRoomViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/NewRoomViewController.swift
@@ -178,7 +178,7 @@ class NewRoomViewController: BaseViewController {
             }
 
             SubscriptionManager.updateSubscriptions(auth) { _ in
-                if let newRoom = Realm.shared?.objects(Subscription.self).filter("name == '\(name)' && privateType != 'd'").first {
+                if let newRoom = Realm.current?.objects(Subscription.self).filter("name == '\(name)' && privateType != 'd'").first {
 
                     let controller = ChatViewController.shared
                     controller?.subscription = newRoom

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
@@ -304,7 +304,7 @@ extension SubscriptionsViewController {
     func subscribeModelChanges() {
         guard !assigned else { return }
         guard let auth = AuthManager.isAuthenticated() else { return }
-        guard let realm = Realm.shared else { return }
+        guard let realm = Realm.current else { return }
 
         assigned = true
 

--- a/Rocket.Chat/Extensions/Models/UserExtensions.swift
+++ b/Rocket.Chat/Extensions/Models/UserExtensions.swift
@@ -9,7 +9,7 @@
 import RealmSwift
 
 extension User {
-    static func search(usernameContaining word: String, preference: Set<String> = [], limit: Int = 5, realm: Realm? = Realm.shared) -> [(String, Any)] {
+    static func search(usernameContaining word: String, preference: Set<String> = [], limit: Int = 5, realm: Realm? = Realm.current) -> [(String, Any)] {
         guard let realm = realm else { return [] }
 
         var result = [(String, Any)]()

--- a/Rocket.Chat/Extensions/RealmExtension.swift
+++ b/Rocket.Chat/Extensions/RealmExtension.swift
@@ -58,11 +58,19 @@ extension Realm {
         Realm.current?.execute(execution, completion: completion)
     }
 
-    static func executeOnMainThread(_ execution: @escaping (Realm) -> Void) {
-        guard let realm = self.current else { return }
+    static func executeOnMainThread(realm: Realm? = nil, _ execution: @escaping (Realm) -> Void) {
+        if let realm = realm {
+            try? realm.write {
+                execution(realm)
+            }
 
-        try? realm.write {
-            execution(realm)
+            return
+        }
+
+        guard let currentRealm = Realm.current else { return }
+
+        try? currentRealm.write {
+            execution(currentRealm)
         }
     }
 

--- a/Rocket.Chat/Extensions/RealmExtension.swift
+++ b/Rocket.Chat/Extensions/RealmExtension.swift
@@ -14,7 +14,7 @@ var realmConfiguration: Realm.Configuration?
 
 extension Realm {
 
-    static var shared: Realm? {
+    static var current: Realm? {
         if let configuration = realmConfiguration {
             return try? Realm(configuration: configuration)
         } else {
@@ -55,11 +55,11 @@ extension Realm {
     }
 
     static func execute(_ execution: @escaping (Realm) -> Void, completion: VoidCompletion? = nil) {
-        Realm.shared?.execute(execution, completion: completion)
+        Realm.current?.execute(execution, completion: completion)
     }
 
     static func executeOnMainThread(_ execution: @escaping (Realm) -> Void) {
-        guard let realm = self.shared else { return }
+        guard let realm = self.current else { return }
 
         try? realm.write {
             execution(realm)

--- a/Rocket.Chat/Managers/AppManager.swift
+++ b/Rocket.Chat/Managers/AppManager.swift
@@ -153,10 +153,11 @@ extension AppManager {
         }
 
         // If not, fetch it
+        let currentRealm = Realm.current
         let request = SubscriptionInfoRequest(roomName: name)
         API.current()?.fetch(request, succeeded: { result in
             DispatchQueue.main.async {
-                Realm.executeOnMainThread({ realm in
+                Realm.executeOnMainThread(realm: currentRealm, { realm in
                     guard let values = result.channel else { return }
 
                     let subscription = Subscription.getOrCreate(realm: realm, values: values, updates: { object in

--- a/Rocket.Chat/Managers/Model/AuthManager.swift
+++ b/Rocket.Chat/Managers/Model/AuthManager.swift
@@ -16,7 +16,7 @@ struct AuthManager {
     /**
         - returns: Last auth object (sorted by lastAccess), if exists.
     */
-    static func isAuthenticated(realm: Realm? = Realm.shared) -> Auth? {
+    static func isAuthenticated(realm: Realm? = Realm.current) -> Auth? {
         guard let realm = realm else { return nil }
         return realm.objects(Auth.self).sorted(byKeyPath: "lastAccess", ascending: false).first
     }

--- a/Rocket.Chat/Managers/Model/AuthSettingsManager.swift
+++ b/Rocket.Chat/Managers/Model/AuthSettingsManager.swift
@@ -32,18 +32,19 @@ final class AuthSettingsManager {
             "method": "public-settings/get"
         ] as [String: Any]
 
+        let currentRealm = Realm.current
         SocketManager.send(object) { (response) in
             guard !response.isError() else {
                 completion(nil)
                 return
             }
 
-            Realm.execute({ realm in
-                let settings = AuthManager.isAuthenticated()?.settings ?? AuthSettings()
+            currentRealm?.execute({ realm in
+                let settings = AuthManager.isAuthenticated(realm: realm)?.settings ?? AuthSettings()
                 settings.map(response.result["result"], realm: realm)
                 realm.add(settings, update: true)
 
-                if let auth = AuthManager.isAuthenticated() {
+                if let auth = AuthManager.isAuthenticated(realm: realm) {
                     auth.settings = settings
                     realm.add(auth, update: true)
                 }

--- a/Rocket.Chat/Managers/Model/CustomEmojiManager.swift
+++ b/Rocket.Chat/Managers/Model/CustomEmojiManager.swift
@@ -17,13 +17,14 @@ struct CustomEmojiManager {
             "params": []
         ] as [String: Any]
 
+        let currentRealm = Realm.current
         SocketManager.send(requestEmojis) { response in
             guard !response.isError() else { return Log.debug(response.result.string) }
 
             let emojis = List<CustomEmoji>()
             let list = response.result["result"].array
 
-            Realm.execute({ realm in
+            currentRealm?.execute({ realm in
                 realm.delete(realm.objects(CustomEmoji.self))
 
                 list?.forEach { object in

--- a/Rocket.Chat/Managers/Model/LoginServiceManager.swift
+++ b/Rocket.Chat/Managers/Model/LoginServiceManager.swift
@@ -25,7 +25,7 @@ struct LoginServiceManager {
 // MARK: Realm
 extension LoginServiceManager {
     static func observe(block: @escaping (RealmCollectionChange<Results<LoginService>>) -> Void) -> NotificationToken? {
-        let objects = Realm.shared?.objects(LoginService.self)
+        let objects = Realm.current?.objects(LoginService.self)
         return objects?.observe(block)
     }
 }

--- a/Rocket.Chat/Managers/Model/MessageManager.swift
+++ b/Rocket.Chat/Managers/Model/MessageManager.swift
@@ -38,6 +38,7 @@ extension MessageManager {
 
         let validMessages = List<Message>()
 
+        let currentRealm = Realm.current
         SocketManager.send(request) { response in
             guard !response.isError() else {
                 return Log.debug(response.result.string)
@@ -46,7 +47,7 @@ extension MessageManager {
             let list = response.result["result"]["messages"].array
             let subscriptionIdentifier = subscription.identifier
 
-            Realm.execute({ (realm) in
+            currentRealm?.execute({ (realm) in
                 guard let detachedSubscription = realm.object(ofType: Subscription.self, forPrimaryKey: subscriptionIdentifier ?? "") else { return }
 
                 list?.forEach { object in
@@ -84,6 +85,7 @@ extension MessageManager {
             "params": [eventName, false]
         ] as [String: Any]
 
+        let currentRealm = Realm.current
         SocketManager.subscribe(request, eventName: eventName) { response in
             guard !response.isError() else {
                 return Log.debug(response.result.string)
@@ -92,7 +94,7 @@ extension MessageManager {
             let object = response.result["fields"]["args"][0]
             let subscriptionIdentifier = subscription.identifier
 
-            Realm.execute({ (realm) in
+            currentRealm?.execute({ (realm) in
                 guard let detachedSubscription = realm.object(ofType: Subscription.self, forPrimaryKey: subscriptionIdentifier ?? "") else { return }
                 let message = Message.getOrCreate(realm: realm, values: object, updates: { (object) in
                     object?.subscription = detachedSubscription
@@ -113,11 +115,12 @@ extension MessageManager {
             "params": [eventName, false]
             ] as [String: Any]
 
+        let currentRealm = Realm.current
         SocketManager.subscribe(request, eventName: eventName) { response in
             guard !response.isError() else { return Log.debug(response.result.string) }
 
             if let msgId = response.result["fields"]["args"][0]["_id"].string {
-                Realm.executeOnMainThread({ realm in
+                Realm.executeOnMainThread(realm: currentRealm, { realm in
                     guard let message = realm.object(ofType: Message.self, forPrimaryKey: msgId) else { return }
                     realm.delete(message)
                     completion(msgId)

--- a/Rocket.Chat/Managers/Model/PermissionManager.swift
+++ b/Rocket.Chat/Managers/Model/PermissionManager.swift
@@ -70,7 +70,7 @@ struct PermissionManager {
         }
     }
 
-    static func roles(for permission: PermissionType, realm: Realm? = Realm.shared) -> List<String>? {
+    static func roles(for permission: PermissionType, realm: Realm? = Realm.current) -> List<String>? {
         return realm?.object(ofType: Permission.self, forPrimaryKey: permission.rawValue)?.roles
     }
 }

--- a/Rocket.Chat/Managers/Model/PermissionManager.swift
+++ b/Rocket.Chat/Managers/Model/PermissionManager.swift
@@ -18,12 +18,13 @@ struct PermissionManager {
             "params": [eventName, false]
             ] as [String: Any]
 
+        let currentRealm = Realm.current
         SocketManager.subscribe(request, eventName: eventName) { response in
             guard !response.isError() else { return Log.debug(response.result.string) }
 
             let object = response.result["fields"]["args"][1]
 
-            Realm.execute({ (realm) in
+            currentRealm?.execute({ (realm) in
                 let permission = Permission.getOrCreate(realm: realm, values: object, updates: { _ in })
                 realm.add(permission, update: true)
             })
@@ -37,6 +38,7 @@ struct PermissionManager {
             "params": []
         ] as [String: Any]
 
+        let currentRealm = Realm.current
         SocketManager.send(requestPermissions) { response in
             guard !response.isError() else { return Log.debug(response.result.string) }
 
@@ -49,7 +51,7 @@ struct PermissionManager {
             let updated = response.result["result"]["update"].array
             let removed = response.result["result"]["remove"].array
 
-            Realm.execute({ realm in
+            currentRealm?.execute({ realm in
                 list?.forEach { object in
                     let permission = Permission.getOrCreate(realm: realm, values: object, updates: nil)
                     permissions.append(permission)

--- a/Rocket.Chat/Models/Auth.swift
+++ b/Rocket.Chat/Models/Auth.swift
@@ -38,7 +38,7 @@ final class Auth: Object {
     var user: User? {
         guard let userId = userId else { return nil }
 
-        let realm = self.realm ?? Realm.shared
+        let realm = self.realm ?? Realm.current
         return realm?.object(ofType: User.self, forPrimaryKey: userId)
     }
 

--- a/Rocket.Chat/Models/Base/BaseModel.swift
+++ b/Rocket.Chat/Models/Base/BaseModel.swift
@@ -18,13 +18,13 @@ class BaseModel: Object {
     }
 
     static func find(withIdentifier identifier: String) -> Self? {
-        return Realm.shared?.objects(self).filter("identifier = '\(identifier)'").first
+        return Realm.current?.objects(self).filter("identifier = '\(identifier)'").first
     }
 
     @discardableResult
     static func delete(withIdentifier identifier: String) -> Bool {
         guard
-            let realm = Realm.shared,
+            let realm = Realm.current,
             let object = realm.objects(self).filter("identifier = '\(identifier)'").first
         else {
             return false

--- a/Rocket.Chat/Models/CustomEmoji.swift
+++ b/Rocket.Chat/Models/CustomEmoji.swift
@@ -33,14 +33,14 @@ extension CustomEmoji {
         return imageUrl?.absoluteString
     }
 
-    static func withShortname(_ shortname: String, realm: Realm? = Realm.shared) -> CustomEmoji? {
+    static func withShortname(_ shortname: String, realm: Realm? = Realm.current) -> CustomEmoji? {
         guard let realm = realm, shortname.count > 2 else { return nil }
         let shortname = String(shortname.dropFirst().dropLast())
         return realm.objects(CustomEmoji.self).filter { $0.name == shortname || $0.aliases.contains(shortname) }.first
     }
 
     static func emojis() -> [Emoji] {
-        guard let emojis = Realm.shared?.objects(CustomEmoji.self) else { return [] }
+        guard let emojis = Realm.current?.objects(CustomEmoji.self) else { return [] }
 
         return emojis.flatMap { emoji -> Emoji? in
             guard let name = emoji.name, let imageUrl = emoji.imageUrl() else { return nil }

--- a/Rocket.Chat/Models/Subscription.swift
+++ b/Rocket.Chat/Models/Subscription.swift
@@ -157,11 +157,11 @@ extension Subscription {
 
 // MARK: Queries
 extension Subscription {
-    static func find(rid: String, realm: Realm? = Realm.shared) -> Subscription? {
+    static func find(rid: String, realm: Realm? = Realm.current) -> Subscription? {
         return realm?.objects(Subscription.self).filter("rid == '\(rid)'").first
     }
 
-    static func find(name: String, subscriptionType: [SubscriptionType], realm: Realm? = Realm.shared) -> Subscription? {
+    static func find(name: String, subscriptionType: [SubscriptionType], realm: Realm? = Realm.current) -> Subscription? {
         let predicate = NSPredicate(
             format: "name == %@ && privateType IN %@",
             name, subscriptionType.map { $0.rawValue }

--- a/Rocket.Chat/Models/User.swift
+++ b/Rocket.Chat/Models/User.swift
@@ -35,7 +35,7 @@ class User: BaseModel {
 
 extension User {
 
-    func hasPermission(_ permission: PermissionType, realm: Realm? = Realm.shared) -> Bool {
+    func hasPermission(_ permission: PermissionType, realm: Realm? = Realm.current) -> Bool {
         guard let permissionRoles = PermissionManager.roles(for: permission, realm: realm) else { return false }
 
         for userRole in self.roles {
@@ -75,7 +75,7 @@ extension User {
         return URL(string: "\(baseURL)/avatar/\(encodedUsername)")
     }
 
-    func canViewAdminPanel(realm: Realm? = Realm.shared) -> Bool {
+    func canViewAdminPanel(realm: Realm? = Realm.current) -> Bool {
         return hasPermission(.viewPrivilegedSetting, realm: realm) ||
             hasPermission(.viewStatistics, realm: realm) ||
             hasPermission(.viewUserAdministration, realm: realm) ||
@@ -91,7 +91,7 @@ enum UserQueryParameter {
 }
 
 extension User {
-    static func find(username: String, realm: Realm? = Realm.shared) -> User? {
+    static func find(username: String, realm: Realm? = Realm.current) -> User? {
         guard
             let realm = realm,
             let user = realm.objects(User.self).filter("username = %@", username).first
@@ -102,7 +102,7 @@ extension User {
         return user
     }
 
-    static func fetch(by queryParameter: UserQueryParameter, realm: Realm? = Realm.shared, api: API? = API.current(), completion: @escaping (User?) -> Void) {
+    static func fetch(by queryParameter: UserQueryParameter, realm: Realm? = Realm.current, api: API? = API.current(), completion: @escaping (User?) -> Void) {
         guard
             let realm = realm,
             let api = api

--- a/Rocket.Chat/Views/Form/Cells/MentionsTextFieldTableViewCell.swift
+++ b/Rocket.Chat/Views/Form/Cells/MentionsTextFieldTableViewCell.swift
@@ -61,7 +61,7 @@ class MentionsTextFieldTableViewCell: UITableViewCell, FormTableViewCellProtocol
 
     private func fetchUsers() {
         guard
-            let realm = Realm.shared,
+            let realm = Realm.current,
             let name = textFieldInput.text,
             name.count > 0
         else {

--- a/Rocket.ChatTests/Models/BaseModelSpec.swift
+++ b/Rocket.ChatTests/Models/BaseModelSpec.swift
@@ -84,7 +84,7 @@ class BaseModelSpec: XCTestCase {
             XCTAssert(BaseModel.delete(withIdentifier: "obj3") == false)
         })
 
-        XCTAssert(Realm.shared?.objects(BaseModel.self).count == 1)
-        XCTAssert(Realm.shared?.objects(BaseModel.self).first == object2)
+        XCTAssert(Realm.current?.objects(BaseModel.self).count == 1)
+        XCTAssert(Realm.current?.objects(BaseModel.self).first == object2)
     }
 }


### PR DESCRIPTION
@RocketChat/ios

We were performing write operations on async operations pointing to the `current` instance of Realm. The issue is: if we make a network operation for the "Server A" containing a realm operation on its callback, then switch to the "Server B" the callback would get data from "Server A" but would try to write it on "Server B" realm instance because it would be the `current` one. 

I just started capturing the `current` realm before the network/async operation and then using this reference to execute any instruction contained on the operation's callback.

Closes #1462
