### PR TITLE
[CHORE] Remove the object lookups on Realm updates & increase a lot the performance of the app

### DIFF
--- a/Rocket.Chat.ShareExtension/Info.plist
+++ b/Rocket.Chat.ShareExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>3.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>190</string>
+	<string>191</string>
 	<key>ITSEncryptionExportComplianceCode</key>
 	<string></string>
 	<key>NSExtension</key>

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -628,17 +628,19 @@ final class ChatViewController: SLKTextViewController {
         SubscriptionManager.subscribeTypingEvent(subscription) { [weak self] username, flag in
             guard let username = username, username != loggedUsername else { return }
 
-            let isAtBottom = self?.chatLogIsAtBottom()
+            DispatchQueue.main.async {
+                let isAtBottom = self?.chatLogIsAtBottom()
 
-            if flag {
-                self?.typingIndicatorView?.insertUsername(username)
-            } else {
-                self?.typingIndicatorView?.removeUsername(username)
-            }
+                if flag {
+                    self?.typingIndicatorView?.insertUsername(username)
+                } else {
+                    self?.typingIndicatorView?.removeUsername(username)
+                }
 
-            if let isAtBottom = isAtBottom,
-                isAtBottom == true {
-                self?.scrollToBottom(true)
+                if let isAtBottom = isAtBottom,
+                    isAtBottom == true {
+                    self?.scrollToBottom(true)
+                }
             }
         }
     }

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -624,8 +624,9 @@ final class ChatViewController: SLKTextViewController {
         typingIndicatorView?.interval = 0
         guard let user = AuthManager.currentUser() else { return Log.debug("Could not register TypingEvent") }
 
+        let loggedUsername = user.username
         SubscriptionManager.subscribeTypingEvent(subscription) { [weak self] username, flag in
-            guard let username = username, username != user.username else { return }
+            guard let username = username, username != loggedUsername else { return }
 
             let isAtBottom = self?.chatLogIsAtBottom()
 

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
@@ -53,15 +53,21 @@ final class SubscriptionsViewController: BaseViewController {
                 return
             }
 
-            tableView.beginUpdates()
-            tableView.deleteRows(at: changes.deletions, with: .automatic)
-            tableView.insertRows(at: changes.insertions, with: .automatic)
-            tableView.reloadRows(at: changes.modifications, with: .none)
-            tableView.endUpdates()
-
-            // We need to update the number of unread messages
-            // for the back button when chat screen is opened
             self?.updateBackButton()
+
+            if (changes.insertions.count + changes.deletions.count + changes.modifications.count) == 0 {
+                return
+            }
+
+            if self?.viewModel.numberOfSections ?? 2 > 1 {
+                tableView.reloadData()
+            } else {
+                tableView.beginUpdates()
+                tableView.deleteRows(at: changes.deletions, with: .automatic)
+                tableView.insertRows(at: changes.insertions, with: .automatic)
+                tableView.reloadRows(at: changes.modifications, with: .none)
+                tableView.endUpdates()
+            }
         }
 
         viewModel.didRebuildSections = { [weak self] in

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
@@ -53,22 +53,11 @@ final class SubscriptionsViewController: BaseViewController {
                 return
             }
 
-            let modifications = tableView.indexPathsForVisibleRows?.filter {
-                changes.modifications.contains($0) && self?.shouldUpdateCellAt(indexPath: $0) ?? false
-            } ?? []
-
-            if changes.deletions.count > 0 || changes.insertions.count > 0 {
-                tableView.beginUpdates()
-                tableView.deleteRows(at: changes.deletions, with: .automatic)
-                tableView.insertRows(at: changes.insertions, with: .automatic)
-                tableView.endUpdates()
-            }
-
-            if modifications.count > 0 {
-                UIView.performWithoutAnimation {
-                    tableView.reloadRows(at: modifications, with: .automatic)
-                }
-            }
+            tableView.beginUpdates()
+            tableView.deleteRows(at: changes.deletions, with: .automatic)
+            tableView.insertRows(at: changes.insertions, with: .automatic)
+            tableView.reloadRows(at: changes.modifications, with: .none)
+            tableView.endUpdates()
 
             // We need to update the number of unread messages
             // for the back button when chat screen is opened

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewModel.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewModel.swift
@@ -102,8 +102,6 @@ class SubscriptionsViewModel {
                 assorter.registerSection(name: title)
             }
         }
-
-        didRebuildSections?()
     }
 
     var didUpdateIndexPaths: IndexPathsChangesEvent?

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewModel.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewModel.swift
@@ -59,47 +59,46 @@ class SubscriptionsViewModel {
 
     func buildSections() {
         if let realm = realm {
-            assorter = RealmAssorter<Subscription>(realm: realm, results: subscriptions)
+            assorter = RealmAssorter<Subscription>(realm: realm)
             assorter?.didUpdateIndexPaths = didUpdateIndexPaths
         }
 
-        guard let assorter = assorter else {
+        guard
+            let queryBase = subscriptions,
+            let assorter = assorter
+        else {
             return
         }
 
         switch searchState {
         case .searching(let query):
-            assorter.registerSection(name: localized("subscriptions.search_results")) {
-                $0.filterBy(name: query)
-            }
+            let queryData = queryBase.filterBy(name: query)
+            assorter.registerSection(name: localized("subscriptions.search_results"), objects: queryData)
 
             API.current()?.client(SpotlightClient.self).search(query: query) { _ in }
         case .notSearching:
             if SubscriptionsSortingManager.selectedGroupingOptions.contains(.unread) {
-                assorter.registerSection(name: localized("subscriptions.unreads")) {
-                    $0.filter("alert == true")
-                }
+                let queryData = queryBase.filter("alert == true")
+                assorter.registerSection(name: localized("subscriptions.unreads"), objects: queryData)
             }
 
             if SubscriptionsSortingManager.selectedGroupingOptions.contains(.favorites) {
-                assorter.registerSection(name: localized("subscriptions.favorites")) {
-                    $0.filter("favorite == true")
-                }
+                let queryData = queryBase.filter("favorite == true")
+                assorter.registerSection(name: localized("subscriptions.favorites"), objects: queryData)
             }
 
             if SubscriptionsSortingManager.selectedGroupingOptions.contains(.type) {
-                assorter.registerSection(name: localized("subscriptions.channels")) {
-                    $0.filter("privateType == 'c'")
-                }
-                assorter.registerSection(name: localized("subscriptions.groups")) {
-                    $0.filter("privateType == 'p'")
-                }
-                assorter.registerSection(name: localized("subscriptions.direct_messages")) {
-                    $0.filter("privateType == 'd'")
-                }
+                let queryDataChannels = queryBase.filter("privateType == 'c'")
+                assorter.registerSection(name: localized("subscriptions.channels"), objects: queryDataChannels)
+
+                let queryDataGroups = queryBase.filter("privateType == 'p'")
+                assorter.registerSection(name: localized("subscriptions.groups"), objects: queryDataGroups)
+
+                let queryDataDirectMessages = queryBase.filter("privateType == 'd'")
+                assorter.registerSection(name: localized("subscriptions.direct_messages"), objects: queryDataDirectMessages)
             } else {
                 let title = assorter.numberOfSections > 0 ? localized("subscriptions.conversations") : ""
-                assorter.registerSection(name: title)
+                assorter.registerSection(name: title, objects: queryBase)
             }
         }
     }

--- a/Rocket.Chat/Info.plist
+++ b/Rocket.Chat/Info.plist
@@ -222,7 +222,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>190</string>
+	<string>191</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/Rocket.Chat/Managers/NotificationManager.swift
+++ b/Rocket.Chat/Managers/NotificationManager.swift
@@ -15,13 +15,33 @@ final class NotificationManager {
 
     /// Posts an in-app notification.
     ///
+    /// This method is thread safe, and therefore can be called from any thread.
+    ///
+    /// This method calls `NotificationManager.post(notification:)` on the main thread.
+    ///
+    /// - parameters:
+    ///     - notification: The `ChatNotification` object used to display the
+    ///         contents of the notification. The `title` and the `body` of the
+    ///         notification cannot be empty strings.
+
+    static func postOnMainThread(notification: ChatNotification) {
+        DispatchQueue.main.async {
+            post(notification: notification)
+        }
+    }
+
+    /// Posts an in-app notification.
+    ///
+    /// This method is **not** thread safe, and therefore must be called
+    /// on the main thread.
+    ///
     /// **NOTE:** The notification is only posted if the `rid` of the
     /// notification is different from the `AppManager.currentRoomId`
     ///
     /// - parameters:
-    ///     - notification: The `ChatNotification` object to display the
-    ///         contents of the notification from. The `title` and the `body`
-    ///         cannot be empty strings.
+    ///     - notification: The `ChatNotification` object used to display the
+    ///         contents of the notification. The `title` and the `body` of the
+    ///         notification cannot be empty strings.
 
     static func post(notification: ChatNotification) {
         guard

--- a/Rocket.Chat/Models/ChatNotification.swift
+++ b/Rocket.Chat/Models/ChatNotification.swift
@@ -64,6 +64,6 @@ extension ChatNotification {
     /// notification is different from the `AppManager.currentRoomId`
 
     func post() {
-        NotificationManager.post(notification: self)
+        NotificationManager.postOnMainThread(notification: self)
     }
 }

--- a/Rocket.Chat/Views/Avatar/AvatarView.swift
+++ b/Rocket.Chat/Views/Avatar/AvatarView.swift
@@ -19,9 +19,8 @@ final class AvatarView: UIView {
                 ImageManager.loadImage(with: imageURL, into: imageView) { [weak self] _, error in
                     guard error == nil else { return }
 
-                    self?.labelInitials.text = ""
+                    self?.labelInitials.text = nil
                     self?.backgroundColor = UIColor.clear
-                    self?.superview?.setNeedsLayout()
                 }
             }
         }

--- a/Rocket.Chat/Views/Cells/Subscription/SubscriptionCell.swift
+++ b/Rocket.Chat/Views/Cells/Subscription/SubscriptionCell.swift
@@ -143,7 +143,8 @@ final class SubscriptionCell: UITableViewCell {
     private func setDateColor() {
         guard
             let theme = theme,
-            let subscription = subscription
+            let subscription = subscription,
+            !subscription.isInvalidated
         else {
             return
         }
@@ -263,6 +264,7 @@ extension SubscriptionCell {
 extension SubscriptionCell {
     override func applyTheme() {
         super.applyTheme()
+
         guard let theme = theme else { return }
 
         labelName.textColor = theme.titleText

--- a/Rocket.ChatTests/Managers/NotificationManagerSpec.swift
+++ b/Rocket.ChatTests/Managers/NotificationManagerSpec.swift
@@ -50,12 +50,12 @@ class NotificationManagerSpec: XCTestCase {
     func testMultipleNotifications() {
         var notification1 = notification
         notification1.title = "Notif1"
-        notification1.post()
+        NotificationManager.post(notification: notification1)
         XCTAssert(NotificationManager.shared.notification == notification1, "First notification should be stored")
 
         var notification2 = notification
         notification2.title = "Notif2"
-        notification2.post()
+        NotificationManager.post(notification: notification2)
         XCTAssert(NotificationManager.shared.notification == notification2, "Second notification should be stored")
 
         NotificationManager.shared.didRespondToNotification()
@@ -87,7 +87,7 @@ class NotificationManagerSpec: XCTestCase {
 
         var notification = self.notification
         notification.payload.rid = rid
-        notification.post()
+        NotificationManager.post(notification: notification)
 
         XCTAssertNil(NotificationManager.shared.notification, "The notification should not post, and should not be stored")
         XCTAssertTrue(NotificationViewController.shared.notificationViewIsHidden, "The notification should not be visible")
@@ -107,7 +107,7 @@ class NotificationManagerSpec: XCTestCase {
             AppManager.open(room: subscription)
         }
 
-        self.notification.post()
+        NotificationManager.post(notification: notification)
 
         XCTAssertNotNil(NotificationManager.shared.notification, "The notification should post, and should be stored")
         XCTAssertFalse(NotificationViewController.shared.notificationViewIsHidden, "The notification should be visible")

--- a/Rocket.ChatTests/Models/ChatNotificationSpec.swift
+++ b/Rocket.ChatTests/Models/ChatNotificationSpec.swift
@@ -102,7 +102,14 @@ class ChatNotificationSpec: XCTestCase {
                 internalType: "c"
             )
         )
+
+        let expectation = XCTestExpectation(description: "notification should be stored in the notification manager")
+
         notification.post()
-        XCTAssert(NotificationManager.shared.notification == notification, "notification should be stored in the notification manager")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2)
     }
 }


### PR DESCRIPTION
@RocketChat/ios

Depends on #1937 

This PR removes the whole processing data on Realm, that's showing in the screenshots below. The processing of data with huge amount of data on low-end iPhones were causing freezes.

![screen shot 2018-07-11 at 10 23 41](https://user-images.githubusercontent.com/551004/42591335-ccd0a3ce-851c-11e8-8c95-c38f42d48cab.png)
![screen shot 2018-07-11 at 10 54 42](https://user-images.githubusercontent.com/551004/42591336-ccf30f68-851c-11e8-84f4-f38ccfa00e18.png)