### PR TITLE
[IMPROVEMENT] Remove retain cycles on core chat hierarchy

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChatControllerReplyHandler.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerReplyHandler.swift
@@ -14,7 +14,9 @@ extension ChatViewController {
         replyView = ReplyView.instantiateFromNib()
         replyView.backgroundColor = textInputbar.addonContentView.backgroundColor
         replyView.frame = textInputbar.addonContentView.bounds
-        replyView.onClose = stopReplying
+        replyView.onClose = { [weak self] in
+            self?.stopReplying()
+        }
 
         textInputbar.addonContentView.addSubview(replyView)
     }

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -153,7 +153,6 @@ final class ChatViewController: SLKTextViewController {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
-        SocketManager.removeConnectionHandler(token: socketHandlerToken)
         messagesToken?.invalidate()
         subscriptionToken?.invalidate()
     }

--- a/Rocket.Chat/Controllers/Chat/MainChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MainChatViewController.swift
@@ -47,7 +47,6 @@ class MainChatViewController: SideMenuController, SideMenuControllerDelegate {
         super.viewDidLoad()
 
         delegate = self
-
         SocketManager.addConnectionHandler(token: socketHandlerToken, handler: self)
 
         if let auth = AuthManager.isAuthenticated() {

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
@@ -311,11 +311,15 @@ extension SubscriptionsViewController {
         assigned = true
 
         subscriptions = auth.subscriptions.sorted(byKeyPath: "lastSeen", ascending: false)
-        subscriptionsToken = subscriptions?.observe(handleSubscriptionUpdates)
+        subscriptionsToken = subscriptions?.observe({ [weak self] changes in
+            self?.handleSubscriptionUpdates(changes: changes)
+        })
 
         if let currentUserIdentifier = AuthManager.currentUser()?.identifier {
             let query = realm.objects(User.self).filter("identifier = %@", currentUserIdentifier)
-            currentUserToken = query.observe(handleCurrentUserUpdates)
+            currentUserToken = query.observe({ [weak self] changes in
+                self?.handleCurrentUserUpdates(changes: changes)
+            })
         }
 
         groupSubscription()

--- a/Rocket.Chat/Managers/AppManager.swift
+++ b/Rocket.Chat/Managers/AppManager.swift
@@ -99,6 +99,7 @@ extension AppManager {
     }
 
     static func reloadApp() {
+        SocketManager.sharedInstance.connectionHandlers = [:]
         SocketManager.disconnect { (_, _) in
             DispatchQueue.main.async {
                 if AuthManager.isAuthenticated() != nil {


### PR DESCRIPTION
@RocketChat/ios

Some interesting information about the impact of this improvement. Note that these benchmarks are not meant to be exact information, they're just some information I could collect when simulating the same session before and after this fix. The steps of my test session: switch 30 times between servers then try to scroll up the messages on a busy channel (I made the tests using the same servers and the same channels). 

## CPU - Before

- Usage peak: 177%
- It took about 3 min for me to switch between the servers 30 times due to the performance loss

![cpu](https://user-images.githubusercontent.com/6117280/38841274-04734cd8-41ba-11e8-99c3-bb2643c0882f.png)

## CPU - After 

- Usage peak: 104%
- It took about 1:30 min for me to switch between the servers 30 times (it's visibly smoothier 👌 )

![cpu](https://user-images.githubusercontent.com/6117280/38841471-f069d602-41ba-11e8-8452-db3f1977c4e9.png)

## Memory - Before

- Allocated memory after the tests: 224MB

![memory](https://user-images.githubusercontent.com/6117280/38841548-4e76304c-41bb-11e8-8655-8ce42c31dc6f.png)

## Memory - After

- Allocated memory after the tests: 127MB

![memory](https://user-images.githubusercontent.com/6117280/38841573-6c7101ee-41bb-11e8-84e0-8fb988fd569c.png)

## Network - Before

- Received 10,4MB during the tests
- Sent 0,3MB during the tests

![network](https://user-images.githubusercontent.com/6117280/38841596-91e00862-41bb-11e8-9c99-bfc3f008e17c.png)

## Network - After

- Received 3,8MB during the tests
- Sent 0,1MB during the tests

![network](https://user-images.githubusercontent.com/6117280/38841679-f802fe6a-41bb-11e8-8199-86857ffae173.png)

Again, it's not an exact benchmark, but these discrepancies are for sure mostly caused by the LOTS of zombie instances we were unnecessarily holding in memory 🤓 


Closes #1549
Closes #1473
