### PR TITLE
[IMPROVEMENT] Holding core chat references when adding a new server

### DIFF
--- a/Rocket.Chat/Managers/AppManager.swift
+++ b/Rocket.Chat/Managers/AppManager.swift
@@ -99,6 +99,7 @@ extension AppManager {
     }
 
     static func reloadApp() {
+        SocketManager.sharedInstance.connectionHandlers.removeAllObjects()
         SocketManager.disconnect { (_, _) in
             DispatchQueue.main.async {
                 if AuthManager.isAuthenticated() != nil {

--- a/Rocket.Chat/Managers/AppManager.swift
+++ b/Rocket.Chat/Managers/AppManager.swift
@@ -99,7 +99,6 @@ extension AppManager {
     }
 
     static func reloadApp() {
-        SocketManager.sharedInstance.connectionHandlers = [:]
         SocketManager.disconnect { (_, _) in
             DispatchQueue.main.async {
                 if AuthManager.isAuthenticated() != nil {

--- a/Rocket.Chat/Managers/Socket/Response/SocketHandlers.swift
+++ b/Rocket.Chat/Managers/Socket/Response/SocketHandlers.swift
@@ -48,8 +48,12 @@ extension SocketManager {
         internalConnectionHandler?(socket, true)
         internalConnectionHandler = nil
 
-        for (_, handler) in connectionHandlers {
-            handler.socketDidConnect(socket: self)
+        if let enumerator = connectionHandlers.objectEnumerator() {
+            while let handler = enumerator.nextObject() {
+                if let handler = handler as? SocketConnectionHandler {
+                    handler.socketDidConnect(socket: self)
+                }
+            }
         }
     }
 
@@ -61,8 +65,12 @@ extension SocketManager {
         // Do nothing?
         let error = SocketError(json: result.result["error"])
 
-        for (_, handler) in connectionHandlers {
-            handler.socketDidReturnError(socket: self, error: error)
+        if let enumerator = connectionHandlers.objectEnumerator() {
+            while let handler = enumerator.nextObject() {
+                if let handler = handler as? SocketConnectionHandler {
+                    handler.socketDidReturnError(socket: self, error: error)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
@RocketChat/ios

Since we already had problems caused by holding strong references on `connectionHandlers` I decided to refactor `connectionHandlers` from `Dictionary` to `NSMapTable` which is able to store weak references. 

Although `NSMapTable` lets the objects to be released from memory automatically it doesn't happen as fast as if we manually clear the references, so keep in mind that if you need to deallocate the references stored on `connectionHandlers` immediately to do a heavy operation (such as switching to another server) you better clear it manually to avoid performance issues older devices. 

Closes #1568
