### PR TITLE
[FIX] Some urls not receiving implicit https on connection

### DIFF
--- a/Rocket.Chat/Extensions/URLExtension.swift
+++ b/Rocket.Chat/Extensions/URLExtension.swift
@@ -26,6 +26,11 @@ extension URL {
     }
 
     init?(string: String, scheme: String) {
+        var string = string
+        if !string.contains("://") {
+            string = "https://\(string)"
+        }
+
         guard let url = URL(string: string) else {
             return nil
         }

--- a/Rocket.ChatTests/Extensions/URLExtensionSpec.swift
+++ b/Rocket.ChatTests/Extensions/URLExtensionSpec.swift
@@ -33,7 +33,9 @@ class URLExtensionSpec: XCTestCase {
 
     func testInitWithStringAndScheme() {
         XCTAssertEqual(URL(string: "open.rocket.chat", scheme: "https")?.absoluteString, "https://open.rocket.chat", "will add scheme")
+        XCTAssertEqual(URL(string: "open.rocket.chat:3000", scheme: "https")?.absoluteString, "https://open.rocket.chat:3000", "will add scheme & keep port")
         XCTAssertEqual(URL(string: "https://open.rocket.chat", scheme: "https")?.absoluteString, "https://open.rocket.chat", "will return correct url")
+        XCTAssertEqual(URL(string: "https://open.rocket.chat:3000", scheme: "https")?.absoluteString, "https://open.rocket.chat:3000", "will return correct url & port")
         XCTAssertEqual(URL(string: "http://open.rocket.chat", scheme: "https")?.absoluteString, "https://open.rocket.chat", "will force https scheme")
         XCTAssertEqual(URL(string: "https://open.rocket.chat", scheme: "wss")?.absoluteString, "wss://open.rocket.chat", "will force wss scheme")
         XCTAssertEqual(URL(string: "http://open.rocket.chat/path", scheme: "https")?.absoluteString, "https://open.rocket.chat/path", "will keep path")


### PR DESCRIPTION
@RocketChat/ios

For some reason, URL(string:) urls.like.this:3000 means scheme = "urls.like.this", host = nil 🤔 
