### PR TITLE
[CRASH] Check indexPath of the cell before selecting it

### DIFF
--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
@@ -415,7 +415,12 @@ extension SubscriptionsViewController: UITableViewDataSource {
         guard let selectedSubscription = MainSplitViewController.chatViewController?.subscription else { return }
 
         if subscription.identifier == selectedSubscription.identifier {
-            tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
+            let numberOfSections = tableView.numberOfSections
+            let numberOfRows = tableView.numberOfRows(inSection: indexPath.section)
+
+            if numberOfSections > indexPath.section && numberOfRows > indexPath.row {
+                tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
+            }
         }
     }
 


### PR DESCRIPTION
@RocketChat/ios

I know this crash is very weird, because the cell will be displayed, but here's the stack trace:


```
Fatal Exception: NSRangeException
*** -[__NSArrayM objectAtIndex:]: index 13 beyond bounds [0 .. 12]
```

```
Fatal Exception: NSRangeException
0  CoreFoundation                 0x18270ed8c __exceptionPreprocess
1  libobjc.A.dylib                0x1818c85ec objc_exception_throw
2  CoreFoundation                 0x1826a7750 _CFArgv
3  CoreFoundation                 0x1825d7810 -[__NSArrayM removeObjectAtIndex:]
4  UIKit                          0x18c592f18 -[UITableView _existingCellForRowAtIndexPath:]
5  UIKit                          0x18c5d1a7c -[UITableView _deselectRowAtIndexPath:animated:notifyDelegate:]
6  UIKit                          0x18c36e910 -[UITableView _deselectAllNonMultiSelectRowsAnimated:notifyDelegate:]
7  UIKit                          0x18c5e7d2c -[UITableView _selectRowAtIndexPath:animated:scrollPosition:notifyDelegate:]
8  Rocket.Chat                    0x10063af78 specialized SubscriptionsViewController.tableView(UITableView, willDisplay : UITableViewCell, forRowAt : IndexPath) -> () (SubscriptionsViewController.swift:418)
9  Rocket.Chat                    0x100638eb8 @objc SubscriptionsViewController.tableView(UITableView, willDisplay : UITableViewCell, forRowAt : IndexPath) -> () (SubscriptionsViewController.swift)
10 UIKit                          0x18c3ac2a0 -[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]
11 UIKit                          0x18c3abe00 -[UITableView _createPreparedCellForGlobalRow:willDisplay:]
12 UIKit                          0x18c3aaa68 -[UITableView _updateVisibleCellsNow:isRecursive:]
13 UIKit                          0x18c3a6668 -[UITableView layoutSubviews]
14 UIKit                          0x18c2e3770 -[UIView(CALayerDelegate) layoutSublayersOfLayer:]
15 QuartzCore                     0x18688525c -[CALayer layoutSublayers]
16 QuartzCore                     0x1868893ec CA::Layer::layout_if_needed(CA::Transaction*)
17 QuartzCore                     0x1867f5aa0 CA::Context::commit_transaction(CA::Transaction*)
18 QuartzCore                     0x18681d5d0 CA::Transaction::commit()
19 QuartzCore                     0x18676e1a8 CA::Display::DisplayLink::dispatch_items(unsigned long long, unsigned long long, unsigned long long)
20 IOKit                          0x1829778a0 IODispatchCalloutFromCFMessage
21 CoreFoundation                 0x18269cb20 __CFMachPortPerform
22 CoreFoundation                 0x1826b7ae8 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__
23 CoreFoundation                 0x1826b7230 __CFRunLoopDoSource1
24 CoreFoundation                 0x1826b4c80 __CFRunLoopRun
25 CoreFoundation                 0x1825d4da8 CFRunLoopRunSpecific
26 GraphicsServices               0x1845b7020 GSEventRunModal
27 UIKit                          0x18c5b578c UIApplicationMain
28 Rocket.Chat                    0x1004264f4 main (LoginServiceTableViewCell.swift:14)
29 libdyld.dylib                  0x182065fc0 start
```