### PR TITLE
[HOTFIX] Fix for web browser preference getting hidden instead of the app icon preference if the device does not support changing app icons.

### DIFF
--- a/Rocket.Chat/Controllers/Preferences/PreferencesViewController.swift
+++ b/Rocket.Chat/Controllers/Preferences/PreferencesViewController.swift
@@ -184,7 +184,7 @@ final class PreferencesViewController: UITableViewController {
                 cellContactDidPressed()
             } else if indexPath.row == 1 {
                 cellLanguageDidPressed()
-            } else if indexPath.row == 2 {
+            } else if indexPath.row == 3 {
                 cellAppIconDidPressed()
             }
         } else if indexPath.section == kSectionInformation {

--- a/Rocket.Chat/Storyboards/Preferences.storyboard
+++ b/Rocket.Chat/Storyboards/Preferences.storyboard
@@ -103,25 +103,8 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Lk4-H3-Y3R" style="IBUITableViewCellStyleDefault" id="lxd-VJ-cx9">
-                                        <rect key="frame" x="0.0" y="209" width="375" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lxd-VJ-cx9" id="qDS-Nm-GOO">
-                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Application Icon" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Lk4-H3-Y3R">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="43.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="drM-Ve-z71" detailTextLabel="fgh-3x-fTm" style="IBUITableViewCellStyleValue1" id="n4o-Q3-J5P">
-                                        <rect key="frame" x="0.0" y="253" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="209" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="n4o-Q3-J5P" id="eq8-0Q-EjA">
                                             <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
@@ -146,6 +129,23 @@
                                         <connections>
                                             <segue destination="Zhy-gD-kqe" kind="show" id="L1F-dT-TVb"/>
                                         </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Lk4-H3-Y3R" style="IBUITableViewCellStyleDefault" id="lxd-VJ-cx9">
+                                        <rect key="frame" x="0.0" y="253" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lxd-VJ-cx9" id="qDS-Nm-GOO">
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Application Icon" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Lk4-H3-Y3R">
+                                                    <rect key="frame" x="16" y="0.0" width="324" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>


### PR DESCRIPTION
@RocketChat/ios

If the device did not support changing the app icons, the last option from the first section of the preferences tableview controller would be hidden, which in this case was the preference for setting the default web browser.

To fix this behavior, I have moved the app icon preference to last in the list.

This is just a hot fix, an improved implementation should be worked on later.

## Currently (if the device does not support changing its app icon)

<img width=300 src=https://user-images.githubusercontent.com/7317008/41196375-dfb19ac6-6c3e-11e8-8c20-b7f6d5310af8.png>

## After the fix 

<img width=300 src=https://user-images.githubusercontent.com/7317008/41196379-e91414d6-6c3e-11e8-8eae-d2108b478e7b.png>