### PR TITLE
[FIX] Navbar background color glitch on dismissal fixed

### DIFF
--- a/Rocket.Chat/Controllers/Base/BaseNavigationController.swift
+++ b/Rocket.Chat/Controllers/Base/BaseNavigationController.swift
@@ -104,3 +104,12 @@ extension BaseNavigationController: BaseNavigationBarThemeSource {
         return topViewController?.view.theme
     }
 }
+
+// MARK: Themeable
+
+extension BaseNavigationController {
+    override func applyTheme() {
+        super.applyTheme()
+        view.backgroundColor = navigationBar.theme?.backgroundColor ?? .white
+    }
+}


### PR DESCRIPTION
@RocketChat/ios

Here is what the interactive dismissal looks like after this fix.

<img src=https://user-images.githubusercontent.com/7317008/41679579-943285c0-74c6-11e8-8168-9a84da2d87bc.png width=300>

The `UIAlertController` is already fixed and merged into develop.

Closes #1789