### PR TITLE
[FIX] Added a space before the "sent an attachment" text

### DIFF
--- a/Rocket.Chat/Extensions/Models/SubscriptionLastMessage.swift
+++ b/Rocket.Chat/Extensions/Models/SubscriptionLastMessage.swift
@@ -27,7 +27,7 @@ extension Subscription {
         let isOnlyAttachment = text.count == 0 && lastMessage.attachments.count > 0
 
         if isOnlyAttachment {
-            text = "\(localized("subscriptions.list.sent_an_attachment"))"
+            text = " \(localized("subscriptions.list.sent_an_attachment"))"
         } else {
             if !isFromCurrentUser {
                 text = ": \(text)"


### PR DESCRIPTION
Was removed in a pervious commit by me.
The text currently reads "Yousent an attachment"
