### PR TITLE
[FIX] Logic on sending sequencial messages when the screen appears

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChatDataController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatDataController.swift
@@ -233,7 +233,7 @@ final class ChatDataController {
             }).count == 0
         }
 
-        for (idx, newObj) in items.enumerated() {
+        for newObj in items {
             if let lastObj = lastObj {
                 if needsDateSeparator(lastObj) {
                     insertDaySeparator(from: lastObj)

--- a/Rocket.Chat/Models/Message/MessageReply.swift
+++ b/Rocket.Chat/Models/Message/MessageReply.swift
@@ -36,8 +36,8 @@ extension Message {
             subscription.type != .directMessage,
             let username = self.user?.username,
             username != AuthManager.currentUser()?.username
-            else {
-                return quoteString
+        else {
+            return quoteString
         }
 
         return " @\(username)\(quoteString)"


### PR DESCRIPTION
@RocketChat/ios

## Description

Issue: if you enter in a room and send a message, where this message should be sequential, the message won't be sequential until you send another one and the layout breaks. This was happening because the last message of the dataset was an invisible unread marker.

Now, when you enter in a room and send a message, if the message needs to be sequential, it will be just fine.