### PR TITLE
[FIX] Build URL that may use subdirectory

### DIFF
--- a/Rocket.Chat/API/APIRequest.swift
+++ b/Rocket.Chat/API/APIRequest.swift
@@ -57,8 +57,8 @@ extension APIRequest {
     }
 
     func request(for api: API, options: APIRequestOptions = .none) -> URLRequest? {
-        var components = URLComponents(url: api.host, resolvingAgainstBaseURL: false)
-        components?.path = path
+        let requestedUrl = api.host.appendingPathComponent(path)
+        var components = URLComponents(url: requestedUrl, resolvingAgainstBaseURL: false)
         components?.query = query
 
         if let optionsQuery = options.query {

--- a/Rocket.Chat/API/APIRequest.swift
+++ b/Rocket.Chat/API/APIRequest.swift
@@ -57,8 +57,8 @@ extension APIRequest {
     }
 
     func request(for api: API, options: APIRequestOptions = .none) -> URLRequest? {
-        let requestedUrl = api.host.appendingPathComponent(path)
-        var components = URLComponents(url: requestedUrl, resolvingAgainstBaseURL: false)
+        var components = URLComponents(url: api.host, resolvingAgainstBaseURL: false)
+        components?.path += path
         components?.query = query
 
         if let optionsQuery = options.query {

--- a/Rocket.Chat/Extensions/URLExtension.swift
+++ b/Rocket.Chat/Extensions/URLExtension.swift
@@ -70,6 +70,12 @@ extension URL {
         if components.path.contains("websocket") {
             newURL = newURL?.deletingLastPathComponent()
         }
+
+        if var newURLString = newURL?.absoluteString, newURLString.last == "/" {
+            newURLString.removeLast()
+            newURL = URL(string: newURLString)
+        }
+
         return newURL
     }
 
@@ -84,6 +90,11 @@ extension URL {
         var newURL = components.url
         if !pathComponents.contains("websocket") {
             newURL = newURL?.appendingPathComponent("websocket")
+        }
+
+        if var newURLString = newURL?.absoluteString, newURLString.last == "/" {
+            newURLString.removeLast()
+            newURL = URL(string: newURLString)
         }
 
         return newURL

--- a/Rocket.ChatTests/Models/AuthSpec.swift
+++ b/Rocket.ChatTests/Models/AuthSpec.swift
@@ -66,14 +66,14 @@ class AuthSpec: XCTestCase, RealmTestCase {
         let object = Auth()
         object.serverURL = "wss://team.rocket.chat/websocket"
 
-        XCTAssertEqual(object.apiHost?.absoluteString, "https://team.rocket.chat/", "apiHost returns API Host correctly")
+        XCTAssertEqual(object.apiHost?.absoluteString, "https://team.rocket.chat", "apiHost returns API Host correctly")
     }
 
     func testAPIHostOnSubdirectory() {
         let object = Auth()
         object.serverURL = "wss://team.rocket.chat/subdirectory/websocket"
 
-        XCTAssertEqual(object.apiHost?.absoluteString, "https://team.rocket.chat/subdirectory/", "apiHost returns API Host correctly")
+        XCTAssertEqual(object.apiHost?.absoluteString, "https://team.rocket.chat/subdirectory", "apiHost returns API Host correctly")
     }
 
     func testAPIHostInvalidServerURL() {


### PR DESCRIPTION
@RocketChat/ios

A few weeks ago I've posted a change that introduced support for Rocket.Chat hosted on subdirectory (https://github.com/RocketChat/Rocket.Chat.iOS/pull/1277). Next day, @filipealva posted a fix that actually broken my patch but unblock him due to slash at the end of the `api.host` (https://github.com/RocketChat/Rocket.Chat.iOS/pull/1415). It resulted in a whole path replacement instead of applying requested path to the end of the host address!

There are four cases where Rocket.Chat could be hosted and where `/api/v1/me` should point to:
- `https://instance.com` -> `https://instance.com/api/v1/me`
- `https://instance.com/` -> `https://instance.com/api/v1/me`
- `https://instance.com/rocket` -> `https://instance.com/rocket/api/v1/me`
- `https://instance.com/rocket/` -> `https://instance.com/rocket/api/v1/me`

That's why this patch changes `=` (and even my previous `+=`) to `appendingPathComponent` method, which should work fine in all above cases. I've tested it on my own instance hosted on subdirectory and `https://open.rocket.chat`.