### PR TITLE
[FIX] Crash due to in-app notifications

### DIFF
--- a/Rocket.Chat/Managers/NotificationManager.swift
+++ b/Rocket.Chat/Managers/NotificationManager.swift
@@ -15,36 +15,40 @@ final class NotificationManager {
 
     /// Posts an in-app notification.
     ///
+    /// This method is thread safe, and therefore can be called from any thread.
+    ///
     /// **NOTE:** The notification is only posted if the `rid` of the
     /// notification is different from the `AppManager.currentRoomId`
     ///
     /// - parameters:
-    ///     - notification: The `ChatNotification` object to display the
-    ///         contents of the notification from. The `title` and the `body`
-    ///         cannot be empty strings.
+    ///     - notification: The `ChatNotification` object used to display the
+    ///         contents of the notification. The `title` and the `body` of the
+    ///         notification cannot be empty strings.
 
     static func post(notification: ChatNotification) {
-        guard
-            AppManager.currentRoomId != notification.payload.rid,
-            !notification.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-            !notification.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        else {
-            return
+        DispatchQueue.main.async {
+            guard
+                AppManager.currentRoomId != notification.payload.rid,
+                !notification.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                !notification.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else {
+                return
+            }
+
+            let formattedBody = NSMutableAttributedString(string: notification.body)
+                .transformMarkdown().string
+                .components(separatedBy: .newlines)
+                .joined(separator: " ")
+                .replacingOccurrences(of: "^\\s+", with: "", options: .regularExpression)
+
+            NotificationViewController.shared.displayNotification(
+                title: notification.title,
+                body: formattedBody,
+                username: notification.payload.sender.username
+            )
+
+            NotificationManager.shared.notification = notification
         }
-
-        let formattedBody = NSMutableAttributedString(string: notification.body)
-            .transformMarkdown().string
-            .components(separatedBy: .newlines)
-            .joined(separator: " ")
-            .replacingOccurrences(of: "^\\s+", with: "", options: .regularExpression)
-
-        NotificationViewController.shared.displayNotification(
-            title: notification.title,
-            body: formattedBody,
-            username: notification.payload.sender.username
-        )
-
-        NotificationManager.shared.notification = notification
     }
 
     func didRespondToNotification() {

--- a/Rocket.Chat/Managers/NotificationManager.swift
+++ b/Rocket.Chat/Managers/NotificationManager.swift
@@ -17,6 +17,24 @@ final class NotificationManager {
     ///
     /// This method is thread safe, and therefore can be called from any thread.
     ///
+    /// This method calls `NotificationManager.post(notification:)` on the main thread.
+    ///
+    /// - parameters:
+    ///     - notification: The `ChatNotification` object used to display the
+    ///         contents of the notification. The `title` and the `body` of the
+    ///         notification cannot be empty strings.
+
+    static func postOnMainThread(notification: ChatNotification) {
+        DispatchQueue.main.async {
+            post(notification: notification)
+        }
+    }
+
+    /// Posts an in-app notification.
+    ///
+    /// This method is **not** thread safe, and therefore must be called
+    /// on the main thread.
+    ///
     /// **NOTE:** The notification is only posted if the `rid` of the
     /// notification is different from the `AppManager.currentRoomId`
     ///
@@ -26,29 +44,27 @@ final class NotificationManager {
     ///         notification cannot be empty strings.
 
     static func post(notification: ChatNotification) {
-        DispatchQueue.main.async {
-            guard
-                AppManager.currentRoomId != notification.payload.rid,
-                !notification.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-                !notification.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            else {
-                return
-            }
-
-            let formattedBody = NSMutableAttributedString(string: notification.body)
-                .transformMarkdown().string
-                .components(separatedBy: .newlines)
-                .joined(separator: " ")
-                .replacingOccurrences(of: "^\\s+", with: "", options: .regularExpression)
-
-            NotificationViewController.shared.displayNotification(
-                title: notification.title,
-                body: formattedBody,
-                username: notification.payload.sender.username
-            )
-
-            NotificationManager.shared.notification = notification
+        guard
+            AppManager.currentRoomId != notification.payload.rid,
+            !notification.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            !notification.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return
         }
+
+        let formattedBody = NSMutableAttributedString(string: notification.body)
+            .transformMarkdown().string
+            .components(separatedBy: .newlines)
+            .joined(separator: " ")
+            .replacingOccurrences(of: "^\\s+", with: "", options: .regularExpression)
+
+        NotificationViewController.shared.displayNotification(
+            title: notification.title,
+            body: formattedBody,
+            username: notification.payload.sender.username
+        )
+
+        NotificationManager.shared.notification = notification
     }
 
     func didRespondToNotification() {

--- a/Rocket.Chat/Models/ChatNotification.swift
+++ b/Rocket.Chat/Models/ChatNotification.swift
@@ -64,6 +64,6 @@ extension ChatNotification {
     /// notification is different from the `AppManager.currentRoomId`
 
     func post() {
-        NotificationManager.post(notification: self)
+        NotificationManager.postOnMainThread(notification: self)
     }
 }

--- a/Rocket.ChatTests/Managers/NotificationManagerSpec.swift
+++ b/Rocket.ChatTests/Managers/NotificationManagerSpec.swift
@@ -50,12 +50,12 @@ class NotificationManagerSpec: XCTestCase {
     func testMultipleNotifications() {
         var notification1 = notification
         notification1.title = "Notif1"
-        notification1.post()
+        NotificationManager.post(notification: notification1)
         XCTAssert(NotificationManager.shared.notification == notification1, "First notification should be stored")
 
         var notification2 = notification
         notification2.title = "Notif2"
-        notification2.post()
+        NotificationManager.post(notification: notification2)
         XCTAssert(NotificationManager.shared.notification == notification2, "Second notification should be stored")
 
         NotificationManager.shared.didRespondToNotification()
@@ -87,7 +87,7 @@ class NotificationManagerSpec: XCTestCase {
 
         var notification = self.notification
         notification.payload.rid = rid
-        notification.post()
+        NotificationManager.post(notification: notification)
 
         XCTAssertNil(NotificationManager.shared.notification, "The notification should not post, and should not be stored")
         XCTAssertTrue(NotificationViewController.shared.notificationViewIsHidden, "The notification should not be visible")
@@ -107,7 +107,7 @@ class NotificationManagerSpec: XCTestCase {
             AppManager.open(room: subscription)
         }
 
-        self.notification.post()
+        NotificationManager.post(notification: notification)
 
         XCTAssertNotNil(NotificationManager.shared.notification, "The notification should post, and should be stored")
         XCTAssertFalse(NotificationViewController.shared.notificationViewIsHidden, "The notification should be visible")

--- a/Rocket.ChatTests/Models/ChatNotificationSpec.swift
+++ b/Rocket.ChatTests/Models/ChatNotificationSpec.swift
@@ -102,7 +102,14 @@ class ChatNotificationSpec: XCTestCase {
                 internalType: "c"
             )
         )
+
+        let expectation = XCTestExpectation(description: "notification should be stored in the notification manager")
+
         notification.post()
-        XCTAssert(NotificationManager.shared.notification == notification, "notification should be stored in the notification manager")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2)
     }
 }


### PR DESCRIPTION
@RocketChat/ios

This PR fixed a crash caused due to some code being called on a background thread, which really should only be called on the main thread.

## Other symptoms include:
- In-app notifications not posting/visible.
- In-app notifications stay on screen, and cannot be dismissed.

Closes #1939 