### PR TITLE
[IMPROVEMENT] Show action sheet when tapping usernames, mentions, etc

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -526,6 +526,7 @@
 		80D0CE742050BFBE0056B17F /* AuthManagerCurrentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8076FDB82048581F00114F28 /* AuthManagerCurrentUser.swift */; };
 		80D0CE752050BFD20056B17F /* AuthUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8076FDB42048571200114F28 /* AuthUser.swift */; };
 		80D41DF6208FC57100034D1F /* PreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D41DF5208FC57100034D1F /* PreferencesViewController.swift */; };
+		80D41DFA2092147300034D1F /* UserActionSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D41DF92092147300034D1F /* UserActionSheetPresenter.swift */; };
 		80D5637220592D32008896D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 80D5637120592D32008896D6 /* Assets.xcassets */; };
 		80D563752059325A008896D6 /* MimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D563742059325A008896D6 /* MimeType.swift */; };
 		80D5637720593533008896D6 /* ParseItemProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D5637620593533008896D6 /* ParseItemProviders.swift */; };
@@ -1172,6 +1173,7 @@
 		80D0CE6E20509C100056B17F /* SEAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEAvatarView.swift; sourceTree = "<group>"; };
 		80D0CE7020509C230056B17F /* SEAvatarView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SEAvatarView.xib; sourceTree = "<group>"; };
 		80D41DF5208FC57100034D1F /* PreferencesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesViewController.swift; sourceTree = "<group>"; };
+		80D41DF92092147300034D1F /* UserActionSheetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserActionSheetPresenter.swift; sourceTree = "<group>"; };
 		80D5637120592D32008896D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		80D563742059325A008896D6 /* MimeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeType.swift; sourceTree = "<group>"; };
 		80D5637620593533008896D6 /* ParseItemProviders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseItemProviders.swift; sourceTree = "<group>"; };
@@ -1654,6 +1656,7 @@
 		4161332F1D46CA2800E09DA2 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				80D41DFB2092152A00034D1F /* ActionSheets */,
 				41C275DD1D847FEE003C88CF /* Avatar */,
 				416133301D46CA3100E09DA2 /* Cells */,
 				41F167E51DAC450200775CCA /* Chat */,
@@ -1869,11 +1872,11 @@
 				419205481D52EDE6004EEC5F /* UILabelExtension.swift */,
 				994D1EDE205AB945007F29C8 /* UINavigationControllerExtension.swift */,
 				41E53A161E546F5500C3FBB3 /* UINibExtensions.swift */,
-				41A1748B1DD9F2F900188E3B /* UIViewControllerExtension.swift */,
 				41D5BC301DAFBEF4009A493A /* UIViewExtentions.swift */,
 				41B554C41FBF0C71000510B7 /* UIWindowExtensions.swift */,
 				41BAE3E61D71B26C00C2445A /* URLExtension.swift */,
 				8076FDE52048CD0600114F28 /* UserDefaults+Group.swift */,
+				41A1748B1DD9F2F900188E3B /* UIViewControllerExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2666,6 +2669,14 @@
 				807FB53E2045F36D00E21429 /* EmojioneSpec.swift */,
 			);
 			path = RCEmojiKit;
+			sourceTree = "<group>";
+		};
+		80D41DFB2092152A00034D1F /* ActionSheets */ = {
+			isa = PBXGroup;
+			children = (
+				80D41DF92092147300034D1F /* UserActionSheetPresenter.swift */,
+			);
+			path = ActionSheets;
 			sourceTree = "<group>";
 		};
 		80D563702058A8A7008896D6 /* Cells */ = {
@@ -3790,6 +3801,7 @@
 				4174CB131D2D99960086DAC8 /* BaseViewController.swift in Sources */,
 				897083D31F8CF08100233561 /* CheckTableViewCell.swift in Sources */,
 				8076FDC72048632300114F28 /* SubscriptionQueries.swift in Sources */,
+				80D41DFA2092147300034D1F /* UserActionSheetPresenter.swift in Sources */,
 				80054CFE1FDAFF5200F5ECF9 /* PushClient.swift in Sources */,
 				597ECBA21E3708A50041C5C5 /* DataExtension.swift in Sources */,
 				414A1FFC1D46395900093E10 /* SocketResponse.swift in Sources */,

--- a/Rocket.Chat/Controllers/Chat/ChannelInfoViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChannelInfoViewController.swift
@@ -126,7 +126,6 @@ class ChannelInfoViewController: BaseViewController {
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let membersList = segue.destination as? MembersListViewController {
-            membersList.delegate = self
             membersList.data.subscription = self.subscription
         }
 
@@ -255,17 +254,4 @@ extension ChannelInfoViewController: UITableViewDataSource {
         return tableViewData[section].count
     }
 
-}
-
-// MARK: MembersListDelegate
-
-extension ChannelInfoViewController: MembersListDelegate {
-    func membersList(_ controller: MembersListViewController, didSelectUser user: User) {
-        guard let username = user.username else { return }
-
-        AppManager.openDirectMessage(username: username) {
-            controller.dismiss(animated: true, completion: nil)
-            self.dismiss(animated: true, completion: nil)
-        }
-    }
 }

--- a/Rocket.Chat/Controllers/Chat/ChatControllerMessageCellProtocol.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerMessageCellProtocol.swift
@@ -1,4 +1,4 @@
- //
+//
 //  ChatControllerMessageCellProtocol.swift
 //  Rocket.Chat
 //

--- a/Rocket.Chat/Controllers/Chat/ChatControllerMessageCellProtocol.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerMessageCellProtocol.swift
@@ -1,4 +1,4 @@
-//
+ //
 //  ChatControllerMessageCellProtocol.swift
 //  Rocket.Chat
 //
@@ -12,7 +12,7 @@ import MobilePlayer
 import FLAnimatedImage
 import SimpleImageViewer
 
-extension ChatViewController: ChatMessageCellProtocol {
+extension ChatViewController: ChatMessageCellProtocol, UserActionSheetPresenter {
     func handleLongPress(reactionListView: ReactionListView, reactionView: ReactionView) {
 
         // set up controller
@@ -68,8 +68,8 @@ extension ChatViewController: ChatMessageCellProtocol {
     }
 
     func handleUsernameTapMessageCell(_ message: Message, view: UIView, recognizer: UIGestureRecognizer) {
-        guard let username = message.user?.username else { return }
-        AppManager.openDirectMessage(username: username)
+        guard let user = message.user else { return }
+        presentActionSheetForUser(user, source: (view, nil))
     }
 
     func openURL(url: URL) {

--- a/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MembersListViewController.swift
@@ -8,10 +8,6 @@
 
 import UIKit
 
-protocol MembersListDelegate: class {
-    func membersList(_ controller: MembersListViewController, didSelectUser user: User)
-}
-
 class MembersListViewData {
     var subscription: Subscription?
 
@@ -74,8 +70,6 @@ class MembersListViewController: BaseViewController {
     var loaderCell: LoaderTableViewCell!
 
     var data = MembersListViewData()
-
-    weak var delegate: MembersListDelegate?
 
     @objc func refreshControlDidPull(_ sender: UIRefreshControl) {
         let data = MembersListViewData()
@@ -182,12 +176,10 @@ extension MembersListViewController: UITableViewDataSource {
     }
 }
 
-extension MembersListViewController: UITableViewDelegate {
+extension MembersListViewController: UITableViewDelegate, UserActionSheetPresenter {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-
-        let user = data.member(at: indexPath.row)
-        delegate?.membersList(self, didSelectUser: user)
+        presentActionSheetForUser(data.member(at: indexPath.row), source: (tableView, tableView.rectForRow(at: indexPath)))
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {

--- a/Rocket.Chat/Resources/cs.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/cs.lproj/Localizable.strings
@@ -300,3 +300,6 @@
 "myaccount.settings.profile.new_password.password_required.title" = "Enter your password"; // TODO
 "myaccount.settings.profile.new_password.password_required.message" = "Your current password is required when setting a new password."; // TODO
 "myaccount.settings.profile.new_password.password_required.placeholder" = "Password"; // TODO
+
+// User Action Sheet
+"user_action_sheet.conversation" = "Conversation"; // TODO

--- a/Rocket.Chat/Resources/de.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/de.lproj/Localizable.strings
@@ -300,3 +300,6 @@
 "myaccount.settings.profile.new_password.password_required.title" = "Passwort eingeben";
 "myaccount.settings.profile.new_password.password_required.message" = "Das aktuelle Passwort wird zum Ändern benötigt.";
 "myaccount.settings.profile.new_password.password_required.placeholder" = "Passwort";
+
+// User Action Sheet
+"user_action_sheet.conversation" = "Conversation"; // TODO

--- a/Rocket.Chat/Resources/el.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/el.lproj/Localizable.strings
@@ -300,3 +300,6 @@
 "myaccount.settings.profile.new_password.password_required.title" = "Enter your password"; // TODO
 "myaccount.settings.profile.new_password.password_required.message" = "Your current password is required when setting a new password."; // TODO
 "myaccount.settings.profile.new_password.password_required.placeholder" = "Password"; // TODO
+
+// User Action Sheet
+"user_action_sheet.conversation" = "Conversation"; // TODO

--- a/Rocket.Chat/Resources/en.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/en.lproj/Localizable.strings
@@ -300,3 +300,6 @@
 "myaccount.settings.profile.new_password.password_required.title" = "Enter your password";
 "myaccount.settings.profile.new_password.password_required.message" = "Your current password is required when setting a new password.";
 "myaccount.settings.profile.new_password.password_required.placeholder" = "Password";
+
+// User Action Sheet
+"user_action_sheet.conversation" = "Conversation";

--- a/Rocket.Chat/Resources/es.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/es.lproj/Localizable.strings
@@ -300,3 +300,6 @@
 "myaccount.settings.profile.new_password.password_required.title" = "Enter your password"; // TODO
 "myaccount.settings.profile.new_password.password_required.message" = "Your current password is required when setting a new password."; // TODO
 "myaccount.settings.profile.new_password.password_required.placeholder" = "Password"; // TODO
+
+// User Action Sheet
+"user_action_sheet.conversation" = "Conversation"; // TODO

--- a/Rocket.Chat/Resources/fr.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/fr.lproj/Localizable.strings
@@ -301,3 +301,7 @@
 "myaccount.settings.profile.new_password.password_required.title" = "Enter your password"; // TODO
 "myaccount.settings.profile.new_password.password_required.message" = "Your current password is required when setting a new password."; // TODO
 "myaccount.settings.profile.new_password.password_required.placeholder" = "Password"; // TODO
+
+// User Action Sheet
+"user_action_sheet.conversation" = "Conversation"; // TODO
+

--- a/Rocket.Chat/Resources/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pl.lproj/Localizable.strings
@@ -300,3 +300,6 @@
 "myaccount.settings.profile.new_password.password_required.title" = "Enter your password"; // TODO
 "myaccount.settings.profile.new_password.password_required.message" = "Your current password is required when setting a new password."; // TODO
 "myaccount.settings.profile.new_password.password_required.placeholder" = "Password"; // TODO
+
+// User Action Sheet
+"user_action_sheet.conversation" = "Conversation"; // TODO

--- a/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
@@ -300,3 +300,6 @@
 "myaccount.settings.profile.new_password.password_required.title" = "Insira sua senha";
 "myaccount.settings.profile.new_password.password_required.message" = "É necessário inserir sua senha atual para criar uma nova senha.";
 "myaccount.settings.profile.new_password.password_required.placeholder" = "Senha";
+
+// User Action Sheet
+"user_action_sheet.conversation" = "Conversa";

--- a/Rocket.Chat/Views/ActionSheets/UserActionSheetPresenter.swift
+++ b/Rocket.Chat/Views/ActionSheets/UserActionSheetPresenter.swift
@@ -1,0 +1,34 @@
+//
+//  UserActionSheetPresenter.swift
+//  Rocket.Chat
+//
+//  Created by Matheus Cardoso on 4/26/18.
+//  Copyright © 2018 Rocket.Chat. All rights reserved.
+//
+
+import Foundation
+
+protocol UserActionSheetPresenter {
+    func presentActionSheetForUser(_ user: User, source: (view: UIView?, rect: CGRect?)?)
+}
+
+extension UserActionSheetPresenter where Self: UIViewController {
+    func presentActionSheetForUser(_ user: User, source: (view: UIView?, rect: CGRect?)? = nil) {
+        let controller = UIAlertController(title: user.displayName(), message: nil, preferredStyle: .actionSheet)
+        controller.popoverPresentationController?.sourceView = source?.view
+        controller.popoverPresentationController?.sourceRect = source?.rect ?? source?.view?.frame ?? .zero
+
+        controller.addAction(UIAlertAction(title: localized("user_action_sheet.conversation"), style: .default, handler: { [weak self] _ in
+            guard let username = user.username else { return }
+
+            AppManager.openDirectMessage(username: username) {
+                controller.dismiss(animated: true, completion: nil)
+                self?.dismiss(animated: true, completion: nil)
+            }
+        }))
+
+        controller.addAction(UIAlertAction(title: localized("global.cancel"), style: .cancel))
+
+        present(controller, animated: true, completion: nil)
+    }
+}

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -290,7 +290,7 @@ final class ChatMessageCell: UICollectionViewCell {
     }
 
     @objc func handleUsernameTapGestureCell(recognizer: UIGestureRecognizer) {
-        delegate?.handleUsernameTapMessageCell(message, view: contentView, recognizer: recognizer)
+        delegate?.handleUsernameTapMessageCell(message, view: labelUsername, recognizer: recognizer)
     }
 }
 

--- a/Rocket.Chat/Views/Cells/Chat/Info/MemberCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/Info/MemberCell.swift
@@ -13,7 +13,7 @@ struct MemberCellData {
 
     var nameText: String {
         let utcText = member.utcOffset != nil ? "(UTC \(member.utcOffset ?? 0))" : ""
-        return "\(member.name ?? "") \(utcText)"
+        return "\(member.displayName()) \(utcText)"
     }
 
     var statusColor: UIColor {

--- a/Rocket.Chat/Views/Chat/RCTextView.swift
+++ b/Rocket.Chat/Views/Chat/RCTextView.swift
@@ -154,6 +154,20 @@ extension RCTextView: UITextViewDelegate {
             return false
         }
 
-        return true
+        if let deepLink = DeepLink(url: URL) {
+            guard
+                case let .mention(name) = deepLink,
+                let user = User.find(username: name),
+                let start = textView.position(from: textView.beginningOfDocument, offset: characterRange.location),
+                let end = textView.position(from: start, offset: characterRange.length),
+                let range = textView.textRange(from: start, to: end)
+            else {
+                return true
+            }
+
+            ChatViewController.shared?.presentActionSheetForUser(user, source: (textView, textView.firstRect(for: range)))
+        }
+
+        return false
     }
 }


### PR DESCRIPTION
@RocketChat/ios

- Instead of just opening the direct message without prompting the user, now we show an action sheet.
- Also fixes real name/username not displaying according server settings in member cells. (used in members list and reactions)

Preview images:
![](https://i.imgur.com/2MpWMof.jpg)
![](https://i.imgur.com/GIRI1XL.jpg)
![](https://i.imgur.com/ByJqrzS.jpg)

iPhone:
![](https://i.imgur.com/gT2En70.png)