### PR TITLE
[FIX] Channel description becomes smaller with longer length

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChannelActionsViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChannelActionsViewController.swift
@@ -287,22 +287,22 @@ extension ChannelActionsViewController: UITableViewDelegate {
         let data = tableViewData[indexPath.section][indexPath.row]
 
         if data as? ChannelInfoActionCellData != nil {
-            return CGFloat(ChannelInfoActionCell.defaultHeight)
+            return ChannelInfoActionCell.defaultHeight
         }
 
         if data as? ChannelInfoUserCellData != nil {
-            return CGFloat(ChannelInfoUserCell.defaultHeight)
+            return ChannelInfoUserCell.defaultHeight
         }
 
         if data as? ChannelInfoDescriptionCellData != nil {
-            return CGFloat(ChannelInfoDescriptionCell.defaultHeight)
+            return ChannelInfoDescriptionCell.defaultHeight
         }
 
         if data as? ChannelInfoBasicCellData != nil {
-            return CGFloat(ChannelInfoBasicCell.defaultHeight)
+            return ChannelInfoBasicCell.defaultHeight
         }
 
-        return CGFloat(0)
+        return 0
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoActionCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoActionCell.swift
@@ -29,7 +29,7 @@ class ChannelInfoActionCell: UITableViewCell, ChannelInfoCellProtocol {
     typealias DataType = ChannelInfoActionCellData
 
     static let identifier = "kChannelInfoActionCell"
-    static let defaultHeight: Float = 44
+    static let defaultHeight: CGFloat = 44
     var data: DataType? {
         didSet {
             labelTitle.text = data?.title

--- a/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoBasicCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoBasicCell.swift
@@ -18,7 +18,7 @@ final class ChannelInfoBasicCell: UITableViewCell, ChannelInfoCellProtocol {
     typealias DataType = ChannelInfoBasicCellData
 
     static let identifier = "kChannelInfoCellBasic"
-    static let defaultHeight: Float = 44
+    static let defaultHeight: CGFloat = 44
 
     var data: DataType? {
         didSet {

--- a/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoCellProtocol.swift
+++ b/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoCellProtocol.swift
@@ -12,7 +12,7 @@ protocol ChannelInfoCellProtocol {
     associatedtype DataType
 
     static var identifier: String { get }
-    static var defaultHeight: Float { get }
+    static var defaultHeight: CGFloat { get }
     var data: DataType? { get set }
 }
 

--- a/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoDescriptionCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoDescriptionCell.swift
@@ -20,7 +20,7 @@ final class ChannelInfoDescriptionCell: UITableViewCell, ChannelInfoCellProtocol
     typealias DataType = ChannelInfoDescriptionCellData
 
     static let identifier = "kChannelInfoCellDescription"
-    static let defaultHeight: Float = 80
+    static let defaultHeight: CGFloat = UITableViewAutomaticDimension
 
     @IBOutlet weak var labelTitle: UILabel!
     @IBOutlet weak var labelSubtitle: UILabel!

--- a/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoDescriptionCell.xib
+++ b/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoDescriptionCell.xib
@@ -28,7 +28,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L2L-Al-CUM">
+                            <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L2L-Al-CUM">
                                 <rect key="frame" x="0.0" y="18" width="343" height="18"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <color key="textColor" red="0.61960784313725492" green="0.63529411764705879" blue="0.6588235294117647" alpha="1" colorSpace="calibratedRGB"/>

--- a/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoUserCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoUserCell.swift
@@ -17,7 +17,7 @@ final class ChannelInfoUserCell: UITableViewCell, ChannelInfoCellProtocol {
     typealias DataType = ChannelInfoUserCellData
 
     static let identifier = "kChannelInfoCellUser"
-    static let defaultHeight: Float = 80
+    static let defaultHeight: CGFloat = 80
 
     var data: DataType? {
         didSet {


### PR DESCRIPTION
@RocketChat/ios

`ChannelInfoDescriptionCell` now uses `UITableViewAutomaticDimension` rather than a constant height.

Closes #1882 