### PR TITLE
[FIX] Handle invalid session

### DIFF
--- a/Rocket.Chat/Controllers/Chat/MainChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MainChatViewController.swift
@@ -118,10 +118,6 @@ extension MainChatViewController: SocketConnectionHandler {
     func socketDidReturnError(socket: SocketManager, error: SocketError) {
         switch error.error {
         case .invalidUser:
-            if !socket.isUserAuthenticated {
-                return
-            }
-
             let alert = UIAlertController(
                 title: localized("alert.socket_error.invalid_user.title"),
                 message: localized("alert.socket_error.invalid_user.message"),

--- a/Rocket.Chat/Managers/Socket/Response/SocketError.swift
+++ b/Rocket.Chat/Managers/Socket/Response/SocketError.swift
@@ -15,7 +15,7 @@ extension SocketError {
 
         init(rawValue: String) {
             switch rawValue {
-            case "error-invalid-user":
+            case "error-invalid-user", "403":
                 self = .invalidUser
             default:
                 self = .other(rawValue)


### PR DESCRIPTION
@RocketChat/ios

It seems that the socket is now sending the status code for an invalid session error (`"403"`) when we were expecting the following string: `"error-invalid-user"`. 

Closes #1404
