### PR TITLE
[BUG] Replace deprecated method and fix interaction with deep press

### DIFF
--- a/Rocket.Chat/Views/Chat/RCTextView.swift
+++ b/Rocket.Chat/Views/Chat/RCTextView.swift
@@ -150,7 +150,11 @@ class HighlightLayoutManager: NSLayoutManager {
 
 extension RCTextView: UITextViewDelegate {
 
-    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange) -> Bool {
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        if interaction != .invokeDefaultAction {
+            return false
+        }
+
         if URL.scheme == "http" || URL.scheme == "https" {
             delegate?.openURL(url: URL)
             return false


### PR DESCRIPTION
@RocketChat/ios

There is currently an issue while using a deep press (3d touch) on links that may cause them to open twice. This PR fixes it as well as replaces deprecated method od `UITextViewDelegate`.

![interaciton-issue](https://user-images.githubusercontent.com/3925166/42876087-e4530ece-8a85-11e8-8435-c08fa5188776.gif)

