### PR TITLE
[FEATURE] Add Home Screen Quick Actions

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0B3A9766202C738E0019CA92 /* ChangeAppIconViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A9765202C738E0019CA92 /* ChangeAppIconViewModel.swift */; };
 		0B3A9769202C76080019CA92 /* ChangeAppIconCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A9768202C76080019CA92 /* ChangeAppIconCell.swift */; };
 		0B7A210D204680D500D11085 /* ChangeLanguageResetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7A210C204680D500D11085 /* ChangeLanguageResetCell.swift */; };
+		0B92E65520F74CE8003DAB5A /* ShortcutsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B92E65420F74CE8003DAB5A /* ShortcutsManager.swift */; };
 		0B9AB2C120444ECD00ABEA05 /* LanguageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9AB2C020444ECD00ABEA05 /* LanguageViewController.swift */; };
 		0B9AB2C320444ED600ABEA05 /* LanguageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9AB2C220444ED600ABEA05 /* LanguageViewModel.swift */; };
 		0BB9678A2031A74B0051D68C /* DrawingBrushColorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB967892031A74B0051D68C /* DrawingBrushColorViewModel.swift */; };
@@ -798,6 +799,7 @@
 		0B3A9765202C738E0019CA92 /* ChangeAppIconViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeAppIconViewModel.swift; sourceTree = "<group>"; };
 		0B3A9768202C76080019CA92 /* ChangeAppIconCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeAppIconCell.swift; sourceTree = "<group>"; };
 		0B7A210C204680D500D11085 /* ChangeLanguageResetCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeLanguageResetCell.swift; sourceTree = "<group>"; };
+		0B92E65420F74CE8003DAB5A /* ShortcutsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsManager.swift; sourceTree = "<group>"; };
 		0B9AB2C020444ECD00ABEA05 /* LanguageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageViewController.swift; sourceTree = "<group>"; };
 		0B9AB2C220444ED600ABEA05 /* LanguageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageViewModel.swift; sourceTree = "<group>"; };
 		0BB967892031A74B0051D68C /* DrawingBrushColorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingBrushColorViewModel.swift; sourceTree = "<group>"; };
@@ -2197,6 +2199,7 @@
 				41B554C61FBF0F9D000510B7 /* WindowManager.swift */,
 				99B802EC20BC3BD400230109 /* ImageManager.swift */,
 				99D77C6A20E474BF008F2438 /* AnalyticsManager.swift */,
+				0B92E65420F74CE8003DAB5A /* ShortcutsManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -4281,6 +4284,7 @@
 				8052F75920B7522100B3B0CF /* UIAlertActionImage.swift in Sources */,
 				41C275DF1D848005003C88CF /* AvatarView.swift in Sources */,
 				41DE687D20C6D57F00AA5EC8 /* SubscriptionSortingCell.swift in Sources */,
+				0B92E65520F74CE8003DAB5A /* ShortcutsManager.swift in Sources */,
 				8013F8651FD5E13600EE1A4E /* APIExtensions.swift in Sources */,
 				4147CE7F1F5EB27B00C322C3 /* AddServerCell.swift in Sources */,
 				995F711620C790AB00B7535F /* AuthTableViewControllerAuthenticationHandler.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0B7A210D204680D500D11085 /* ChangeLanguageResetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7A210C204680D500D11085 /* ChangeLanguageResetCell.swift */; };
 		0B92E65520F74CE8003DAB5A /* ShortcutsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B92E65420F74CE8003DAB5A /* ShortcutsManager.swift */; };
 		0B92E65720F76393003DAB5A /* ShortcutsManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B92E65620F76393003DAB5A /* ShortcutsManagerSpec.swift */; };
+		0B92E66A20F767F8003DAB5A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0B92E66C20F767F8003DAB5A /* InfoPlist.strings */; };
 		0B9AB2C120444ECD00ABEA05 /* LanguageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9AB2C020444ECD00ABEA05 /* LanguageViewController.swift */; };
 		0B9AB2C320444ED600ABEA05 /* LanguageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9AB2C220444ED600ABEA05 /* LanguageViewModel.swift */; };
 		0BB9678A2031A74B0051D68C /* DrawingBrushColorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB967892031A74B0051D68C /* DrawingBrushColorViewModel.swift */; };
@@ -802,6 +803,16 @@
 		0B7A210C204680D500D11085 /* ChangeLanguageResetCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeLanguageResetCell.swift; sourceTree = "<group>"; };
 		0B92E65420F74CE8003DAB5A /* ShortcutsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsManager.swift; sourceTree = "<group>"; };
 		0B92E65620F76393003DAB5A /* ShortcutsManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsManagerSpec.swift; sourceTree = "<group>"; };
+		0B92E66B20F767F8003DAB5A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		0B92E66D20F767F9003DAB5A /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		0B92E66E20F767FA003DAB5A /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		0B92E66F20F767FA003DAB5A /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		0B92E67020F767FB003DAB5A /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		0B92E67120F767FB003DAB5A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		0B92E67220F767FC003DAB5A /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		0B92E67320F767FD003DAB5A /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		0B92E67420F767FD003DAB5A /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		0B92E67520F767FE003DAB5A /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		0B9AB2C020444ECD00ABEA05 /* LanguageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageViewController.swift; sourceTree = "<group>"; };
 		0B9AB2C220444ED600ABEA05 /* LanguageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageViewModel.swift; sourceTree = "<group>"; };
 		0BB967892031A74B0051D68C /* DrawingBrushColorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingBrushColorViewModel.swift; sourceTree = "<group>"; };
@@ -1595,6 +1606,7 @@
 				41DF76E91D2C50710028DBF8 /* Assets.xcassets */,
 				41EB22381E5F056600AA3AE7 /* Localizable.strings */,
 				80307E431FD75DC0006AD9EF /* VoiceOver.strings */,
+				0B92E66C20F767F8003DAB5A /* InfoPlist.strings */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -3816,6 +3828,7 @@
 				14F8A22C202E5CBF00175FDC /* Black-76@3x.png in Resources */,
 				14F8A297202E65C700175FDC /* Blue-40@2x.png in Resources */,
 				14F8A271202E653E00175FDC /* Grey-40@3x.png in Resources */,
+				0B92E66A20F767F8003DAB5A /* InfoPlist.strings in Resources */,
 				14F8A292202E65C700175FDC /* Blue-29@3x.png in Resources */,
 				14F8A294202E65C700175FDC /* Blue-60@3x.png in Resources */,
 				41DF76EA1D2C50710028DBF8 /* Assets.xcassets in Resources */,
@@ -4825,6 +4838,23 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		0B92E66C20F767F8003DAB5A /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0B92E66B20F767F8003DAB5A /* en */,
+				0B92E66D20F767F9003DAB5A /* pt-BR */,
+				0B92E66E20F767FA003DAB5A /* de */,
+				0B92E66F20F767FA003DAB5A /* pl */,
+				0B92E67020F767FB003DAB5A /* cs */,
+				0B92E67120F767FB003DAB5A /* fr */,
+				0B92E67220F767FC003DAB5A /* el */,
+				0B92E67320F767FD003DAB5A /* es */,
+				0B92E67420F767FD003DAB5A /* ru */,
+				0B92E67520F767FE003DAB5A /* pt-PT */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
 		41DF76EB1D2C50720028DBF8 /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0B3A9769202C76080019CA92 /* ChangeAppIconCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3A9768202C76080019CA92 /* ChangeAppIconCell.swift */; };
 		0B7A210D204680D500D11085 /* ChangeLanguageResetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7A210C204680D500D11085 /* ChangeLanguageResetCell.swift */; };
 		0B92E65520F74CE8003DAB5A /* ShortcutsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B92E65420F74CE8003DAB5A /* ShortcutsManager.swift */; };
+		0B92E65720F76393003DAB5A /* ShortcutsManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B92E65620F76393003DAB5A /* ShortcutsManagerSpec.swift */; };
 		0B9AB2C120444ECD00ABEA05 /* LanguageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9AB2C020444ECD00ABEA05 /* LanguageViewController.swift */; };
 		0B9AB2C320444ED600ABEA05 /* LanguageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9AB2C220444ED600ABEA05 /* LanguageViewModel.swift */; };
 		0BB9678A2031A74B0051D68C /* DrawingBrushColorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB967892031A74B0051D68C /* DrawingBrushColorViewModel.swift */; };
@@ -800,6 +801,7 @@
 		0B3A9768202C76080019CA92 /* ChangeAppIconCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeAppIconCell.swift; sourceTree = "<group>"; };
 		0B7A210C204680D500D11085 /* ChangeLanguageResetCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeLanguageResetCell.swift; sourceTree = "<group>"; };
 		0B92E65420F74CE8003DAB5A /* ShortcutsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsManager.swift; sourceTree = "<group>"; };
+		0B92E65620F76393003DAB5A /* ShortcutsManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsManagerSpec.swift; sourceTree = "<group>"; };
 		0B9AB2C020444ECD00ABEA05 /* LanguageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageViewController.swift; sourceTree = "<group>"; };
 		0B9AB2C220444ED600ABEA05 /* LanguageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageViewModel.swift; sourceTree = "<group>"; };
 		0BB967892031A74B0051D68C /* DrawingBrushColorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingBrushColorViewModel.swift; sourceTree = "<group>"; };
@@ -1970,6 +1972,7 @@
 				412435C920CACF1400A3602D /* SubscriptionSortingManagerSpec.swift */,
 				B5893BF51F6C4B1D00365768 /* UserReviewManagerSpec.swift */,
 				994DA2AF20653FB600083FB8 /* WebBrowserManagerSpec.swift */,
+				0B92E65620F76393003DAB5A /* ShortcutsManagerSpec.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -4579,6 +4582,7 @@
 				99F41BCE20658B1300B240FC /* EditProfileViewModelSpec.swift in Sources */,
 				8062E33320A3AA760044F407 /* SubscriptionsClientSpec.swift in Sources */,
 				417A70031D47918200FF46EE /* ResponseMessageSpec.swift in Sources */,
+				0B92E65720F76393003DAB5A /* ShortcutsManagerSpec.swift in Sources */,
 				D18675EE1F716FBC00406FB4 /* LoginRequestSpec.swift in Sources */,
 				41BA89241D303D8B00CBF526 /* AuthManagerSpec.swift in Sources */,
 				412435C820CAC89C00A3602D /* SubscriptionsSortingViewModelSpec.swift in Sources */,

--- a/Rocket.Chat/AppDelegate.swift
+++ b/Rocket.Chat/AppDelegate.swift
@@ -108,15 +108,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: Shortcuts
 
     func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
-        guard
-            let userInfo = shortcutItem.userInfo,
-            let serverIndex = userInfo[ShortcutsManager.serverIndex] as? Int
-        else {
-            completionHandler(false)
-            return
-        }
+        if let userInfo = shortcutItem.userInfo,
+            let serverIndex = userInfo[ShortcutsManager.serverIndex] as? Int {
+            ShortcutsManager.selectServer(at: serverIndex)
+            completionHandler(true)
+        } else if shortcutItem.type == ShortcutsManager.addServerActionIdentifier, AuthManager.isAuthenticated() != nil {
+            WindowManager.open(
+                .auth(
+                    serverUrl: "",
+                    credentials: nil
+                ), viewControllerIdentifier: ShortcutsManager.connectServerNavIdentifier
+            )
 
-        ShortcutsManager.selectServer(at: serverIndex)
-        completionHandler(true)
+            completionHandler(true)
+        } else {
+            completionHandler(false)
+        }
     }
 }

--- a/Rocket.Chat/AppDelegate.swift
+++ b/Rocket.Chat/AppDelegate.swift
@@ -64,10 +64,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 SocketManager.reconnect()
             }
         }
+
+        ShortcutsManager.sync()
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
         SubscriptionManager.updateUnreadApplicationBadge()
+        ShortcutsManager.sync()
 
         if AuthManager.isAuthenticated() != nil {
             UserManager.setUserPresence(status: .away) { (_) in
@@ -100,5 +103,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         Log.debug("Fail to register for notification: \(error)")
+    }
+
+    // MARK: Shortcuts
+
+    func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
+        guard
+            let userInfo = shortcutItem.userInfo,
+            let serverIndex = userInfo[ShortcutsManager.serverIndex] as? Int
+        else {
+            completionHandler(false)
+            return
+        }
+
+        ShortcutsManager.selectServer(at: serverIndex)
+        completionHandler(true)
     }
 }

--- a/Rocket.Chat/Info.plist
+++ b/Rocket.Chat/Info.plist
@@ -264,6 +264,17 @@
 			</dict>
 		</dict>
 	</dict>
+    <key>UIApplicationShortcutItems</key>
+    <array>
+        <dict>
+            <key>UIApplicationShortcutItemIconType</key>
+            <string>UIApplicationShortcutIconTypeAdd</string>
+            <key>UIApplicationShortcutItemTitle</key>
+            <string>add-server-shortcut</string>
+            <key>UIApplicationShortcutItemType</key>
+            <string>addserver</string>
+        </dict>
+    </array>
 	<key>NSCameraUsageDescription</key>
 	<string>To take photos and record videos</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/Rocket.Chat/Managers/ShortcutsManager.swift
+++ b/Rocket.Chat/Managers/ShortcutsManager.swift
@@ -1,0 +1,49 @@
+//
+//  ShortcutsManager.swift
+//  Rocket.Chat
+//
+//  Created by Artur Rymarz on 12.07.2018.
+//  Copyright © 2018 Rocket.Chat. All rights reserved.
+//
+
+import UIKit
+
+struct ShortcutServerItem {
+    let name: String
+    let url: String
+    let index: Int
+}
+
+struct ShortcutsManager {
+    static let serverIndex = "kServerIndex"
+
+    private static var shortcuts: [ShortcutServerItem]? {
+        let servers = DatabaseManager.servers?.enumerated().compactMap({ index, server in
+            ShortcutServerItem(name: server[ServerPersistKeys.serverName] ?? "", url: server[ServerPersistKeys.serverURL] ?? "", index: index)
+        })
+
+        return servers
+    }
+
+    static func sync() {
+        UIApplication.shared.shortcutItems = shortcuts?.compactMap({ shortcut in
+            let url = URL(string: shortcut.url)?.host ?? shortcut.url
+            return UIMutableApplicationShortcutItem(type: url, localizedTitle: shortcut.name, localizedSubtitle: url, icon: nil, userInfo: [serverIndex: shortcut.index])
+        })
+    }
+
+    static func selectServer(at index: Int) {
+        guard index != DatabaseManager.selectedIndex else {
+            return
+        }
+
+        DatabaseManager.selectDatabase(at: index)
+        DatabaseManager.changeDatabaseInstance(index: index)
+
+        SocketManager.disconnect { (_, _) in
+            WindowManager.open(.subscriptions)
+        }
+
+        AppManager.changeSelectedServer(index: index)
+    }
+}

--- a/Rocket.Chat/Managers/ShortcutsManager.swift
+++ b/Rocket.Chat/Managers/ShortcutsManager.swift
@@ -15,6 +15,8 @@ struct ShortcutServerItem {
 }
 
 struct ShortcutsManager {
+    static let addServerActionIdentifier = "addserver"
+    static let connectServerNavIdentifier = "ConnectServerNav"
     static let serverIndex = "kServerIndex"
 
     private static var shortcuts: [ShortcutServerItem]? {

--- a/Rocket.Chat/Resources/cs.lproj/InfoPlist.strings
+++ b/Rocket.Chat/Resources/cs.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* 
+  InfoPlist.strings
+  Rocket.Chat
+
+  Created by Artur Rymarz on 12.07.2018.
+  Copyright © 2018 Rocket.Chat. All rights reserved.
+*/
+
+add-server-shortcut = "Add Server"; // TODO:

--- a/Rocket.Chat/Resources/de.lproj/InfoPlist.strings
+++ b/Rocket.Chat/Resources/de.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* 
+  InfoPlist.strings
+  Rocket.Chat
+
+  Created by Artur Rymarz on 12.07.2018.
+  Copyright © 2018 Rocket.Chat. All rights reserved.
+*/
+
+add-server-shortcut = "Add Server"; // TODO:

--- a/Rocket.Chat/Resources/el.lproj/InfoPlist.strings
+++ b/Rocket.Chat/Resources/el.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* 
+  InfoPlist.strings
+  Rocket.Chat
+
+  Created by Artur Rymarz on 12.07.2018.
+  Copyright © 2018 Rocket.Chat. All rights reserved.
+*/
+
+add-server-shortcut = "Add Server"; // TODO:

--- a/Rocket.Chat/Resources/en.lproj/InfoPlist.strings
+++ b/Rocket.Chat/Resources/en.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* 
+  InfoPlist.strings
+  Rocket.Chat
+
+  Created by Artur Rymarz on 12.07.2018.
+  Copyright © 2018 Rocket.Chat. All rights reserved.
+*/
+
+add-server-shortcut = "Add Server";

--- a/Rocket.Chat/Resources/es.lproj/InfoPlist.strings
+++ b/Rocket.Chat/Resources/es.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* 
+  InfoPlist.strings
+  Rocket.Chat
+
+  Created by Artur Rymarz on 12.07.2018.
+  Copyright © 2018 Rocket.Chat. All rights reserved.
+*/
+
+add-server-shortcut = "Add Server"; // TODO:

--- a/Rocket.Chat/Resources/fr.lproj/InfoPlist.strings
+++ b/Rocket.Chat/Resources/fr.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* 
+  InfoPlist.strings
+  Rocket.Chat
+
+  Created by Artur Rymarz on 12.07.2018.
+  Copyright © 2018 Rocket.Chat. All rights reserved.
+*/
+
+add-server-shortcut = "Add Server"; // TODO:

--- a/Rocket.Chat/Resources/pl.lproj/InfoPlist.strings
+++ b/Rocket.Chat/Resources/pl.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* 
+  InfoPlist.strings
+  Rocket.Chat
+
+  Created by Artur Rymarz on 12.07.2018.
+  Copyright © 2018 Rocket.Chat. All rights reserved.
+*/
+
+add-server-shortcut = "Dodaj Serwer";

--- a/Rocket.Chat/Resources/pt-BR.lproj/InfoPlist.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* 
+  InfoPlist.strings
+  Rocket.Chat
+
+  Created by Artur Rymarz on 12.07.2018.
+  Copyright © 2018 Rocket.Chat. All rights reserved.
+*/
+
+add-server-shortcut = "Add Server"; // TODO:

--- a/Rocket.Chat/Resources/pt-PT.lproj/InfoPlist.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* 
+  InfoPlist.strings
+  Rocket.Chat
+
+  Created by Artur Rymarz on 12.07.2018.
+  Copyright © 2018 Rocket.Chat. All rights reserved.
+*/
+
+add-server-shortcut = "Add Server"; // TODO:

--- a/Rocket.Chat/Resources/ru.lproj/InfoPlist.strings
+++ b/Rocket.Chat/Resources/ru.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* 
+  InfoPlist.strings
+  Rocket.Chat
+
+  Created by Artur Rymarz on 12.07.2018.
+  Copyright © 2018 Rocket.Chat. All rights reserved.
+*/
+
+add-server-shortcut = "Add Server"; // TODO:

--- a/Rocket.ChatTests/Managers/ShortcutsManagerSpec.swift
+++ b/Rocket.ChatTests/Managers/ShortcutsManagerSpec.swift
@@ -1,0 +1,27 @@
+//
+//  ShortcutsManagerSpec.swift
+//  Rocket.ChatTests
+//
+//  Created by Artur Rymarz on 12.07.2018.
+//  Copyright © 2018 Rocket.Chat. All rights reserved.
+//
+
+import XCTest
+@testable import Rocket_Chat
+
+class ShortcutsManagerSpec: XCTestCase {
+
+    func testNoShortcutsAvailable() {
+        DatabaseManager.clearAllServers()
+        ShortcutsManager.sync()
+
+        XCTAssertEqual(UIApplication.shared.shortcutItems?.count, 0, "no shortcuts in the list")
+    }
+
+    func testShortcutsAvailable() {
+        DatabaseManager.setupTestServers()
+        ShortcutsManager.sync()
+
+        XCTAssertEqual(UIApplication.shared.shortcutItems?.count, 2, "2 shortcuts in the list")
+    }
+}


### PR DESCRIPTION
@RocketChat/ios

Closes #833

Added servers so far. Can add more types of shortcuts later on.

Do we want anything else except servers? Maybe channels and DMs? But since we are kinda limited with the number of shortcuts, we would need a good algorithm to determine which to shows - rather not the latest since it might be a little bit confusing (often) showing different shortcuts each time.

- [x] Dynamic items (servers)
- [x] Static Action - Add Server