### PR TITLE
[IMPROVEMENT] Removed whitespaces at the beginning of a message.

### DIFF
--- a/Rocket.Chat/Extensions/Models/SubscriptionLastMessage.swift
+++ b/Rocket.Chat/Extensions/Models/SubscriptionLastMessage.swift
@@ -19,6 +19,9 @@ extension Subscription {
         }
 
         var text = MessageTextCacheManager.shared.message(for: lastMessage)?.string ?? lastMessage.text
+        text = text.components(separatedBy: .newlines)
+            .joined(separator: " ")
+            .replacingOccurrences(of: "^\\s+", with: "", options: .regularExpression)
 
         let isFromCurrentUser = userLastMessage.identifier == AuthManager.currentUser()?.identifier
         let isOnlyAttachment = text.count == 0 && lastMessage.attachments.count > 0

--- a/Rocket.Chat/Extensions/Models/SubscriptionLastMessage.swift
+++ b/Rocket.Chat/Extensions/Models/SubscriptionLastMessage.swift
@@ -27,7 +27,7 @@ extension Subscription {
         let isOnlyAttachment = text.count == 0 && lastMessage.attachments.count > 0
 
         if isOnlyAttachment {
-            text = " \(localized("subscriptions.list.sent_an_attachment"))"
+            text = "\(localized("subscriptions.list.sent_an_attachment"))"
         } else {
             if !isFromCurrentUser {
                 text = ": \(text)"


### PR DESCRIPTION
@RocketChat/ios

- Removed whitespaces at the beginning of a message. 
- Newlines replaced with a single space.

Done to prevent situations similar to the one shown in the screengrab.
<img width="360" alt="screen shot 2018-05-31 at 1 57 00 am" src="https://user-images.githubusercontent.com/7317008/40746643-98cf3546-6478-11e8-99b6-1c88052a994c.png">