### PR TITLE
[FIX] Transparent nav bar and reactors list headers

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -689,7 +689,7 @@
 		99923773204B3BD800C2D15F /* UploadAvatarRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99923772204B3BD800C2D15F /* UploadAvatarRequest.swift */; };
 		999483EB20644CC4004F61CA /* WebBrowserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999483EA20644CC4004F61CA /* WebBrowserViewModel.swift */; };
 		999F25B5207EEB0C002E0F68 /* FileModelMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999F25B4207EEB0C002E0F68 /* FileModelMapping.swift */; };
-		999F25B7207EEE70002E0F68 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		999F25B7207EEE70002E0F68 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		99B060CE1FB1225200F471C2 /* DraftMessageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B060CD1FB1225200F471C2 /* DraftMessageManager.swift */; };
 		99B802ED20BC3BD400230109 /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B802EC20BC3BD400230109 /* ImageManager.swift */; };
 		99B802EE20BC3EF700230109 /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B802EC20BC3BD400230109 /* ImageManager.swift */; };
@@ -4325,7 +4325,7 @@
 				80A2F39220057AD0005D2DCA /* EmojiAutocompleteCell.swift in Sources */,
 				41DF76E31D2C50710028DBF8 /* AppDelegate.swift in Sources */,
 				D18675EC1F716A0D00406FB4 /* LoginRequest.swift in Sources */,
-				999F25B7207EEE70002E0F68 /* BuildFile in Sources */,
+				999F25B7207EEE70002E0F68 /* (null) in Sources */,
 				806728FF20079734009FE94D /* DeleteMessageRequest.swift in Sources */,
 				99DBB872208FF6FE00382DB2 /* SearchMessagesRequest.swift in Sources */,
 				80054CF11FD9505A00F5ECF9 /* SendMessageRequest.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		33D08E2E20BD9267008D03EF /* ThemePreferenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D08E2C20BD9267008D03EF /* ThemePreferenceController.swift */; };
 		33D08E2F20BD9267008D03EF /* ThemePreferenceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D08E2D20BD9267008D03EF /* ThemePreferenceViewModel.swift */; };
 		33D08E3120BD92A5008D03EF /* ThemePreferenceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D08E3020BD92A5008D03EF /* ThemePreferenceCell.swift */; };
+		33E33ED620E0E59B00EF4560 /* AuthNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E33ED520E0E59B00EF4560 /* AuthNavigationController.swift */; };
 		33F73B2D2073BDF400F03F29 /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F73B2B2073BDF400F03F29 /* NotificationView.swift */; };
 		33F73B302073F24200F03F29 /* NotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F73B2F2073F24200F03F29 /* NotificationViewController.swift */; };
 		33FB9D3E20CEF610005AF504 /* SubscriptionsSortingSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33FB9D3D20CEF610005AF504 /* SubscriptionsSortingSeparatorView.swift */; };
@@ -881,6 +882,7 @@
 		33D08E2C20BD9267008D03EF /* ThemePreferenceController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemePreferenceController.swift; sourceTree = "<group>"; };
 		33D08E2D20BD9267008D03EF /* ThemePreferenceViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemePreferenceViewModel.swift; sourceTree = "<group>"; };
 		33D08E3020BD92A5008D03EF /* ThemePreferenceCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ThemePreferenceCell.swift; path = Preferences/ThemePreferenceCell.swift; sourceTree = "<group>"; };
+		33E33ED520E0E59B00EF4560 /* AuthNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthNavigationController.swift; sourceTree = "<group>"; };
 		33F73B2B2073BDF400F03F29 /* NotificationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationView.swift; sourceTree = "<group>"; };
 		33F73B2F2073F24200F03F29 /* NotificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationViewController.swift; sourceTree = "<group>"; };
 		33FB9D3D20CEF610005AF504 /* SubscriptionsSortingSeparatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionsSortingSeparatorView.swift; sourceTree = "<group>"; };
@@ -2079,6 +2081,7 @@
 				995F710A20C7822A00B7535F /* AuthTableViewController.swift */,
 				995F711520C790AB00B7535F /* AuthTableViewControllerAuthenticationHandler.swift */,
 				995F711720C790D800B7535F /* AuthTableViewControllerConnectionHandler.swift */,
+				33E33ED520E0E59B00EF4560 /* AuthNavigationController.swift */,
 				995F711920C7910800B7535F /* AuthTableViewControllerLoginServices.swift */,
 				80D955C1202154A300E3F281 /* CASViewController.swift */,
 				4174CB0C1D2D994A0086DAC8 /* ConnectServerViewController.swift */,
@@ -4163,6 +4166,7 @@
 				412BCC871E55C6B800F7F4EE /* ChatMessageTextView.swift in Sources */,
 				140A95E6202F7074003FD564 /* DrawingControllerDelegate.swift in Sources */,
 				80054CF31FD951B100F5ECF9 /* MessagesClient.swift in Sources */,
+				33E33ED620E0E59B00EF4560 /* AuthNavigationController.swift in Sources */,
 				33F73B302073F24200F03F29 /* NotificationViewController.swift in Sources */,
 				99DBB8742090360600382DB2 /* MessagesListControllerSearch.swift in Sources */,
 				414E8A8D20A5DD2200615CE6 /* RoomRolesRequest.swift in Sources */,

--- a/Rocket.Chat/Controllers/Auth/AuthNavigationController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthNavigationController.swift
@@ -1,0 +1,85 @@
+//
+//  AuthNavigationController.swift
+//  Rocket.Chat
+//
+//  Created by Samar Sunkaria on 6/25/18.
+//  Copyright © 2018 Rocket.Chat. All rights reserved.
+//
+
+import UIKit
+
+class AuthNavigationController: UINavigationController {
+
+    override var shouldAutorotate: Bool {
+        guard let topViewController = topViewController else { return true }
+        return !(topViewController is WelcomeViewController)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .white
+
+        let navBar = self.navigationBar
+        navBar.isTranslucent = false
+        navBar.tintColor = .RCBlue()
+        navBar.barTintColor = .RCNavigationBarColor()
+    }
+
+    override func popToRootViewController(animated: Bool) -> [UIViewController]? {
+        let viewControllers = super.popToRootViewController(animated: animated)
+        setTransparentTheme()
+        return viewControllers
+    }
+
+    override func popViewController(animated: Bool) -> UIViewController? {
+        let poppedViewController = super.popViewController(animated: animated)
+
+        if topViewController is ConnectServerViewController {
+            setTransparentTheme()
+        }
+
+        return poppedViewController
+    }
+
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        let pushedFromViewController = topViewController
+        super.pushViewController(viewController, animated: animated)
+
+        if viewController is LoginTableViewController || viewController is AuthTableViewController {
+            setGrayTheme(
+                forceRedraw: pushedFromViewController is ConnectServerViewController
+            )
+        }
+    }
+
+    func setTransparentTheme(forceRedraw: Bool = false) {
+        let navBar = self.navigationBar
+        navBar.barStyle = .default
+        navBar.setBackgroundImage(UIImage(), for: .default)
+        navBar.shadowImage = UIImage()
+        navBar.backgroundColor = UIColor.clear
+        navBar.isTranslucent = true
+        navBar.tintColor = .RCBlue()
+        if forceRedraw { forceNavigationToRedraw() }
+        setNeedsStatusBarAppearanceUpdate()
+    }
+
+    func setGrayTheme(forceRedraw: Bool = false) {
+        let navBar = self.navigationBar
+        navBar.barStyle = .black
+        navBar.shadowImage = UIImage()
+        navBar.backgroundColor = .RCNavBarGray()
+        navBar.barTintColor = .RCNavBarGray()
+        navBar.isTranslucent = false
+        navBar.tintColor = .white
+        navBar.titleTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.white]
+        if forceRedraw { forceNavigationToRedraw() }
+        setNeedsStatusBarAppearanceUpdate()
+    }
+
+    func forceNavigationToRedraw() {
+        isNavigationBarHidden = true
+        isNavigationBarHidden = false
+    }
+}

--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -146,7 +146,7 @@ class AuthTableViewController: BaseTableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        if let nav = navigationController as? BaseNavigationController {
+        if let nav = navigationController as? AuthNavigationController {
             nav.setGrayTheme()
         }
 

--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -77,7 +77,7 @@ final class ConnectServerViewController: BaseViewController {
         infoRequestHandler.delegate = self
         textFieldServerURL.placeholder = defaultURL
 
-        if let nav = navigationController as? BaseNavigationController {
+        if let nav = navigationController as? AuthNavigationController {
             nav.setTransparentTheme()
         }
 

--- a/Rocket.Chat/Controllers/Auth/LegalTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LegalTableViewController.swift
@@ -26,7 +26,7 @@ class LegalTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if let nav = navigationController as? BaseNavigationController {
+        if let nav = navigationController as? AuthNavigationController {
             nav.setGrayTheme()
         }
     }

--- a/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
@@ -145,7 +145,7 @@ class LoginTableViewController: BaseTableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        if let nav = navigationController as? BaseNavigationController {
+        if let nav = navigationController as? AuthNavigationController {
             nav.setGrayTheme()
         }
     }

--- a/Rocket.Chat/Controllers/Auth/RegisterUsernameTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/RegisterUsernameTableViewController.swift
@@ -31,7 +31,7 @@ final class RegisterUsernameTableViewController: BaseTableViewController {
             navigationItem.title = SocketManager.sharedInstance.serverURL?.host
         }
 
-        if let nav = navigationController as? BaseNavigationController {
+        if let nav = navigationController as? AuthNavigationController {
             nav.setGrayTheme()
         }
     }

--- a/Rocket.Chat/Controllers/Auth/WelcomeViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/WelcomeViewController.swift
@@ -91,7 +91,7 @@ class WelcomeViewController: BaseViewController {
     // MARK: Setup
 
     func setupAppearance() {
-        if let nav = navigationController as? BaseNavigationController {
+        if let nav = navigationController as? AuthNavigationController {
             nav.setTransparentTheme()
         }
 

--- a/Rocket.Chat/Controllers/Base/BaseNavigationController.swift
+++ b/Rocket.Chat/Controllers/Base/BaseNavigationController.swift
@@ -42,7 +42,10 @@ class BaseNavigationController: UINavigationController {
 
     override func popToRootViewController(animated: Bool) -> [UIViewController]? {
         let viewControllers = super.popToRootViewController(animated: animated)
-        setTransparentTheme()
+
+        if topViewController is ConnectServerViewController || topViewController is WelcomeViewController {
+            setTransparentTheme()
+        }
 
         return viewControllers
     }

--- a/Rocket.Chat/Controllers/Base/BaseNavigationController.swift
+++ b/Rocket.Chat/Controllers/Base/BaseNavigationController.swift
@@ -6,15 +6,9 @@
 //  Copyright © 2016 Rocket.Chat. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 class BaseNavigationController: UINavigationController {
-
-    override var shouldAutorotate: Bool {
-        guard let topViewController = topViewController else { return true }
-        return !(topViewController is WelcomeViewController)
-    }
 
     override init(rootViewController: UIViewController) {
         super.init(navigationBarClass: BaseNavigationBar.self, toolbarClass: nil)
@@ -38,67 +32,6 @@ class BaseNavigationController: UINavigationController {
 
         view.backgroundColor = .white
         ThemeManager.addObserver(self)
-    }
-
-    override func popToRootViewController(animated: Bool) -> [UIViewController]? {
-        let viewControllers = super.popToRootViewController(animated: animated)
-
-        if topViewController is ConnectServerViewController || topViewController is WelcomeViewController {
-            setTransparentTheme()
-        }
-
-        return viewControllers
-    }
-
-    override func popViewController(animated: Bool) -> UIViewController? {
-        let poppedViewController = super.popViewController(animated: animated)
-
-        if topViewController is ConnectServerViewController {
-            setTransparentTheme()
-        }
-
-        return poppedViewController
-    }
-
-    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
-        let pushedFromViewController = topViewController
-        super.pushViewController(viewController, animated: animated)
-
-        if viewController is LoginTableViewController || viewController is AuthTableViewController {
-            setGrayTheme(
-                forceRedraw: pushedFromViewController is ConnectServerViewController
-            )
-        }
-    }
-
-    func setTransparentTheme(forceRedraw: Bool = false) {
-        let navBar = self.navigationBar
-        navBar.barStyle = .default
-        navBar.setBackgroundImage(UIImage(), for: .default)
-        navBar.shadowImage = UIImage()
-        navBar.backgroundColor = UIColor.clear
-        navBar.isTranslucent = true
-        navBar.tintColor = .RCBlue()
-        if forceRedraw { forceNavigationToRedraw() }
-        setNeedsStatusBarAppearanceUpdate()
-    }
-
-    func setGrayTheme(forceRedraw: Bool = false) {
-        let navBar = self.navigationBar
-        navBar.barStyle = .black
-        navBar.shadowImage = UIImage()
-        navBar.backgroundColor = .RCNavBarGray()
-        navBar.barTintColor = .RCNavBarGray()
-        navBar.isTranslucent = false
-        navBar.tintColor = .white
-        navBar.titleTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.white]
-        if forceRedraw { forceNavigationToRedraw() }
-        setNeedsStatusBarAppearanceUpdate()
-    }
-
-    func forceNavigationToRedraw() {
-        isNavigationBarHidden = true
-        isNavigationBarHidden = false
     }
 }
 

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsViewController.swift
@@ -310,6 +310,7 @@ final class SubscriptionsViewController: BaseViewController {
 extension SubscriptionsViewController: UISearchBarDelegate {
 
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        searchBar.setShowsCancelButton(true, animated: true)
         serversView?.close()
         sortingView?.close()
     }
@@ -327,6 +328,7 @@ extension SubscriptionsViewController: UISearchBarDelegate {
     }
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.setShowsCancelButton(false, animated: true)
         searchBar.resignFirstResponder()
         searchBar.text = ""
         searchText = ""
@@ -608,14 +610,6 @@ extension SubscriptionsViewController: UITableViewDelegate {
 }
 
 extension SubscriptionsViewController {
-
-    func showCancelSearchButton() {
-        searchController?.searchBar.setShowsCancelButton(true, animated: true)
-    }
-
-    func hideCancelSearchButton() {
-        searchController?.searchBar.setShowsCancelButton(false, animated: true)
-    }
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let currentText = textField.text ?? ""

--- a/Rocket.Chat/External/RCEmojiKit/Views/Reaction/ReactorListView.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/Reaction/ReactorListView.swift
@@ -141,7 +141,7 @@ extension ReactorListView: UITableViewDelegate {
         view.addSubview(stackView)
 
         view.applyTheme()
-        view.backgroundColor = #colorLiteral(red: 0.4980838895, green: 0.4951269031, blue: 0.5003594756, alpha: 0.09813784247)
+        view.backgroundColor = view.theme?.auxiliaryBackground
 
         return view
     }

--- a/Rocket.Chat/Storyboards/Auth.storyboard
+++ b/Rocket.Chat/Storyboards/Auth.storyboard
@@ -1090,11 +1090,11 @@
             </objects>
             <point key="canvasLocation" x="2933" y="18"/>
         </scene>
-        <!--Base Navigation Controller-->
+        <!--Auth Navigation Controller-->
         <scene sceneID="eWA-Rw-ed8">
             <objects>
-                <navigationController storyboardIdentifier="RegisterUsernameNav" id="q3n-0j-UeJ" customClass="BaseNavigationController" customModule="Rocket_Chat" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="fAH-Yd-p9w" customClass="BaseNavigationBar" customModule="Rocket_Chat" customModuleProvider="target">
+                <navigationController storyboardIdentifier="RegisterUsernameNav" id="q3n-0j-UeJ" customClass="AuthNavigationController" customModule="Rocket_Chat" customModuleProvider="target" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="fAH-Yd-p9w" customClass="NotThemeableNavigationBar" customModule="Rocket_Chat" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1336,11 +1336,11 @@ to mention you in messages</string>
             </objects>
             <point key="canvasLocation" x="610" y="714"/>
         </scene>
-        <!--Base Navigation Controller-->
+        <!--Auth Navigation Controller-->
         <scene sceneID="eEk-8u-HV2">
             <objects>
-                <navigationController storyboardIdentifier="ConnectServerNav" id="OC3-Ih-BUc" customClass="BaseNavigationController" customModule="Rocket_Chat" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="0We-EH-aKl" customClass="BaseNavigationBar" customModule="Rocket_Chat" customModuleProvider="target">
+                <navigationController storyboardIdentifier="ConnectServerNav" id="OC3-Ih-BUc" customClass="AuthNavigationController" customModule="Rocket_Chat" customModuleProvider="target" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="0We-EH-aKl" customClass="NotThemeableNavigationBar" customModule="Rocket_Chat" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1352,12 +1352,12 @@ to mention you in messages</string>
             </objects>
             <point key="canvasLocation" x="609" y="1433"/>
         </scene>
-        <!--Base Navigation Controller-->
+        <!--Auth Navigation Controller-->
         <scene sceneID="VVk-L1-Mm3">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="kCN-DM-NIV" customClass="BaseNavigationController" customModule="Rocket_Chat" customModuleProvider="target" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="kCN-DM-NIV" customClass="AuthNavigationController" customModule="Rocket_Chat" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="fqn-Q1-9Rp" customClass="BaseNavigationBar" customModule="Rocket_Chat" customModuleProvider="target">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="fqn-Q1-9Rp" customClass="NotThemeableNavigationBar" customModule="Rocket_Chat" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1370,12 +1370,12 @@ to mention you in messages</string>
             </objects>
             <point key="canvasLocation" x="-1033" y="713"/>
         </scene>
-        <!--Base Navigation Controller-->
+        <!--Auth Navigation Controller-->
         <scene sceneID="PM5-Dp-rQ1">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="gD1-Tz-RKb" customClass="BaseNavigationController" customModule="Rocket_Chat" customModuleProvider="target" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="gD1-Tz-RKb" customClass="AuthNavigationController" customModule="Rocket_Chat" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="trJ-5o-du2" customClass="BaseNavigationBar" customModule="Rocket_Chat" customModuleProvider="target">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="trJ-5o-du2" customClass="NotThemeableNavigationBar" customModule="Rocket_Chat" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>

--- a/Rocket.Chat/Theme/ThemeableViews.swift
+++ b/Rocket.Chat/Theme/ThemeableViews.swift
@@ -170,11 +170,11 @@ extension UITextView {
 
 extension UINavigationBar {
     override func applyTheme() {
-        super.applyTheme()
         guard let theme = theme else { return }
         tintColor = theme.tintColor
         barStyle = theme.appearence.barStyle
         barTintColor = theme.focusedBackground
+        items?.forEach { $0.titleView?.applyTheme() }
     }
 
     open override func insertSubview(_ view: UIView, at index: Int) {


### PR DESCRIPTION
@RocketChat/ios

This also addresses an issue where the nav bar would get colored the same as the background color of the chat view controller when the user is editing a message.

An `AuthNavigationController` has been added since all the changes required to the navigation controller for the new on boarding are not generic and do not belong in the `BaseNavigationController`

Closes #1820 
Closes #1821
Closes #1781 