### PR TITLE
[CRASH] 2FA auth crashing when popped

### DIFF
--- a/Rocket.Chat/Controllers/Auth/AuthTableViewControllerAuthenticationHandler.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewControllerAuthenticationHandler.swift
@@ -28,10 +28,6 @@ extension AuthTableViewController {
                 return
             }
 
-            if let publicSettings = serverPublicSettings {
-                AuthSettingsManager.persistPublicSettings(settings: publicSettings)
-            }
-
             if let realm = Realm.current, let auth = AuthManager.isAuthenticated(realm: realm), let version = serverVersion {
                 try? realm.write {
                     auth.serverVersion = version.description

--- a/Rocket.Chat/Controllers/Auth/LoginTableViewControllerAuthenticationHandler.swift
+++ b/Rocket.Chat/Controllers/Auth/LoginTableViewControllerAuthenticationHandler.swift
@@ -29,10 +29,6 @@ extension LoginTableViewController {
                 return
             }
 
-            if let publicSettings = serverPublicSettings {
-                AuthSettingsManager.persistPublicSettings(settings: publicSettings)
-            }
-
             if let realm = Realm.current, let auth = AuthManager.isAuthenticated(realm: realm), let version = serverVersion {
                 try? realm.write {
                     auth.serverVersion = version.description


### PR DESCRIPTION
@RocketChat/ios

This crash happens because when we authenticate we persist  `AuthSettings` object, on the first time it happens we are persisting an unmanaged object, so there's no problem. But, when we authenticate, then navigate to 2FA screen, then get back and authenticate again, our `serverPublicSettings` object is not unmanaged anymore, and since we delete all `AuthSettings` objects before persisting a new one we wind up removing the object we are about to add again, so `Realm` says that we are trying to persist an invalidated object. Besides this issue, this process would cause a threading issue with `Realm` as well. 

My first thought was to approach the two `Realm` issues, but then I wondered why we are persisting  `AuthSettings` after authenticating the user if we already have persisted it when we connected to the server and the `AuthSettings` object hasn't changed since then. I could conclude that we have no reason to persist the same object on Realm again, so I removed it from our auth handling process and the issue doesn't happen anymore. 

Let me know if I'm wrong about it and shouldn't have stopped persisting it again, then I'll get back to it and approach the Realm issues. 

Closes #1765
