### PR TITLE
[BUG] Attempt to fix a database inconsistency and some minor improvements on the server switching process

### DIFF
--- a/Rocket.Chat/API/Clients/SubscriptionsClient.swift
+++ b/Rocket.Chat/API/Clients/SubscriptionsClient.swift
@@ -32,8 +32,6 @@ struct SubscriptionsClient: APIClient {
     func fetchSubscriptions(updatedSince: Date?, realm: Realm? = Realm.current, completion: (() -> Void)? = nil) {
         let req = SubscriptionsRequest(updatedSince: updatedSince)
 
-        let currentRealm = realm
-
         api.fetch(req, options: [.retryOnError(count: 3)]) { response in
             switch response {
             case .resource(let resource):
@@ -44,7 +42,7 @@ struct SubscriptionsClient: APIClient {
 
                 let subscriptions = List<Subscription>()
 
-                currentRealm?.execute({ realm in
+                realm?.execute({ realm in
                     guard let auth = AuthManager.isAuthenticated(realm: realm) else { return }
 
                     func queueSubscriptionForUpdate(_ subscription: Subscription) {
@@ -79,8 +77,6 @@ struct SubscriptionsClient: APIClient {
     func fetchRooms(updatedSince: Date?, realm: Realm? = Realm.current, completion: (() -> Void)? = nil) {
         let req = RoomsRequest(updatedSince: updatedSince)
 
-        let currentRealm = realm
-
         api.fetch(req, options: [.retryOnError(count: 3)]) { response in
             switch response {
             case .resource(let resource):
@@ -89,7 +85,7 @@ struct SubscriptionsClient: APIClient {
                     return
                 }
 
-                currentRealm?.execute({ realm in
+                realm?.execute({ realm in
                     guard let auth = AuthManager.isAuthenticated(realm: realm) else { return }
                     auth.lastRoomFetchWithLastMessage = Date.serverDate
                     realm.add(auth, update: true)
@@ -97,7 +93,7 @@ struct SubscriptionsClient: APIClient {
 
                 let subscriptions = List<Subscription>()
 
-                currentRealm?.execute({ realm in
+                realm?.execute({ realm in
                     func queueRoomValuesForUpdate(_ object: JSON) {
                         guard
                             let rid = object["_id"].string,

--- a/Rocket.Chat/API/Requests/Subscription/SubscriptionsRequest.swift
+++ b/Rocket.Chat/API/Requests/Subscription/SubscriptionsRequest.swift
@@ -33,23 +33,26 @@ struct SubscriptionsRequest: APIRequest {
 
 final class SubscriptionsResource: APIResource {
     var update: [Subscription]? {
-        guard let realm = Realm.current else { return [] }
         return raw?["update"].array?.map {
-            return Subscription.getOrCreate(realm: realm, values: $0, updates: nil)
+            let subscription = Subscription()
+            subscription.map($0, realm: nil)
+            return subscription
         }.compactMap { $0 }
     }
 
     var remove: [Subscription]? {
-        guard let realm = Realm.current else { return [] }
         return raw?["remove"].array?.map {
-            return Subscription.getOrCreate(realm: realm, values: $0, updates: nil)
+            let subscription = Subscription()
+            subscription.map($0, realm: nil)
+            return subscription
         }.compactMap { $0 }
     }
 
     var list: [Subscription]? {
-        guard let realm = Realm.current else { return [] }
         return raw?["result"].array?.map {
-            return Subscription.getOrCreate(realm: realm, values: $0, updates: nil)
+            let subscription = Subscription()
+            subscription.map($0, realm: nil)
+            return subscription
         }.compactMap { $0 }
     }
 

--- a/Rocket.Chat/Extensions/API/APIExtensions.swift
+++ b/Rocket.Chat/Extensions/API/APIExtensions.swift
@@ -6,12 +6,12 @@
 //  Copyright © 2017 Rocket.Chat. All rights reserved.
 //
 
-import Foundation
+import RealmSwift
 
 extension API {
-    static func current(auth: Auth? = AuthManager.isAuthenticated()) -> API? {
+    static func current(realm: Realm? = Realm.current) -> API? {
         guard
-            let auth = auth,
+            let auth = AuthManager.isAuthenticated(realm: realm),
             let host = auth.apiHost?.httpServerURL() ?? auth.apiHost
         else {
             return nil
@@ -27,7 +27,6 @@ extension API {
 
     static func server(index: Int) -> API? {
         let realm = DatabaseManager.databaseInstace(index: index)
-        let auth = AuthManager.isAuthenticated(realm: realm)
-        return current(auth: auth)
+        return current(realm: realm)
     }
 }

--- a/Rocket.Chat/Managers/Model/CustomEmojiManager.swift
+++ b/Rocket.Chat/Managers/Model/CustomEmojiManager.swift
@@ -10,10 +10,8 @@ import Foundation
 import RealmSwift
 
 struct CustomEmojiManager {
-    static func sync() {
+    static func sync(realm: Realm? = Realm.current) {
         CustomEmoji.cachedEmojis = nil
-
-        let currentRealm = Realm.current
 
         API.current()?.fetch(CustomEmojiRequest()) { response in
             switch response {
@@ -22,7 +20,7 @@ struct CustomEmojiManager {
                     return Log.debug(resource.errorMessage)
                 }
 
-                currentRealm?.execute({ realm in
+                realm?.execute({ realm in
                     realm.delete(realm.objects(CustomEmoji.self))
 
                     let emoji = List<CustomEmoji>()
@@ -35,7 +33,7 @@ struct CustomEmojiManager {
                 })
             case .error(let error):
                 switch error {
-                case .version: websocketSync(currentRealm)
+                case .version: websocketSync(realm)
                 default: break
                 }
             }

--- a/Rocket.Chat/Managers/Model/CustomEmojiManager.swift
+++ b/Rocket.Chat/Managers/Model/CustomEmojiManager.swift
@@ -13,7 +13,7 @@ struct CustomEmojiManager {
     static func sync(realm: Realm? = Realm.current) {
         CustomEmoji.cachedEmojis = nil
 
-        API.current()?.fetch(CustomEmojiRequest()) { response in
+        API.current(realm: realm)?.fetch(CustomEmojiRequest()) { response in
             switch response {
             case .resource(let resource):
                 guard resource.success else {

--- a/Rocket.Chat/Managers/Model/SubscriptionManager/SubscriptionManager.swift
+++ b/Rocket.Chat/Managers/Model/SubscriptionManager/SubscriptionManager.swift
@@ -22,31 +22,32 @@ struct SubscriptionManager {
         })
     }
 
-    static func updateSubscriptions(_ auth: Auth, completion: (() -> Void)?) {
-        Realm.current?.refresh()
+    static func updateSubscriptions(_ auth: Auth, realm: Realm? = Realm.current, completion: (() -> Void)?) {
+        realm?.refresh()
+
         let client = API.current()?.client(SubscriptionsClient.self)
         let lastUpdateSubscriptions = auth.lastSubscriptionFetchWithLastMessage
         let lastUpdateRooms = auth.lastRoomFetchWithLastMessage
         let dispatchGroup = DispatchGroup()
 
         dispatchGroup.enter()
-        client?.fetchSubscriptions(updatedSince: lastUpdateSubscriptions) {
+        client?.fetchSubscriptions(updatedSince: lastUpdateSubscriptions, realm: realm) {
             dispatchGroup.leave()
 
             // We don't trust the updatedSince response all the time.
             // Our API is having issues with caching and we can't try
             // to avoid this on the request.
-            client?.fetchSubscriptions(updatedSince: nil) { }
+            client?.fetchSubscriptions(updatedSince: nil, realm: realm) { }
         }
 
         dispatchGroup.enter()
-        client?.fetchRooms(updatedSince: lastUpdateRooms) {
+        client?.fetchRooms(updatedSince: lastUpdateRooms, realm: realm) {
             dispatchGroup.leave()
 
             // We don't trust the updatedSince response all the time.
             // Our API is having issues with caching and we can't try
             // to avoid this on the request.
-            client?.fetchRooms(updatedSince: nil) { }
+            client?.fetchRooms(updatedSince: nil, realm: realm) { }
         }
 
         dispatchGroup.notify(queue: .main) {

--- a/Rocket.Chat/Managers/Model/SubscriptionManager/SubscriptionManager.swift
+++ b/Rocket.Chat/Managers/Model/SubscriptionManager/SubscriptionManager.swift
@@ -25,7 +25,7 @@ struct SubscriptionManager {
     static func updateSubscriptions(_ auth: Auth, realm: Realm? = Realm.current, completion: (() -> Void)?) {
         realm?.refresh()
 
-        let client = API.current()?.client(SubscriptionsClient.self)
+        let client = API.current(realm: realm)?.client(SubscriptionsClient.self)
         let lastUpdateSubscriptions = auth.lastSubscriptionFetchWithLastMessage
         let lastUpdateRooms = auth.lastRoomFetchWithLastMessage
         let dispatchGroup = DispatchGroup()

--- a/Rocket.Chat/Managers/Socket/SocketManager.swift
+++ b/Rocket.Chat/Managers/Socket/SocketManager.swift
@@ -159,13 +159,14 @@ extension SocketManager {
 
         sharedInstance.state = .connecting
 
+        let currentRealm = Realm.current
         AuthManager.resume(auth, completion: { (response) in
             guard !response.isError() else {
                 return
             }
 
-            infoClient.fetchInfo(completion: {
-                SubscriptionManager.updateSubscriptions(auth) {
+            infoClient.fetchInfo(realm: currentRealm, completion: {
+                SubscriptionManager.updateSubscriptions(auth, realm: currentRealm) {
                     AuthSettingsManager.updatePublicSettings(auth)
 
                     UserManager.userDataChanges()
@@ -174,16 +175,16 @@ extension SocketManager {
                     SubscriptionManager.subscribeRoomChanges()
                     SubscriptionManager.subscribeInAppNotifications()
                     PermissionManager.changes()
-                    infoClient.fetchPermissions()
-                    CustomEmojiManager.sync()
+                    infoClient.fetchPermissions(realm: currentRealm)
+                    CustomEmojiManager.sync(realm: currentRealm)
 
-                    commandsClient.fetchCommands()
+                    commandsClient.fetchCommands(realm: currentRealm)
 
                     if let userIdentifier = auth.userId {
                         PushManager.updateUser(userIdentifier)
                     }
 
-                    if AuthManager.currentUser()?.username == nil {
+                    if AuthManager.currentUser(realm: currentRealm)?.username == nil {
                         WindowManager.open(
                             .auth(
                                 serverUrl: "",

--- a/Rocket.Chat/Views/Subscriptions/ServersListView.swift
+++ b/Rocket.Chat/Views/Subscriptions/ServersListView.swift
@@ -121,13 +121,6 @@ final class ServersListView: UIView {
         if indexPath.row == DatabaseManager.selectedIndex {
             close()
         } else {
-            DatabaseManager.selectDatabase(at: indexPath.row)
-            DatabaseManager.changeDatabaseInstance(index: indexPath.row)
-
-            SocketManager.disconnect { (_, _) in
-                WindowManager.open(.subscriptions)
-            }
-
             AppManager.changeSelectedServer(index: indexPath.row)
         }
     }

--- a/Rocket.ChatTests/Extensions/API/APIExtensionsSpec.swift
+++ b/Rocket.ChatTests/Extensions/API/APIExtensionsSpec.swift
@@ -13,7 +13,7 @@ import XCTest
 class APIExtensionsSpec: XCTestCase, RealmTestCase {
     func testCurrent() {
         let realm = testRealm()
-        let auth = Auth.testInstance()
+        var auth = Auth.testInstance()
 
         try? realm.write {
             realm.add(auth)
@@ -26,11 +26,11 @@ class APIExtensionsSpec: XCTestCase, RealmTestCase {
         XCTAssertEqual(api?.version, Version(1, 2, 3))
 
         auth.serverVersion = "invalid"
-        api = API.current(auth: auth)
+        api = API.current(realm: realm)
         XCTAssertEqual(api?.version, Version.zero)
 
         auth = Auth()
-        api = API.current(auth: auth)
+        api = API.current(realm: realm)
 
         XCTAssertNil(api)
     }

--- a/Rocket.ChatTests/Extensions/API/APIExtensionsSpec.swift
+++ b/Rocket.ChatTests/Extensions/API/APIExtensionsSpec.swift
@@ -10,10 +10,16 @@ import XCTest
 
 @testable import Rocket_Chat
 
-class APIExtensionsSpec: XCTestCase {
+class APIExtensionsSpec: XCTestCase, RealmTestCase {
     func testCurrent() {
-        var auth = Auth.testInstance()
-        var api = API.current(auth: auth)
+        let realm = testRealm()
+        let auth = Auth.testInstance()
+
+        try? realm.write {
+            realm.add(auth)
+        }
+
+        var api = API.current(realm: realm)
 
         XCTAssertEqual(api?.userId, "auth-userid")
         XCTAssertEqual(api?.authToken, "auth-token")


### PR DESCRIPTION
@RocketChat/ios

This issue is very hard to reproduce. I'm not sure if this PR really fixes the issue or just make it harder to reproduce. We may need to rethink the entire way that we deal with the isolation of the databases. Just trusting in the "selected" doesn't work well when dealing with async calls (and we have A LOT of async calls that interact with the database on the callback). In the ideal world, we would have to think on how to make each call know which database/server it belongs to.

Closes #1903
