### PR TITLE
[BUG] Authenticating without username

### DIFF
--- a/Rocket.Chat/AppDelegate.swift
+++ b/Rocket.Chat/AppDelegate.swift
@@ -29,12 +29,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If user is authenticated, open the chat right away
         // but if not, just open the authentication screen.
         if let auth = AuthManager.isAuthenticated() {
-            AuthManager.persistAuthInformation(auth)
-            AuthSettingsManager.shared.updateCachedSettings()
-            WindowManager.open(.subscriptions)
+            if AuthManager.currentUser()?.username != nil {
+                AuthManager.persistAuthInformation(auth)
+                AuthSettingsManager.shared.updateCachedSettings()
+                WindowManager.open(.subscriptions)
 
-            if let user = auth.user {
-                BugTrackingCoordinator.identifyCrashReports(withUser: user)
+                if let user = auth.user {
+                    BugTrackingCoordinator.identifyCrashReports(withUser: user)
+                }
+            } else {
+                WindowManager.open(.auth(serverUrl: "", credentials: nil), viewControllerIdentifier: "RegisterUsernameNav")
             }
         } else {
             WindowManager.open(.auth(serverUrl: "", credentials: nil))

--- a/Rocket.Chat/Controllers/Auth/RegisterUsernameTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/RegisterUsernameTableViewController.swift
@@ -76,16 +76,23 @@ final class RegisterUsernameTableViewController: BaseTableViewController {
     }
 
     fileprivate func requestUsername() {
-        startLoading()
+        let error = { (errorMessage: String?) in
+            Alert(
+                title: localized("error.socket.default_error.title"),
+                message: errorMessage ?? localized("error.socket.default_error.message")
+            ).present()
+        }
 
+        guard let username = textFieldUsername.text, !username.isEmpty else {
+            return error(nil)
+        }
+
+        startLoading()
         AuthManager.setUsername(textFieldUsername.text ?? "") { [weak self] success, errorMessage in
             DispatchQueue.main.async {
             self?.stopLoading()
                 if !success {
-                    Alert(
-                        title: localized("error.socket.default_error.title"),
-                        message: errorMessage ?? localized("error.socket.default_error.message")
-                    ).present()
+                    error(errorMessage)
                 } else {
                     self?.dismiss(animated: true, completion: nil)
                     AppManager.reloadApp()

--- a/Rocket.Chat/Controllers/Auth/RegisterUsernameTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/RegisterUsernameTableViewController.swift
@@ -25,14 +25,24 @@ final class RegisterUsernameTableViewController: BaseTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationItem.title = SocketManager.sharedInstance.serverURL?.host
+        if let serverURL = AuthManager.selectedServerInformation()?[ServerPersistKeys.serverURL], let url = URL(string: serverURL) {
+            navigationItem.title = url.host
+        } else {
+            navigationItem.title = SocketManager.sharedInstance.serverURL?.host
+        }
 
-        startLoading()
-        AuthManager.usernameSuggestion { [weak self] (response) in
-            self?.stopLoading()
+        if let nav = navigationController as? BaseNavigationController {
+            nav.setGrayTheme()
+        }
 
-            if !response.isError() {
-                self?.textFieldUsername.text = response.result["result"].stringValue
+        if SocketManager.isConnected() {
+            startLoading()
+            AuthManager.usernameSuggestion { [weak self] (response) in
+                self?.stopLoading()
+
+                if !response.isError() {
+                    self?.textFieldUsername.text = response.result["result"].stringValue
+                }
             }
         }
     }

--- a/Rocket.Chat/Managers/WindowManager.swift
+++ b/Rocket.Chat/Managers/WindowManager.swift
@@ -67,10 +67,16 @@ final class WindowManager {
         - parameter name: The name of the Storyboard to be instantiated.
         - parameter transitionType: The transition to open new view controller.
      */
-    static func open(_ storyboard: Storyboard, transitionType: String = kCATransitionFade) {
-        let controller = storyboard.initialViewController()
-        let application = UIApplication.shared
+    static func open(_ storyboard: Storyboard, viewControllerIdentifier: String? = nil, transitionType: String = kCATransitionFade) {
+        var controller: UIViewController?
 
+        if let identifier = viewControllerIdentifier {
+            controller = storyboard.instantiate(viewController: identifier)
+        } else {
+            controller = storyboard.initialViewController()
+        }
+
+        let application = UIApplication.shared
         if let window = application.windows.first, let controller = controller {
             let transition = CATransition()
             transition.type = transitionType

--- a/Rocket.Chat/Storyboards/Auth.storyboard
+++ b/Rocket.Chat/Storyboards/Auth.storyboard
@@ -697,7 +697,7 @@
                         <outlet property="textFieldPassword" destination="i30-m3-yKn" id="H3k-Zh-b6t"/>
                         <outlet property="textFieldUsername" destination="4sT-R7-k6m" id="uli-YQ-OI7"/>
                         <segue destination="em6-TJ-1CF" kind="show" identifier="TwoFactor" id="9kY-lU-ad7"/>
-                        <segue destination="0XD-Z9-Dv5" kind="show" identifier="Username" id="B9E-PP-gIC"/>
+                        <segue destination="0XD-Z9-Dv5" kind="show" identifier="RequestUsername" id="B9E-PP-gIC"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vKq-Sy-PR9" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1039,6 +1039,22 @@
             </objects>
             <point key="canvasLocation" x="2933" y="18"/>
         </scene>
+        <!--Base Navigation Controller-->
+        <scene sceneID="eWA-Rw-ed8">
+            <objects>
+                <navigationController storyboardIdentifier="RegisterUsernameNav" id="q3n-0j-UeJ" customClass="BaseNavigationController" customModule="Rocket_Chat" customModuleProvider="target" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="fAH-Yd-p9w" customClass="BaseNavigationBar" customModule="Rocket_Chat" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="0XD-Z9-Dv5" kind="relationship" relationship="rootViewController" id="bxA-XM-a3K"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="sGi-8X-Ah7" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="609" y="-1385"/>
+        </scene>
         <!--Register Username Table View Controller-->
         <scene sceneID="JMr-VV-DlN">
             <objects>
@@ -1167,6 +1183,7 @@ to mention you in messages</string>
                             <outlet property="delegate" destination="0XD-Z9-Dv5" id="7h5-DX-phg"/>
                         </connections>
                     </tableView>
+                    <navigationItem key="navigationItem" id="1Sm-hf-iEJ"/>
                     <connections>
                         <outlet property="registerButton" destination="sdI-DC-ZEg" id="wqe-JD-bEA"/>
                         <outlet property="textFieldUsername" destination="3vM-gD-Ajn" id="kdw-bD-A30"/>


### PR DESCRIPTION
@RocketChat/ios 

To reproduce:

1. Create an account on `open.rocket.chat` but don't set a username (close the window when prompted to) 
2. Log in on the iOS app using the e-mail and password, but don't set a username. 
3. Close the app.
4. Open it again

Before this fix it would authenticate the user even without a username, now it will always check if there's a username and if not it will show the register username screen.

It also fixes a bug that used to allow the user to set an empty username.

Closes #1764
