### PR TITLE
[CRASH] Fatal Exception: NSInternalInconsistencyException Only run on the main thread!

### DIFF
--- a/Rocket.Chat/Views/Avatar/AvatarView.swift
+++ b/Rocket.Chat/Views/Avatar/AvatarView.swift
@@ -175,11 +175,9 @@ final class AvatarView: UIView {
         subscription = nil
         emoji = nil
 
-        DispatchQueue.main.async {
-            self.imageView.image = nil
-            self.imageView.animatedImage = nil
-            self.labelInitials.text = ""
-        }
+        imageView.image = nil
+        imageView.animatedImage = nil
+        labelInitials.text = ""
     }
 
 }

--- a/Rocket.Chat/Views/Avatar/AvatarView.swift
+++ b/Rocket.Chat/Views/Avatar/AvatarView.swift
@@ -175,10 +175,11 @@ final class AvatarView: UIView {
         subscription = nil
         emoji = nil
 
-        imageView.image = nil
-        imageView.animatedImage = nil
-
-        labelInitials.text = ""
+        DispatchQuee.main.async {
+            self.imageView.image = nil
+            self.imageView.animatedImage = nil
+            self.labelInitials.text = ""
+        }
     }
 
 }

--- a/Rocket.Chat/Views/Avatar/AvatarView.swift
+++ b/Rocket.Chat/Views/Avatar/AvatarView.swift
@@ -175,7 +175,7 @@ final class AvatarView: UIView {
         subscription = nil
         emoji = nil
 
-        DispatchQuee.main.async {
+        DispatchQueue.main.async {
             self.imageView.image = nil
             self.imageView.animatedImage = nil
             self.labelInitials.text = ""

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -147,11 +147,10 @@ final class ChatMessageCell: UICollectionViewCell {
     }
 
     override func prepareForReuse() {
-        DispatchQueue.main.async {
-            self.labelUsername.text = ""
-            self.labelText.message = nil
-            self.labelDate.text = ""
-        }
+        super.prepareForReuse()
+        labelUsername.text = ""
+        labelText.message = nil
+        labelDate.text = ""
 
         sequential = false
         message = nil

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -147,9 +147,12 @@ final class ChatMessageCell: UICollectionViewCell {
     }
 
     override func prepareForReuse() {
-        labelUsername.text = ""
-        labelText.message = nil
-        labelDate.text = ""
+        DispatchQueue.main.async {
+            self.labelUsername.text = ""
+            self.labelText.message = nil
+            self.labelDate.text = ""
+        }
+
         sequential = false
         message = nil
 


### PR DESCRIPTION
@RocketChat/ios

This crash happened only twice times and for a single jaibroken device. In one of the cases it has only 4% of RAM available and in another it was running the app in background when it happened.

After testing it and figuring it out that the device conditions may be the cause of this crash I decided to just add the missing `super.prepareForReuse` call and revert any other change that I made to possibly fix this crash.

We'll monitor it and if it wind up happenning with other devices and users we will investigate. 

Closes #1989
