### PR TITLE
[FIX] Fix server list view frame on iOS 10

### DIFF
--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
@@ -316,9 +316,25 @@ extension SubscriptionsViewController: UISearchBarDelegate {
             serversView.close()
         } else {
             titleView?.updateTitleImage(reverse: true)
-            serversView = ServersListView.showIn(self.view)
+            serversView = ServersListView.showIn(self.view, frame: frameForDropDownOverlay)
             serversView?.delegate = self
         }
+    }
+
+    private var frameForDropDownOverlay: CGRect {
+        var frameHeight = view.bounds.height
+        var yOffset: CGFloat = 0.0
+
+        if #available(iOS 11.0, *) {
+            frameHeight -= view.safeAreaInsets.top - view.safeAreaInsets.bottom
+            yOffset = view.safeAreaInsets.top
+        } else {
+            let navBarHeight = UIApplication.shared.statusBarFrame.size.height +  (navigationController?.navigationBar.frame.height ?? 0.0)
+            frameHeight -= navBarHeight
+            yOffset = navBarHeight
+        }
+
+        return CGRect(x: 0.0, y: yOffset, width: view.bounds.width, height: view.bounds.height)
     }
 
 }

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
@@ -329,7 +329,7 @@ extension SubscriptionsViewController: UISearchBarDelegate {
             frameHeight -= view.safeAreaInsets.top - view.safeAreaInsets.bottom
             yOffset = view.safeAreaInsets.top
         } else {
-            let navBarHeight = UIApplication.shared.statusBarFrame.size.height +  (navigationController?.navigationBar.frame.height ?? 0.0)
+            let navBarHeight = UIApplication.shared.statusBarFrame.size.height + (navigationController?.navigationBar.frame.height ?? 0.0)
             frameHeight -= navBarHeight
             yOffset = navBarHeight
         }

--- a/Rocket.Chat/Views/Subscriptions/ServersListView.swift
+++ b/Rocket.Chat/Views/Subscriptions/ServersListView.swift
@@ -65,21 +65,10 @@ final class ServersListView: UIView {
 
     // MARK: Showing the View
 
-    static func showIn(_ view: UIView) -> ServersListView? {
+    static func showIn(_ view: UIView, frame: CGRect) -> ServersListView? {
         guard let instance = ServersListView.instantiateFromNib() else { return nil }
         instance.backgroundColor = UIColor.black.withAlphaComponent(0)
-
-        var frameHeight = view.bounds.height
-        var yOffset: CGFloat = 0.0
-        if #available(iOS 11.0, *) {
-            frameHeight -= view.safeAreaInsets.top - view.safeAreaInsets.bottom
-            yOffset = view.safeAreaInsets.top
-        } else {
-            frameHeight -= view.layoutMargins.top - view.layoutMargins.bottom
-            yOffset = view.layoutMargins.top
-        }
-
-        instance.frame = CGRect(x: 0.0, y: yOffset, width: view.bounds.width, height: frameHeight)
+        instance.frame = frame
         view.addSubview(instance)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {


### PR DESCRIPTION
@RocketChat/ios

Fixes the incorrect inset for server list view on iOS 10. 

A `frameForDropDownOverlay` property has been added to `SubscriptionsViewController`, so that that same changes can be easily applied to `SubscriptionsSortingView` (#1737).