### PR TITLE
[NEW] Add support to Broadcast rooms

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -262,6 +262,7 @@
 		41D4ABAB1F4CD10C00ACDDDD /* ChatCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D4ABAA1F4CD10C00ACDDDD /* ChatCollectionViewFlowLayout.swift */; };
 		41D51B0620A62DD60073E8E7 /* Role.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D51B0520A62DD60073E8E7 /* Role.swift */; };
 		41D51B0720A62DD60073E8E7 /* Role.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D51B0520A62DD60073E8E7 /* Role.swift */; };
+		41D51B0920A635150073E8E7 /* SubscriptionRolesRequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D51B0820A635150073E8E7 /* SubscriptionRolesRequestSpec.swift */; };
 		41D5BC311DAFBEF4009A493A /* UIViewExtentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D5BC301DAFBEF4009A493A /* UIViewExtentions.swift */; };
 		41D701D61E67111E00FED2EE /* MessageTextFontAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D701D51E67111E00FED2EE /* MessageTextFontAttributes.swift */; };
 		41D701D81E6763D100FED2EE /* NSAttributedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D701D71E6763D100FED2EE /* NSAttributedStringExtensions.swift */; };
@@ -943,6 +944,7 @@
 		41D3A62F1E0805490011949D /* ChatMessageDaySeparator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageDaySeparator.swift; sourceTree = "<group>"; };
 		41D4ABAA1F4CD10C00ACDDDD /* ChatCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		41D51B0520A62DD60073E8E7 /* Role.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Role.swift; sourceTree = "<group>"; };
+		41D51B0820A635150073E8E7 /* SubscriptionRolesRequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionRolesRequestSpec.swift; sourceTree = "<group>"; };
 		41D5BC301DAFBEF4009A493A /* UIViewExtentions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewExtentions.swift; sourceTree = "<group>"; };
 		41D701D51E67111E00FED2EE /* MessageTextFontAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageTextFontAttributes.swift; sourceTree = "<group>"; };
 		41D701D71E6763D100FED2EE /* NSAttributedStringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensions.swift; sourceTree = "<group>"; };
@@ -2465,6 +2467,7 @@
 				990FF6D7207438D4007B4A53 /* SubscriptionMentionsRequestSpec.swift */,
 				992B5AB7209A2890009C8123 /* SubscriptionFilesRequestSpec.swift */,
 				80E9DBD7209CB06000A48CA9 /* SubscriptionReadRequestSpec.swift */,
+				41D51B0820A635150073E8E7 /* SubscriptionRolesRequestSpec.swift */,
 			);
 			path = Subscription;
 			sourceTree = "<group>";
@@ -3963,6 +3966,7 @@
 				77C2612E1F97453600724A1F /* TextFieldSpec.swift in Sources */,
 				4171ABA51E7C056E009FC3F0 /* AvatarViewSpec.swift in Sources */,
 				994DA2B32065486D00083FB8 /* WebBrowserViewModelSpec.swift in Sources */,
+				41D51B0920A635150073E8E7 /* SubscriptionRolesRequestSpec.swift in Sources */,
 				805DEC391FFE54820033151B /* CustomEmojiSpec.swift in Sources */,
 				D18675EA1F70A58B00406FB4 /* InfoRequestSpec.swift in Sources */,
 				808792361FB145B200EFE77F /* PermissionManagerSpec.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -165,6 +165,8 @@
 		414A1FFA1D46395400093E10 /* SocketManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414A1FF91D46395400093E10 /* SocketManager.swift */; };
 		414A1FFC1D46395900093E10 /* SocketResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414A1FFB1D46395900093E10 /* SocketResponse.swift */; };
 		414D99161EA0E7CB0020F7E9 /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414D99151EA0E7CB0020F7E9 /* SignupViewController.swift */; };
+		414E8A8D20A5DD2200615CE6 /* SubscriptionRolesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414E8A8C20A5DD2200615CE6 /* SubscriptionRolesRequest.swift */; };
+		414E8A8F20A5DDF800615CE6 /* ChatControllerRolesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414E8A8E20A5DDF800615CE6 /* ChatControllerRolesController.swift */; };
 		414EFF921E54FE69004F001F /* AuthExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414EFF911E54FE69004F001F /* AuthExtensions.swift */; };
 		415066881EB8B541003AEA1C /* MessageTextCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 415066871EB8B541003AEA1C /* MessageTextCacheManager.swift */; };
 		4151807C1EAE249F0000A039 /* ChatMessageTextViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4151807A1EAE249F0000A039 /* ChatMessageTextViewModelSpec.swift */; };
@@ -258,6 +260,8 @@
 		41D3A62E1E0805310011949D /* ChatMessageDaySeparator.xib in Resources */ = {isa = PBXBuildFile; fileRef = 41D3A62D1E0805310011949D /* ChatMessageDaySeparator.xib */; };
 		41D3A6301E0805490011949D /* ChatMessageDaySeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D3A62F1E0805490011949D /* ChatMessageDaySeparator.swift */; };
 		41D4ABAB1F4CD10C00ACDDDD /* ChatCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D4ABAA1F4CD10C00ACDDDD /* ChatCollectionViewFlowLayout.swift */; };
+		41D51B0620A62DD60073E8E7 /* Role.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D51B0520A62DD60073E8E7 /* Role.swift */; };
+		41D51B0720A62DD60073E8E7 /* Role.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D51B0520A62DD60073E8E7 /* Role.swift */; };
 		41D5BC311DAFBEF4009A493A /* UIViewExtentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D5BC301DAFBEF4009A493A /* UIViewExtentions.swift */; };
 		41D701D61E67111E00FED2EE /* MessageTextFontAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D701D51E67111E00FED2EE /* MessageTextFontAttributes.swift */; };
 		41D701D81E6763D100FED2EE /* NSAttributedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D701D71E6763D100FED2EE /* NSAttributedStringExtensions.swift */; };
@@ -843,6 +847,8 @@
 		414A1FF91D46395400093E10 /* SocketManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketManager.swift; sourceTree = "<group>"; };
 		414A1FFB1D46395900093E10 /* SocketResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketResponse.swift; sourceTree = "<group>"; };
 		414D99151EA0E7CB0020F7E9 /* SignupViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupViewController.swift; sourceTree = "<group>"; };
+		414E8A8C20A5DD2200615CE6 /* SubscriptionRolesRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionRolesRequest.swift; sourceTree = "<group>"; };
+		414E8A8E20A5DDF800615CE6 /* ChatControllerRolesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatControllerRolesController.swift; sourceTree = "<group>"; };
 		414EFF911E54FE69004F001F /* AuthExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthExtensions.swift; sourceTree = "<group>"; };
 		415066871EB8B541003AEA1C /* MessageTextCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageTextCacheManager.swift; sourceTree = "<group>"; };
 		4151807A1EAE249F0000A039 /* ChatMessageTextViewModelSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageTextViewModelSpec.swift; sourceTree = "<group>"; };
@@ -936,6 +942,7 @@
 		41D3A62D1E0805310011949D /* ChatMessageDaySeparator.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ChatMessageDaySeparator.xib; sourceTree = "<group>"; };
 		41D3A62F1E0805490011949D /* ChatMessageDaySeparator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageDaySeparator.swift; sourceTree = "<group>"; };
 		41D4ABAA1F4CD10C00ACDDDD /* ChatCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
+		41D51B0520A62DD60073E8E7 /* Role.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Role.swift; sourceTree = "<group>"; };
 		41D5BC301DAFBEF4009A493A /* UIViewExtentions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewExtentions.swift; sourceTree = "<group>"; };
 		41D701D51E67111E00FED2EE /* MessageTextFontAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageTextFontAttributes.swift; sourceTree = "<group>"; };
 		41D701D71E6763D100FED2EE /* NSAttributedStringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensions.swift; sourceTree = "<group>"; };
@@ -2040,6 +2047,7 @@
 				805DEC361FFC08870033151B /* CustomEmoji.swift */,
 				8073719F1F96937100D53ADF /* LoginService.swift */,
 				806401301FB09DE800990572 /* Permission.swift */,
+				41D51B0520A62DD60073E8E7 /* Role.swift */,
 				99C577ED207E4F1500CE9B4D /* File.swift */,
 			);
 			path = Models;
@@ -2240,6 +2248,7 @@
 				41EE157F1E05BF1F00754D45 /* ChatControllerMessageCellProtocol.swift */,
 				41852E881F92BBEC00D1C499 /* ChatControllerReplyHandler.swift */,
 				41EE15811E05BF9600754D45 /* ChatControllerSocketConnectionHandler.swift */,
+				414E8A8E20A5DDF800615CE6 /* ChatControllerRolesController.swift */,
 				41B4B2331E40B1D200F4D252 /* ChatControllerUploader.swift */,
 				41C45AEE1DFAD42800D9969C /* ChatDataController.swift */,
 				41E2FA061D41513C00238DFD /* ChatViewController.swift */,
@@ -2441,6 +2450,7 @@
 				990FF6D520740C79007B4A53 /* SubscriptionMentionsRequest.swift */,
 				800E22851F8507E400DA84F1 /* SubscriptionMessagesRequest.swift */,
 				9987B59B2093E60C007D277C /* SubscriptionFilesRequest.swift */,
+				414E8A8C20A5DD2200615CE6 /* SubscriptionRolesRequest.swift */,
 				806EFA5D209BF1AC00D0D650 /* SubscriptionReadRequest.swift */,
 			);
 			path = Subscription;
@@ -3763,6 +3773,7 @@
 				80054CF31FD951B100F5ECF9 /* MessagesClient.swift in Sources */,
 				33F73B302073F24200F03F29 /* NotificationViewController.swift in Sources */,
 				99DBB8742090360600382DB2 /* MessagesListControllerSearch.swift in Sources */,
+				414E8A8D20A5DD2200615CE6 /* SubscriptionRolesRequest.swift in Sources */,
 				80AE2542203E61AF00DC2867 /* ChatMessageUnreadSeparator.swift in Sources */,
 				8013F86D1FD6B59A00EE1A4E /* APIClient.swift in Sources */,
 				414D99161EA0E7CB0020F7E9 /* SignupViewController.swift in Sources */,
@@ -3881,6 +3892,7 @@
 				35A203212022D3F900B4BE5A /* ChatMessageAttachmentView.swift in Sources */,
 				80CFB5741F8DA55C00FC9715 /* ReplyView.swift in Sources */,
 				41E991D41D343A9F00BDDCA8 /* DateExtension.swift in Sources */,
+				41D51B0620A62DD60073E8E7 /* Role.swift in Sources */,
 				41D3A6301E0805490011949D /* ChatMessageDaySeparator.swift in Sources */,
 				41B554C71FBF0F9D000510B7 /* WindowManager.swift in Sources */,
 				41900C271D9FE35400308EF4 /* Attachment.swift in Sources */,
@@ -3932,6 +3944,7 @@
 				41865AF21FC8B23400A5E48F /* WebViewControllerEmbedded.swift in Sources */,
 				414A1FF61D46320F00093E10 /* ResponseMessage.swift in Sources */,
 				4151B44E1E2CF19A00F8AA1B /* UserModelHandler.swift in Sources */,
+				414E8A8F20A5DDF800615CE6 /* ChatControllerRolesController.swift in Sources */,
 				80DC9A6C206BA95600032BE0 /* Localized.swift in Sources */,
 				14A6A83120421DF8008C210D /* ColorPickerView.swift in Sources */,
 				8013F88E1FD6B83C00EE1A4E /* CommandModelMapping.swift in Sources */,
@@ -4077,6 +4090,7 @@
 				80FA90702056A33A0069038F /* SEComposeViewModel.swift in Sources */,
 				8076FD9B20484DBF00114F28 /* DatabaseManager.swift in Sources */,
 				80977AB2204EE21F00C41435 /* SendMessageRequest.swift in Sources */,
+				41D51B0720A62DD60073E8E7 /* Role.swift in Sources */,
 				80977AB6204EEF1E00C41435 /* SelectServer.swift in Sources */,
 				807FB55B2046E7DD00E21429 /* SERoomsViewController.swift in Sources */,
 				80977AC4204FEEA700C41435 /* SEComposeHeaderViewModel.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -250,6 +250,8 @@
 		41C275DF1D848005003C88CF /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C275DE1D848005003C88CF /* AvatarView.swift */; };
 		41C275E11D84815C003C88CF /* AvatarView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 41C275E01D84815C003C88CF /* AvatarView.xib */; };
 		41C45AEF1DFAD42800D9969C /* ChatDataController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C45AEE1DFAD42800D9969C /* ChatDataController.swift */; };
+		41C955FA20A3931C00FC8314 /* ChatMessageActionButtonsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 41F3705320A3917D00C5449E /* ChatMessageActionButtonsView.xib */; };
+		41C955FC20A3937A00FC8314 /* ChatMessageActionButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C955FB20A3937A00FC8314 /* ChatMessageActionButtonsView.swift */; };
 		41CABFF81F5047D600E0B289 /* ChatLoaderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 41CABFF71F5047D600E0B289 /* ChatLoaderCell.xib */; };
 		41CABFFA1F5047E200E0B289 /* ChatLoaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CABFF91F5047E200E0B289 /* ChatLoaderCell.swift */; };
 		41CABFFC1F50515100E0B289 /* ArrayExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CABFFB1F50515100E0B289 /* ArrayExtensions.swift */; };
@@ -927,6 +929,7 @@
 		41C275DE1D848005003C88CF /* AvatarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
 		41C275E01D84815C003C88CF /* AvatarView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AvatarView.xib; sourceTree = "<group>"; };
 		41C45AEE1DFAD42800D9969C /* ChatDataController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatDataController.swift; sourceTree = "<group>"; };
+		41C955FB20A3937A00FC8314 /* ChatMessageActionButtonsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageActionButtonsView.swift; sourceTree = "<group>"; };
 		41CABFF71F5047D600E0B289 /* ChatLoaderCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ChatLoaderCell.xib; sourceTree = "<group>"; };
 		41CABFF91F5047E200E0B289 /* ChatLoaderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatLoaderCell.swift; sourceTree = "<group>"; };
 		41CABFFB1F50515100E0B289 /* ArrayExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayExtensions.swift; sourceTree = "<group>"; };
@@ -976,6 +979,7 @@
 		41EE15811E05BF9600754D45 /* ChatControllerSocketConnectionHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatControllerSocketConnectionHandler.swift; sourceTree = "<group>"; };
 		41F167E81DAC4D4300775CCA /* ChatTitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatTitleView.swift; sourceTree = "<group>"; };
 		41F167EA1DAC4D5500775CCA /* ChatTitleView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ChatTitleView.xib; sourceTree = "<group>"; };
+		41F3705320A3917D00C5449E /* ChatMessageActionButtonsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ChatMessageActionButtonsView.xib; sourceTree = "<group>"; };
 		41F3C0FF1DB577ED000E0C76 /* MessageURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageURL.swift; sourceTree = "<group>"; };
 		41F8487D1FA38B0A00C9AE84 /* PreferencesViewModelSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesViewModelSpec.swift; sourceTree = "<group>"; };
 		41FE55521F6038D60071E97A /* DatabaseManagerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseManagerSpec.swift; sourceTree = "<group>"; };
@@ -1756,6 +1760,8 @@
 				80AE2543203E61CF00DC2867 /* ChatMessageUnreadSeparator.xib */,
 				412A95D41FD94ED000954AA6 /* ChatMessageVideoView.swift */,
 				412A95D51FD94ED000954AA6 /* ChatMessageVideoView.xib */,
+				41C955FB20A3937A00FC8314 /* ChatMessageActionButtonsView.swift */,
+				41F3705320A3917D00C5449E /* ChatMessageActionButtonsView.xib */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -3224,6 +3230,7 @@
 				41C275E11D84815C003C88CF /* AvatarView.xib in Resources */,
 				14F8A261202E64B200175FDC /* BnW-76@3x.png in Resources */,
 				809B53121FE2F2F900833DD2 /* ReactionView.xib in Resources */,
+				41C955FA20A3931C00FC8314 /* ChatMessageActionButtonsView.xib in Resources */,
 				14F8A270202E653E00175FDC /* Grey-76@2x.png in Resources */,
 				14F8A295202E65C700175FDC /* Blue-76@3x.png in Resources */,
 				80A2F39420057B48005D2DCA /* EmojiAutocompleteCell.xib in Resources */,
@@ -3746,6 +3753,7 @@
 				80113DF81F98330C0048F2C2 /* OAuthViewController.swift in Sources */,
 				80E9DBD6209CA8FE00A48CA9 /* Closeable.swift in Sources */,
 				9987B5962093E4BA007D277C /* FilesListViewController.swift in Sources */,
+				41C955FC20A3937A00FC8314 /* ChatMessageActionButtonsView.swift in Sources */,
 				806DB94820695BCF004ED8ED /* AuthViewControllerConnectionHandler.swift in Sources */,
 				339B692B2050449700F97392 /* KeyboardFrameView.swift in Sources */,
 				0B9AB2C320444ED600ABEA05 /* LanguageViewModel.swift in Sources */,

--- a/Rocket.Chat/API/Requests/Subscription/SubscriptionFilesRequest.swift
+++ b/Rocket.Chat/API/Requests/Subscription/SubscriptionFilesRequest.swift
@@ -23,7 +23,7 @@ fileprivate extension SubscriptionType {
     }
 }
 
-class SubscriptionFilesRequest: APIRequest {
+final class SubscriptionFilesRequest: APIRequest {
     typealias APIResourceType = SubscriptionFilesResource
 
     var path: String {

--- a/Rocket.Chat/API/Requests/Subscription/SubscriptionRolesRequest.swift
+++ b/Rocket.Chat/API/Requests/Subscription/SubscriptionRolesRequest.swift
@@ -44,9 +44,10 @@ final class SubscriptionRolesRequest: APIRequest {
 
 final class SubscriptionRolesResource: APIResource {
     var subscriptionRoles: [SubscriptionRoles]? {
+        guard let realm = Realm.current else { return nil }
         return raw?["roles"].arrayValue.map {
             let object = SubscriptionRoles()
-            object.user = User.find(withIdentifier: $0["u"]["_id"].stringValue)
+            object.user = User.getOrCreate(realm: realm, values: $0["u"], updates: nil)
             object.roles.append(contentsOf: $0["roles"].arrayValue.compactMap({ $0.string }))
             return object
         }

--- a/Rocket.Chat/API/Requests/Subscription/SubscriptionRolesRequest.swift
+++ b/Rocket.Chat/API/Requests/Subscription/SubscriptionRolesRequest.swift
@@ -25,6 +25,8 @@ fileprivate extension SubscriptionType {
 final class SubscriptionRolesRequest: APIRequest {
     typealias APIResourceType = SubscriptionRolesResource
 
+    let requiredVersion = Version(0, 64, 2)
+
     var path: String {
         return type.path
     }
@@ -43,7 +45,7 @@ final class SubscriptionRolesRequest: APIRequest {
 final class SubscriptionRolesResource: APIResource {
     var subscriptionRoles: [SubscriptionRoles]? {
         return raw?["roles"].arrayValue.map {
-            var object = SubscriptionRoles()
+            let object = SubscriptionRoles()
             object.user = User.find(withIdentifier: $0["u"]["_id"].stringValue)
             object.roles.append(contentsOf: $0["roles"].arrayValue.compactMap({ $0.string }))
             return object

--- a/Rocket.Chat/API/Requests/Subscription/SubscriptionRolesRequest.swift
+++ b/Rocket.Chat/API/Requests/Subscription/SubscriptionRolesRequest.swift
@@ -1,0 +1,56 @@
+//
+//  SubscriptionRolesRequest.swift
+//  Rocket.Chat
+//
+//  Created by Rafael Kellermann Streit on 11/05/18.
+//  Copyright © 2018 Rocket.Chat. All rights reserved.
+//
+
+import SwiftyJSON
+import RealmSwift
+
+fileprivate extension SubscriptionType {
+    var path: String {
+        switch self {
+        case .channel:
+            return "/api/v1/channels.roles"
+        case .group:
+            return "/api/v1/groups.roles"
+        case .directMessage:
+            return ""
+        }
+    }
+}
+
+final class SubscriptionRolesRequest: APIRequest {
+    typealias APIResourceType = SubscriptionRolesResource
+
+    var path: String {
+        return type.path
+    }
+
+    var query: String?
+    let roomName: String?
+    let type: SubscriptionType
+
+    init(roomName: String, subscriptionType: SubscriptionType) {
+        self.type = subscriptionType
+        self.roomName = roomName
+        self.query = "roomName=\(roomName)"
+    }
+}
+
+final class SubscriptionRolesResource: APIResource {
+    var subscriptionRoles: [SubscriptionRoles]? {
+        return raw?["roles"].arrayValue.map {
+            var object = SubscriptionRoles()
+            object.user = User.find(withIdentifier: $0["u"]["_id"].stringValue)
+            object.roles.append(contentsOf: $0["roles"].arrayValue.compactMap({ $0.string }))
+            return object
+        }
+    }
+
+    var success: Bool {
+        return raw?["success"].bool ?? false
+    }
+}

--- a/Rocket.Chat/Controllers/Auth/AuthViewControllerAuthenticationHandler.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthViewControllerAuthenticationHandler.swift
@@ -11,15 +11,17 @@ import Foundation
 extension AuthViewController {
     internal func handleAuthenticationResponse(_ response: LoginResponse) {
         if case let .resource(resource) = response, let error = resource.error {
-            stopLoading()
+            DispatchQueue.main.async { [weak self] in
+                self?.stopLoading()
 
-            switch error.lowercased() {
-            case "totp-required":
-                return performSegue(withIdentifier: "TwoFactor", sender: nil)
-            case "unauthorized":
-                return Alert(key: "error.login_unauthorized").present()
-            default:
-                return Alert(key: "error.login").present()
+                switch error.lowercased() {
+                case "totp-required":
+                    self?.performSegue(withIdentifier: "TwoFactor", sender: nil)
+                case "unauthorized":
+                    Alert(key: "error.login_unauthorized").present()
+                default:
+                    Alert(key: "error.login").present()
+                }
             }
         }
 

--- a/Rocket.Chat/Controllers/Chat/ChannelInfoViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChannelInfoViewController.swift
@@ -22,13 +22,12 @@ class ChannelInfoViewController: BaseViewController {
         didSet {
             guard let subscription = self.subscription else { return }
 
-            let shouldListMentions = subscription.type != .directMessage
             let channelInfoData = [
                 ChannelInfoDetailCellData(title: localized("chat.info.item.files"), detail: "", action: showFilesList),
-                ChannelInfoDetailCellData(title: localized("chat.info.item.members"), detail: "", action: showMembersList),
+                subscription.canViewMembersList ? ChannelInfoDetailCellData(title: localized("chat.info.item.members"), detail: "", action: showMembersList) : nil,
                 ChannelInfoDetailCellData(title: localized("chat.info.item.pinned"), detail: "", action: showPinnedList),
                 ChannelInfoDetailCellData(title: localized("chat.info.item.starred"), detail: "", action: showStarredList),
-                shouldListMentions ? ChannelInfoDetailCellData(title: localized("chat.info.item.mentions"), detail: "", action: showMentionsList) : nil
+                subscription.canViewMentionsList ? ChannelInfoDetailCellData(title: localized("chat.info.item.mentions"), detail: "", action: showMentionsList) : nil
             ].compactMap({$0})
 
             if subscription.type == .directMessage {

--- a/Rocket.Chat/Controllers/Chat/ChatControllerMessageCellProtocol.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerMessageCellProtocol.swift
@@ -96,7 +96,8 @@ extension ChatViewController: ChatMessageCellProtocol, UserActionSheetPresenter 
     }
 
     func openReplyMessage(message: Message) {
-        
+        guard let username = message.user?.username else { return }
+        AppManager.openDirectMessage(username: username, replyMessageIdentifier: message.identifier, completion: nil)
     }
 
     func openImageFromCell(attachment: Attachment, thumbnail: FLAnimatedImageView) {

--- a/Rocket.Chat/Controllers/Chat/ChatControllerMessageCellProtocol.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerMessageCellProtocol.swift
@@ -95,6 +95,10 @@ extension ChatViewController: ChatMessageCellProtocol, UserActionSheetPresenter 
         present(controller, animated: true, completion: nil)
     }
 
+    func openReplyMessage(message: Message) {
+        
+    }
+
     func openImageFromCell(attachment: Attachment, thumbnail: FLAnimatedImageView) {
         textView.resignFirstResponder()
 

--- a/Rocket.Chat/Controllers/Chat/ChatControllerRolesController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerRolesController.swift
@@ -1,0 +1,38 @@
+//
+//  ChatControllerRolesController.swift
+//  Rocket.Chat
+//
+//  Created by Rafael Kellermann Streit on 11/05/18.
+//  Copyright © 2018 Rocket.Chat. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+extension ChatViewController {
+
+    func updateSubscriptionRoles() {
+        guard let subscription = subscription else { return }
+        let rid = subscription.rid
+
+        let rolesRequest = SubscriptionRolesRequest(roomName: subscription.name, subscriptionType: subscription.type)
+        API.current()?.fetch(rolesRequest, completion: { result in
+            switch result {
+            case .resource(let resource):
+                if let subscription = Subscription.find(rid: rid) {
+                    Realm.executeOnMainThread({ (realm) in
+                        subscription.usersRoles.removeAll()
+                        resource.subscriptionRoles?.forEach({ (role) in
+                            subscription.usersRoles.append(role)
+                        })
+
+                        realm.add(subscription, update: true)
+                    })
+                }
+            default:
+                Alert.defaultError.present()
+            }
+        })
+    }
+
+}

--- a/Rocket.Chat/Controllers/Chat/ChatControllerRolesController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerRolesController.swift
@@ -34,8 +34,9 @@ extension ChatViewController {
                         realm.add(subscription, update: true)
                     })
                 }
-            default:
-                Alert.defaultError.present()
+
+            // Fail silently
+            default: break
             }
         })
     }

--- a/Rocket.Chat/Controllers/Chat/ChatControllerRolesController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerRolesController.swift
@@ -12,9 +12,14 @@ import RealmSwift
 extension ChatViewController {
 
     func updateSubscriptionRoles() {
-        guard let subscription = subscription else { return }
-        let rid = subscription.rid
+        guard
+            let subscription = subscription,
+            subscription.type != .directMessage
+        else {
+            return
+        }
 
+        let rid = subscription.rid
         let rolesRequest = SubscriptionRolesRequest(roomName: subscription.name, subscriptionType: subscription.type)
         API.current()?.fetch(rolesRequest, completion: { result in
             switch result {

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -10,8 +10,8 @@ import RealmSwift
 import SlackTextViewController
 import SimpleImageViewer
 
-private typealias NibCellIndentifier = (nibName: String, cellIdentifier: String)
-private let kEmptyCellIdentifier = "kEmptyCellIdentifier"
+typealias NibCellIndentifier = (nibName: String, cellIdentifier: String)
+let kEmptyCellIdentifier = "kEmptyCellIdentifier"
 
 // swiftlint:disable file_length type_body_length
 final class ChatViewController: SLKTextViewController {

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -646,6 +646,7 @@ final class ChatViewController: SLKTextViewController {
             })
         }
 
+        updateSubscriptionRoles()
         updateMessageSendingPermission()
     }
 

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -10,8 +10,8 @@ import RealmSwift
 import SlackTextViewController
 import SimpleImageViewer
 
-typealias NibCellIndentifier = (nibName: String, cellIdentifier: String)
-let kEmptyCellIdentifier = "kEmptyCellIdentifier"
+private typealias NibCellIndentifier = (nibName: String, cellIdentifier: String)
+private let kEmptyCellIdentifier = "kEmptyCellIdentifier"
 
 // swiftlint:disable file_length type_body_length
 final class ChatViewController: SLKTextViewController {

--- a/Rocket.Chat/Extensions/Models/MessageExtensions.swift
+++ b/Rocket.Chat/Extensions/Models/MessageExtensions.swift
@@ -9,6 +9,22 @@
 import UIKit
 
 extension Message {
+
+    func isBroadcastReplyAvailable() -> Bool {
+        guard
+            !temporary,
+            !failed,
+            !markedForDeletion,
+            !isSystemMessage(),
+            let currentUser = AuthManager.currentUser(),
+            currentUser.identifier != user?.identifier
+        else {
+            return false
+        }
+
+        return subscription.roomBroadcast
+    }
+
     func isSystemMessage() -> Bool {
         return !(
             type == .text ||
@@ -112,9 +128,11 @@ extension Message {
 
         return text
     }
+
 }
 
 // MARK: Accessibility
+
 extension Message {
     override var accessibilityLabel: String? {
         get {

--- a/Rocket.Chat/Extensions/Models/MessageExtensions.swift
+++ b/Rocket.Chat/Extensions/Models/MessageExtensions.swift
@@ -17,7 +17,7 @@ extension Message {
         not for the message. If the subscription is not
         a broadcast type, it'll return false.
      */
-    func isBroadcastReplyAvailable(realm: Realm? = nil) -> Bool {
+    func isBroadcastReplyAvailable(realm: Realm? = Realm.current) -> Bool {
         guard
             !temporary,
             !failed,

--- a/Rocket.Chat/Extensions/Models/MessageExtensions.swift
+++ b/Rocket.Chat/Extensions/Models/MessageExtensions.swift
@@ -7,17 +7,24 @@
 //
 
 import UIKit
+import RealmSwift
 
 extension Message {
 
-    func isBroadcastReplyAvailable() -> Bool {
+    /**
+        This method will return if the reply button
+        in a broadcast room needs to be displayed or
+        not for the message. If the subscription is not
+        a broadcast type, it'll return false.
+     */
+    func isBroadcastReplyAvailable(realm: Realm? = nil) -> Bool {
         guard
             !temporary,
             !failed,
             !markedForDeletion,
             subscription.roomBroadcast,
             !isSystemMessage(),
-            let currentUser = AuthManager.currentUser(),
+            let currentUser = AuthManager.currentUser(realm: realm),
             currentUser.identifier != user?.identifier
         else {
             return false

--- a/Rocket.Chat/Extensions/Models/MessageExtensions.swift
+++ b/Rocket.Chat/Extensions/Models/MessageExtensions.swift
@@ -15,6 +15,7 @@ extension Message {
             !temporary,
             !failed,
             !markedForDeletion,
+            subscription.roomBroadcast,
             !isSystemMessage(),
             let currentUser = AuthManager.currentUser(),
             currentUser.identifier != user?.identifier
@@ -22,7 +23,7 @@ extension Message {
             return false
         }
 
-        return subscription.roomBroadcast
+        return true
     }
 
     func isSystemMessage() -> Bool {

--- a/Rocket.Chat/Extensions/Models/SubscriptionExtensions.swift
+++ b/Rocket.Chat/Extensions/Models/SubscriptionExtensions.swift
@@ -9,6 +9,30 @@
 import Foundation
 import RealmSwift
 
+// MARK: Information Viewing Options
+
+extension Subscription {
+
+    var canViewMembersList: Bool {
+        guard let currentUser = AuthManager.currentUser() else { return false }
+
+        if currentUser == roomOwner {
+            return true
+        }
+
+        if currentUser.canViewAdminPanel() {
+            return true
+        }
+
+        return !roomBroadcast
+    }
+
+    var canViewMentionsList: Bool {
+        return type != .directMessage
+    }
+
+}
+
 extension LinkingObjects where Element == Subscription {
     func sortedByLastSeen() -> Results<Subscription> {
         return self.sorted(byKeyPath: "lastSeen", ascending: false)

--- a/Rocket.Chat/Extensions/Models/SubscriptionExtensions.swift
+++ b/Rocket.Chat/Extensions/Models/SubscriptionExtensions.swift
@@ -14,7 +14,13 @@ import RealmSwift
 extension Subscription {
 
     var canViewMembersList: Bool {
-        guard let currentUser = AuthManager.currentUser() else { return false }
+        if !roomBroadcast {
+            return true
+        }
+
+        guard let currentUser = AuthManager.currentUser() else {
+            return false
+        }
 
         if currentUser == roomOwner {
             return true
@@ -24,7 +30,13 @@ extension Subscription {
             return true
         }
 
-        return !roomBroadcast
+        if let currentUserRoles = usersRoles.filter({ $0.user?.identifier == currentUser.identifier }).first?.roles {
+            if currentUserRoles.contains(Role.admin.rawValue) { return true }
+            if currentUserRoles.contains(Role.moderator.rawValue) { return true }
+            if currentUserRoles.contains(Role.owner.rawValue) { return true }
+        }
+
+        return false
     }
 
     var canViewMentionsList: Bool {

--- a/Rocket.Chat/Managers/AppManager.swift
+++ b/Rocket.Chat/Managers/AppManager.swift
@@ -125,12 +125,18 @@ extension AppManager {
 // MARK: Open Rooms
 
 extension AppManager {
-    static func openDirectMessage(username: String, completion: (() -> Void)? = nil) {
+    static func openDirectMessage(username: String, replyMessageIdentifier: String? = nil, completion: (() -> Void)? = nil) {
         func openDirectMessage() -> Bool {
             guard let directMessageRoom = Subscription.find(name: username, subscriptionType: [.directMessage]) else { return false }
 
             let controller = ChatViewController.shared
             controller?.subscription = directMessageRoom
+
+            if let identifier = replyMessageIdentifier {
+                if let message = Realm.current?.object(ofType: Message.self, forPrimaryKey: identifier) {
+                    controller?.reply(to: message)
+                }
+            }
 
             completion?()
 

--- a/Rocket.Chat/Managers/Model/AuthManager/AuthManagerCurrentUser.swift
+++ b/Rocket.Chat/Managers/Model/AuthManager/AuthManagerCurrentUser.swift
@@ -7,13 +7,13 @@
 //
 
 import Foundation
+import RealmSwift
 
 extension AuthManager {
-
     /**
      - returns: Current user object, if exists.
      */
-    static func currentUser() -> User? {
-        return isAuthenticated()?.user
+    static func currentUser(realm: Realm? = Realm.current) -> User? {
+        return isAuthenticated(realm: realm)?.user
     }
 }

--- a/Rocket.Chat/Managers/Model/AuthManager/AuthManagerCurrentUser.swift
+++ b/Rocket.Chat/Managers/Model/AuthManager/AuthManagerCurrentUser.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 extension AuthManager {
+
     /**
      - returns: Current user object, if exists.
      */

--- a/Rocket.Chat/Models/Base/ModelMappeable.swift
+++ b/Rocket.Chat/Models/Base/ModelMappeable.swift
@@ -19,10 +19,10 @@ protocol ModelMappeable {
 
 extension ModelMappeable where Self: BaseModel {
 
-    static func getOrCreate(realm: Realm, values: JSON, updates: UpdateBlock<Self>?) -> Self {
+    static func getOrCreate(realm: Realm, values: JSON?, updates: UpdateBlock<Self>?) -> Self {
         var object: Self!
 
-        if let primaryKey = values["_id"].string {
+        if let primaryKey = values?["_id"].string {
             if let newObject = realm.object(ofType: Self.self, forPrimaryKey: primaryKey as AnyObject) {
                 object = newObject
             }
@@ -32,7 +32,10 @@ extension ModelMappeable where Self: BaseModel {
             object = Self()
         }
 
-        object.map(values, realm: realm)
+        if let values = values {
+            object.map(values, realm: realm)
+        }
+
         updates?(object)
         return object
     }

--- a/Rocket.Chat/Models/File.swift
+++ b/Rocket.Chat/Models/File.swift
@@ -9,7 +9,7 @@
 import Foundation
 import RealmSwift
 
-class File: BaseModel {
+final class File: BaseModel {
     @objc dynamic var name = ""
     @objc dynamic var rid = ""
     @objc dynamic var size: Double = 0

--- a/Rocket.Chat/Models/Mapping/SubscriptionModelMapping.swift
+++ b/Rocket.Chat/Models/Mapping/SubscriptionModelMapping.swift
@@ -45,18 +45,13 @@ extension Subscription: ModelMappeable {
     func mapRoom(_ values: JSON) {
         self.roomDescription = values["description"].stringValue
         self.roomTopic = values["topic"].stringValue
+        self.roomReadOnly = values["ro"].boolValue
+        self.roomBroadcast = values["broadcast"].boolValue
+        self.roomOwnerId = values["u"]["_id"].stringValue
 
         self.roomMuted.removeAll()
         if let roomMuted = values["muted"].array?.compactMap({ $0.string }) {
             self.roomMuted.append(objectsIn: roomMuted)
-        }
-
-        if let readOnly = values["ro"].bool {
-            self.roomReadOnly = readOnly
-        }
-
-        if let ownerId = values["u"]["_id"].string {
-            self.roomOwnerId = ownerId
         }
     }
 }

--- a/Rocket.Chat/Models/Mapping/UserModelMapping.swift
+++ b/Rocket.Chat/Models/Mapping/UserModelMapping.swift
@@ -24,11 +24,6 @@ extension User: ModelMappeable {
             self.name = name
         }
 
-        if let roles = values["roles"].array?.compactMap({ $0.string }) {
-            self.roles.removeAll()
-            self.roles.append(contentsOf: roles)
-        }
-
         if let status = values["status"].string {
             self.status = UserStatus(rawValue: status) ?? .offline
         }
@@ -51,6 +46,15 @@ extension User: ModelMappeable {
 
             self.emails.removeAll()
             self.emails.append(contentsOf: emails)
+        }
+
+        mapRoles(values["roles"])
+    }
+
+    func mapRoles(_ values: JSON) {
+        if let roles = values.array?.compactMap({ $0.string }) {
+            self.roles.removeAll()
+            self.roles.append(contentsOf: roles)
         }
     }
 }

--- a/Rocket.Chat/Models/Role.swift
+++ b/Rocket.Chat/Models/Role.swift
@@ -1,0 +1,16 @@
+//
+//  Role.swift
+//  Rocket.Chat
+//
+//  Created by Rafael Kellermann Streit on 11/05/18.
+//  Copyright © 2018 Rocket.Chat. All rights reserved.
+//
+
+import Foundation
+
+enum Role: String {
+    case admin
+    case moderator
+    case owner
+    case leader
+}

--- a/Rocket.Chat/Models/Subscription/Subscription.swift
+++ b/Rocket.Chat/Models/Subscription/Subscription.swift
@@ -48,15 +48,25 @@ final class Subscription: BaseModel {
     @objc dynamic var roomReadOnly = false
     @objc dynamic var roomBroadcast = false
 
-    let roomMuted = RealmSwift.List<String>()
+    let roomMuted = List<String>()
 
     @objc dynamic var roomOwnerId: String?
     @objc dynamic var otherUserId: String?
 
     let messages = LinkingObjects(fromType: Message.self, property: "subscription")
+
+    // User's roles on the subscription, this values
+    // aren't stored in database.
+    let usersRoles = List<SubscriptionRoles>()
+}
+
+final class SubscriptionRoles: Object {
+    @objc dynamic var user: User?
+    var roles = List<String>()
 }
 
 // MARK: Failed Messages
+
 extension Subscription {
     func setTemporaryMessagesFailed() {
         try? realm?.write {

--- a/Rocket.Chat/Models/Subscription/Subscription.swift
+++ b/Rocket.Chat/Models/Subscription/Subscription.swift
@@ -46,6 +46,7 @@ final class Subscription: BaseModel {
     @objc dynamic var roomTopic: String?
     @objc dynamic var roomDescription: String?
     @objc dynamic var roomReadOnly = false
+    @objc dynamic var roomBroadcast = false
 
     let roomMuted = RealmSwift.List<String>()
 

--- a/Rocket.Chat/Models/User/User.swift
+++ b/Rocket.Chat/Models/User/User.swift
@@ -32,3 +32,9 @@ final class User: BaseModel {
 
     var utcOffset: Double?
 }
+
+extension User {
+    static func == (lhs: User, rhs: User) -> Bool {
+        return lhs.identifier == rhs.identifier
+    }
+}

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageActionButtonsView.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageActionButtonsView.swift
@@ -8,9 +8,16 @@
 
 import UIKit
 
-class ChatMessageActionButtonsView: UIView {
+protocol ChatMessageActionButtonsViewProtocol: class {
+    func openReplyMessage(message: Message)
+}
 
-     static let defaultHeight = CGFloat(55)
+final class ChatMessageActionButtonsView: UIView {
+
+    static let defaultHeight = CGFloat(55)
+
+    weak var delegate: ChatMessageActionButtonsViewProtocol?
+    var message: Message?
 
     @IBOutlet weak var buttonReply: UIButton! {
         didSet {
@@ -19,6 +26,15 @@ class ChatMessageActionButtonsView: UIView {
             buttonReply.layer.borderColor = buttonColor.cgColor
             buttonReply.layer.borderWidth = 1
             buttonReply.layer.cornerRadius = 4
+            buttonReply.setTitle(localized("chat.message.actions.reply"), for: .normal)
+        }
+    }
+
+    // MARK: IBAction
+
+    @IBAction func buttonReplyDidPressed(sender: Any) {
+        if let message = message {
+            delegate?.openReplyMessage(message: message)
         }
     }
 

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageActionButtonsView.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageActionButtonsView.swift
@@ -1,0 +1,25 @@
+//
+//  ChatMessageActionButtonsView.swift
+//  Rocket.Chat
+//
+//  Created by Rafael Kellermann Streit on 09/05/18.
+//  Copyright © 2018 Rocket.Chat. All rights reserved.
+//
+
+import UIKit
+
+class ChatMessageActionButtonsView: UIView {
+
+     static let defaultHeight = CGFloat(55)
+
+    @IBOutlet weak var buttonReply: UIButton! {
+        didSet {
+            let buttonColor = UIColor.RCBlue()
+            buttonReply.tintColor = buttonColor
+            buttonReply.layer.borderColor = buttonColor.cgColor
+            buttonReply.layer.borderWidth = 1
+            buttonReply.layer.cornerRadius = 4
+        }
+    }
+
+}

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageActionButtonsView.xib
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageActionButtonsView.xib
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="ChatMessageActionButtonsView" customModule="Rocket_Chat" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="55"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Aer-QU-01F">
+                    <rect key="frame" x="0.0" y="4" width="90" height="35"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="90" id="IDf-cc-0Vs"/>
+                        <constraint firstAttribute="height" constant="35" id="qM5-9R-cTO"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                    <state key="normal" title="Reply"/>
+                </button>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="Aer-QU-01F" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="DLq-81-JkK"/>
+                <constraint firstItem="Aer-QU-01F" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="4" id="EQP-Ek-00q"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <connections>
+                <outlet property="buttonReply" destination="Aer-QU-01F" id="Esu-Ov-DGR"/>
+            </connections>
+            <point key="canvasLocation" x="33.5" y="-249.5"/>
+        </view>
+    </objects>
+</document>

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageActionButtonsView.xib
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageActionButtonsView.xib
@@ -24,6 +24,9 @@
                     </constraints>
                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                     <state key="normal" title="Reply"/>
+                    <connections>
+                        <action selector="buttonReplyDidPressedWithSender:" destination="iN0-l3-epB" eventType="touchUpInside" id="qKi-Mm-HKo"/>
+                    </connections>
                 </button>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageActionButtonsView.xib
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageActionButtonsView.xib
@@ -17,7 +17,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Aer-QU-01F">
-                    <rect key="frame" x="0.0" y="4" width="90" height="35"/>
+                    <rect key="frame" x="0.0" y="8" width="90" height="35"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="90" id="IDf-cc-0Vs"/>
                         <constraint firstAttribute="height" constant="35" id="qM5-9R-cTO"/>
@@ -32,7 +32,7 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="Aer-QU-01F" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="DLq-81-JkK"/>
-                <constraint firstItem="Aer-QU-01F" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="4" id="EQP-Ek-00q"/>
+                <constraint firstItem="Aer-QU-01F" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="8" id="EQP-Ek-00q"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -151,6 +151,21 @@ final class ChatMessageCell: UICollectionViewCell {
         }
     }
 
+    func insertButtonActions() -> CGFloat {
+        var addedHeight = CGFloat(0)
+
+        if message.subscription.roomBroadcast {
+            if let view = ChatMessageActionButtonsView.instantiateFromNib() {
+//                view.delegate = delegate
+
+                mediaViews.addArrangedSubview(view)
+                addedHeight += ChatMessageActionButtonsView.defaultHeight
+            }
+        }
+
+        return addedHeight
+    }
+
     func insertURLs() -> CGFloat {
         var addedHeight = CGFloat(0)
         message.urls.forEach { url in
@@ -168,7 +183,9 @@ final class ChatMessageCell: UICollectionViewCell {
 
     //swiftlint:disable cyclomatic_complexity
     func insertAttachments() {
-        var mediaViewHeight = insertURLs()
+        var mediaViewHeight = CGFloat(0)
+        mediaViewHeight += insertButtonActions()
+        mediaViewHeight += insertURLs()
 
         message.attachments.forEach { attachment in
             let type = attachment.type
@@ -313,6 +330,10 @@ extension ChatMessageCell {
         var total = (CGFloat)(sequential ? 8 : 29) + (message.reactions.count > 0 ? 40 : 0)
         if attributedString?.string ?? "" != "" {
             total += (attributedString?.heightForView(withWidth: fullWidth - 55) ?? 0)
+        }
+
+        if message.subscription.roomBroadcast {
+            total += ChatMessageActionButtonsView.defaultHeight
         }
 
         for url in message.urls {

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -155,7 +155,7 @@ final class ChatMessageCell: UICollectionViewCell {
     func insertButtonActions() -> CGFloat {
         var addedHeight = CGFloat(0)
 
-        if message.subscription.roomBroadcast {
+        if message.isBroadcastReplyAvailable() {
             if let view = ChatMessageActionButtonsView.instantiateFromNib() {
                 view.message = message
                 view.delegate = delegate
@@ -186,7 +186,6 @@ final class ChatMessageCell: UICollectionViewCell {
     //swiftlint:disable cyclomatic_complexity
     func insertAttachments() {
         var mediaViewHeight = CGFloat(0)
-        mediaViewHeight += insertButtonActions()
         mediaViewHeight += insertURLs()
 
         message.attachments.forEach { attachment in
@@ -242,6 +241,7 @@ final class ChatMessageCell: UICollectionViewCell {
             }
         }
 
+        mediaViewHeight += insertButtonActions()
         mediaViewsHeightConstraint.constant = CGFloat(mediaViewHeight)
     }
 
@@ -334,7 +334,7 @@ extension ChatMessageCell {
             total += (attributedString?.heightForView(withWidth: fullWidth - 55) ?? 0)
         }
 
-        if message.subscription.roomBroadcast {
+        if message.isBroadcastReplyAvailable() {
             total += ChatMessageActionButtonsView.defaultHeight
         }
 

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -8,8 +8,9 @@
 
 import UIKit
 
-protocol ChatMessageCellProtocol: ChatMessageURLViewProtocol, ChatMessageVideoViewProtocol, ChatMessageImageViewProtocol, ChatMessageTextViewProtocol {
+protocol ChatMessageCellProtocol: ChatMessageURLViewProtocol, ChatMessageVideoViewProtocol, ChatMessageImageViewProtocol, ChatMessageTextViewProtocol, ChatMessageActionButtonsViewProtocol {
     func openURL(url: URL)
+
     func handleLongPressMessageCell(_ message: Message, view: UIView, recognizer: UIGestureRecognizer)
     func handleUsernameTapMessageCell(_ message: Message, view: UIView, recognizer: UIGestureRecognizer)
     func handleLongPress(reactionListView: ReactionListView, reactionView: ReactionView)
@@ -156,7 +157,8 @@ final class ChatMessageCell: UICollectionViewCell {
 
         if message.subscription.roomBroadcast {
             if let view = ChatMessageActionButtonsView.instantiateFromNib() {
-//                view.delegate = delegate
+                view.message = message
+                view.delegate = delegate
 
                 mediaViews.addArrangedSubview(view)
                 addedHeight += ChatMessageActionButtonsView.defaultHeight

--- a/Rocket.ChatTests/API/Requests/Subscription/SubscriptionRolesRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/Subscription/SubscriptionRolesRequestSpec.swift
@@ -1,0 +1,76 @@
+//
+//  SubscriptionRolesRequestSpec.swift
+//  Rocket.ChatTests
+//
+//  Created by Rafael Kellermann Streit on 11/05/18.
+//  Copyright © 2018 Rocket.Chat. All rights reserved.
+//
+
+import XCTest
+import SwiftyJSON
+
+@testable import Rocket_Chat
+
+class SubscriptionRolesRequestSpec: APITestCase {
+    func testRequest() {
+        let reactRequest = SubscriptionRolesRequest(roomName: "general", subscriptionType: .channel)
+
+        guard let request = reactRequest.request(for: api) else {
+            return XCTFail("request is not nil")
+        }
+
+        XCTAssertEqual(request.url?.path, "/api/v1/channels.roles", "path is correct")
+        XCTAssertEqual(request.httpMethod, "GET", "http method is correct")
+        XCTAssertEqual(request.url?.query, "roomName=general", "query value is correct")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json", "content type is correct")
+    }
+
+    func testResult() {
+        let jsonString = """
+        {
+            "roles": [{
+                    "u": {
+                        "name": "John Appleseed",
+                        "username": "john.appleseed",
+                        "_id": "Xx6KW6XQsFkmDPGdE"
+                    },
+                    "_id": "j2pdXnucQbLg5WXRu",
+                    "rid": "ABsnusN6m9h7Z7KnR",
+                    "roles": [
+                        "owner",
+                        "moderator",
+                        "leader"
+                    ]
+                },{
+                    "u": {
+                        "name": "John Applesee 2",
+                        "username": "john.appleseed.2",
+                        "_id": "xyJPCay3ShCQyuezh"
+                    },
+                    "_id": "oCMaLjQ74HuhSEW9g",
+                    "rid": "ABsnusN6m9h7Z7KnR",
+                    "roles": [
+                        "moderator"
+                    ]
+                }
+            ],
+            "success": true
+        }
+        """
+
+        let json = JSON(parseJSON: jsonString)
+
+        let result = SubscriptionRolesResource(raw: json)
+        XCTAssertEqual(result.subscriptionRoles?.count, 2)
+        XCTAssertEqual(result.subscriptionRoles?.first?.user?.username, "john.appleseed")
+        XCTAssertEqual(result.subscriptionRoles?.first?.roles.count, 3)
+        XCTAssertEqual(result.subscriptionRoles?.first?.roles.first, Role.owner.rawValue)
+        XCTAssertTrue(result.success)
+    }
+
+    func testEmptyResults() {
+        let nilResult = SubscriptionRolesResource(raw: nil)
+        XCTAssertNil(nilResult.subscriptionRoles)
+    }
+
+}

--- a/Rocket.ChatTests/API/Requests/Subscription/SubscriptionRolesRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/Subscription/SubscriptionRolesRequestSpec.swift
@@ -68,6 +68,119 @@ class SubscriptionRolesRequestSpec: APITestCase {
         XCTAssertTrue(result.success)
     }
 
+    func testNullUserObject() {
+        let jsonString = """
+        {
+            "roles": [{
+                    "u": null,
+                    "_id": "j2pdXnucQbLg5WXRu",
+                    "rid": "ABsnusN6m9h7Z7KnR",
+                    "roles": [
+                        "owner",
+                        "moderator",
+                        "leader"
+                    ]
+                }
+            ],
+            "success": true
+        }
+        """
+
+        let json = JSON(parseJSON: jsonString)
+
+        let result = SubscriptionRolesResource(raw: json)
+        XCTAssertTrue(result.success)
+        XCTAssertEqual(result.subscriptionRoles?.count, 1)
+        XCTAssertEqual(result.subscriptionRoles?.first?.roles.count, 3)
+        XCTAssertNotNil(result.subscriptionRoles?.first?.user)
+        XCTAssertNil(result.subscriptionRoles?.first?.user?.identifier)
+    }
+
+    func testInvalidUserObject() {
+        let jsonString = """
+        {
+            "roles": [{
+                    "u": {
+                        "foo": "bar"
+                    },
+                    "_id": "j2pdXnucQbLg5WXRu",
+                    "rid": "ABsnusN6m9h7Z7KnR",
+                    "roles": [
+                        "owner",
+                        "moderator",
+                        "leader"
+                    ]
+                }
+            ],
+            "success": true
+        }
+        """
+
+        let json = JSON(parseJSON: jsonString)
+
+        let result = SubscriptionRolesResource(raw: json)
+        XCTAssertTrue(result.success)
+        XCTAssertEqual(result.subscriptionRoles?.count, 1)
+        XCTAssertEqual(result.subscriptionRoles?.first?.roles.count, 3)
+        XCTAssertNotNil(result.subscriptionRoles?.first?.user)
+        XCTAssertNil(result.subscriptionRoles?.first?.user?.identifier)
+    }
+
+    func testArrayUserObject() {
+        let jsonString = """
+        {
+            "roles": [{
+                    "u": ["foo"],
+                    "_id": "j2pdXnucQbLg5WXRu",
+                    "rid": "ABsnusN6m9h7Z7KnR",
+                    "roles": [
+                        "owner",
+                        "moderator",
+                        "leader"
+                    ]
+                }
+            ],
+            "success": true
+        }
+        """
+
+        let json = JSON(parseJSON: jsonString)
+
+        let result = SubscriptionRolesResource(raw: json)
+        XCTAssertTrue(result.success)
+        XCTAssertEqual(result.subscriptionRoles?.count, 1)
+        XCTAssertEqual(result.subscriptionRoles?.first?.roles.count, 3)
+        XCTAssertNotNil(result.subscriptionRoles?.first?.user)
+        XCTAssertNil(result.subscriptionRoles?.first?.user?.identifier)
+    }
+
+    func testEmtpyRolesObject() {
+        let jsonString = """
+        {
+            "roles": [{
+                    "u": {
+                        "name": "John Appleseed",
+                        "username": "john.appleseed",
+                        "_id": "Xx6KW6XQsFkmDPGdE"
+                    },
+                    "_id": "j2pdXnucQbLg5WXRu",
+                    "rid": "ABsnusN6m9h7Z7KnR",
+                    "roles": [ ]
+                }
+            ],
+            "success": true
+        }
+        """
+
+        let json = JSON(parseJSON: jsonString)
+
+        let result = SubscriptionRolesResource(raw: json)
+        XCTAssertTrue(result.success)
+        XCTAssertEqual(result.subscriptionRoles?.count, 1)
+        XCTAssertEqual(result.subscriptionRoles?.first?.roles.count, 0)
+        XCTAssertEqual(result.subscriptionRoles?.first?.user?.username, "john.appleseed")
+    }
+
     func testEmptyResults() {
         let nilResult = SubscriptionRolesResource(raw: nil)
         XCTAssertNil(nilResult.subscriptionRoles)

--- a/Rocket.ChatTests/Extensions/Models/SubscriptionExtensionsSpec.swift
+++ b/Rocket.ChatTests/Extensions/Models/SubscriptionExtensionsSpec.swift
@@ -106,3 +106,33 @@ class SubscriptionExtensionsSpec: XCTestCase, RealmTestCase {
         XCTAssert(objects.last == sub1)
     }
 }
+
+// MARK: Information Viewing Options
+
+extension SubscriptionExtensionsSpec {
+
+    func testCanViewMentionsListDirectMessage() {
+        let subscription = Subscription()
+        subscription.type = .directMessage
+        subscription.identifier = "1"
+
+        XCTAssertFalse(subscription.canViewMentionsList)
+    }
+
+    func testCanViewMentionsListChannel() {
+        let subscription = Subscription()
+        subscription.type = .channel
+        subscription.identifier = "1"
+
+        XCTAssertTrue(subscription.canViewMentionsList)
+    }
+
+    func testCanViewMentionsListGroup() {
+        let subscription = Subscription()
+        subscription.type = .group
+        subscription.identifier = "1"
+
+        XCTAssertTrue(subscription.canViewMentionsList)
+    }
+
+}

--- a/Rocket.ChatTests/Models/MessageSpec.swift
+++ b/Rocket.ChatTests/Models/MessageSpec.swift
@@ -203,6 +203,79 @@ extension MessageSpec {
 
 }
 
+// MARK: Broadcast
+
+extension MessageSpec {
+
+    func testMessageBroadcastTrue() {
+        let subscription = Subscription()
+        subscription.identifier = "1"
+        subscription.roomBroadcast = true
+
+        let user = User()
+        user.identifier = "1"
+
+        let message = Message()
+        message.subscription = subscription
+        message.text = "foobar"
+        message.user = user
+
+        XCTAssertTrue(message.isBroadcastReplyAvailable())
+    }
+
+    func testMessageSystemBroadcastFalse() {
+        let subscription = Subscription()
+        subscription.identifier = "1"
+        subscription.roomBroadcast = true
+
+        let message = Message()
+        message.subscription = subscription
+        message.internalType = MessageType.roomArchived.rawValue
+
+        XCTAssertFalse(message.isBroadcastReplyAvailable())
+    }
+
+    func testMessageTemporaryBroadcastFalse() {
+        let subscription = Subscription()
+        subscription.identifier = "1"
+        subscription.roomBroadcast = true
+
+        let message = Message()
+        message.subscription = subscription
+        message.text = "foobar"
+        message.temporary = true
+
+        XCTAssertFalse(message.isBroadcastReplyAvailable())
+    }
+
+    func testMessageFailedBroadcastFalse() {
+        let subscription = Subscription()
+        subscription.identifier = "1"
+        subscription.roomBroadcast = true
+
+        let message = Message()
+        message.subscription = subscription
+        message.text = "foobar"
+        message.failed = true
+
+        XCTAssertFalse(message.isBroadcastReplyAvailable())
+    }
+
+    func testMessageCurrentUserBroadcastFalse() {
+        let subscription = Subscription()
+        subscription.identifier = "1"
+        subscription.roomBroadcast = true
+
+        let message = Message()
+        message.subscription = subscription
+        message.text = "foobar"
+        message.failed = true
+
+        XCTAssertFalse(message.isBroadcastReplyAvailable())
+    }
+
+}
+
 // MARK: Equatable
 
 extension MessageSpec {

--- a/Rocket.ChatTests/Models/MessageSpec.swift
+++ b/Rocket.ChatTests/Models/MessageSpec.swift
@@ -205,22 +205,39 @@ extension MessageSpec {
 
 // MARK: Broadcast
 
-extension MessageSpec {
+extension MessageSpec: RealmTestCase {
 
     func testMessageBroadcastTrue() {
-        let subscription = Subscription()
-        subscription.identifier = "1"
-        subscription.roomBroadcast = true
+        let realm = testRealm()
+
+        let auth = Auth()
+        auth.serverURL = "https://foo.com/"
+        auth.token = "123"
+        auth.tokenExpires = Date()
+        auth.lastAccess = Date()
+        auth.userId = "1"
 
         let user = User()
         user.identifier = "1"
 
+        let userOther = User()
+        userOther.identifier = "2"
+
+        Realm.executeOnMainThread(realm: realm, { realm in
+            realm.add(auth)
+            realm.add(user)
+        })
+
+        let subscription = Subscription()
+        subscription.identifier = "1"
+        subscription.roomBroadcast = true
+
         let message = Message()
         message.subscription = subscription
         message.text = "foobar"
-        message.user = user
+        message.user = userOther
 
-        XCTAssertTrue(message.isBroadcastReplyAvailable())
+        XCTAssertTrue(message.isBroadcastReplyAvailable(realm: realm))
     }
 
     func testMessageSystemBroadcastFalse() {

--- a/Rocket.ChatTests/Models/SubscriptionSpec.swift
+++ b/Rocket.ChatTests/Models/SubscriptionSpec.swift
@@ -107,6 +107,7 @@ class SubscriptionSpec: XCTestCase {
             "muted": [ "username" ],
             "jitsiTimeout": [ "$date": 1480377601 ],
             "ro": true,
+            "broadcast": true,
             "description": "room-description"
         ])
 
@@ -117,7 +118,62 @@ class SubscriptionSpec: XCTestCase {
         XCTAssertEqual(subscription.roomTopic, "room-topic")
         XCTAssertEqual(subscription.roomDescription, "room-description")
         XCTAssertEqual(subscription.roomReadOnly, true)
+        XCTAssertEqual(subscription.roomBroadcast, true)
         XCTAssertEqual(subscription.roomOwnerId, "user-id")
+    }
+
+    func testMapRoomReadOnlyFalse() {
+        let object = JSON([
+            "_id": "room-id",
+            "t": "c",
+            "name": "room-name",
+            "ro": false
+        ])
+
+        let subscription = Subscription()
+        subscription.mapRoom(object)
+
+        XCTAssertEqual(subscription.roomReadOnly, false)
+    }
+
+    func testMapRoomReadOnlyEmpty() {
+        let object = JSON([
+            "_id": "room-id",
+            "t": "c",
+            "name": "room-name"
+        ])
+
+        let subscription = Subscription()
+        subscription.mapRoom(object)
+
+        XCTAssertEqual(subscription.roomReadOnly, false)
+    }
+
+    func testMapRoomBroadcastFalse() {
+        let object = JSON([
+            "_id": "room-id",
+            "t": "c",
+            "name": "room-name",
+            "broadcast": false
+        ])
+
+        let subscription = Subscription()
+        subscription.mapRoom(object)
+
+        XCTAssertEqual(subscription.roomBroadcast, false)
+    }
+
+    func testMapRoomBroadcastEmpty() {
+        let object = JSON([
+            "_id": "room-id",
+            "t": "c",
+            "name": "room-name"
+        ])
+
+        let subscription = Subscription()
+        subscription.mapRoom(object)
+
+        XCTAssertEqual(subscription.roomBroadcast, false)
     }
 
     func testSubscriptionDisplayNameHonorFullnameSettings() {


### PR DESCRIPTION
@RocketChat/ios

Closes #1654

## Progress

- [x] **Map the property broadcast in a channel/group:** now each channel has a property called broadcast. It is a boolean and the default value is false. The value can not be present and the app needs to handle as the default value;
- [x] **Members list must be hidden:** when the room have the broadcast property as true, the members list must be hidden. Only visible for admins, moderators and owners of the rooms; **(BLOCKED by https://github.com/RocketChat/Rocket.Chat/pull/10607)**
- [x] **Normal users can’t send messages:** the room is read-only for normal users. If the client already supports read-only rooms, no changes are required.
- [x] **Reply button on each message:** each message in a room needs to have a Reply button and when the user taps on the button, it needs to open the DM with the user who sent the message and “quoting” the message link. Example: if the user taps on the reply button on message with identifier abc123 we need to open the DM with this text filled on the text view: [ ](https://yourhost.com/direct/rafael.kellermann?msg=abc123).

## Demo

![2018-05-10 10 06 56](https://user-images.githubusercontent.com/551004/39871067-132f032e-543a-11e8-8e92-ccc85a7ba7fe.gif)
