### PR TITLE
[CHORE] Use the right content type to each keyboard on signup & login flow and remove whitespaces from the URL field

### DIFF
--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -23,10 +23,20 @@ final class ConnectServerViewController: BaseViewController {
     var shouldAutoConnect = false
     var url: URL? {
         guard var urlText = textFieldServerURL.text else { return URL(string: defaultURL, scheme: "https") }
+
         if urlText.isEmpty {
             urlText = defaultURL
         }
-        return  URL(string: urlText, scheme: "https")
+
+        // Remove all the whitespaces from the string
+        urlText = urlText.removingWhitespaces()
+
+        // Add .rocket.chat in the end if it's only one string
+        if !urlText.contains(".") {
+            urlText += ".rocket.chat"
+        }
+
+        return URL(string: urlText, scheme: "https")
     }
 
     var serverPublicSettings: AuthSettings?

--- a/Rocket.Chat/Storyboards/Auth.storyboard
+++ b/Rocket.Chat/Storyboards/Auth.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kCN-DM-NIV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kCN-DM-NIV">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -263,7 +263,7 @@
                                                     </constraints>
                                                     <color key="textColor" red="0.61960784310000006" green="0.63529411759999999" blue="0.6588235294" alpha="1" colorSpace="calibratedRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <textInputTraits key="textInputTraits"/>
+                                                    <textInputTraits key="textInputTraits" autocapitalizationType="words" textContentType="name"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="image" keyPath="leftIcon" value="userBlack"/>
                                                     </userDefinedRuntimeAttributes>
@@ -296,7 +296,7 @@
                                                     </constraints>
                                                     <color key="textColor" red="0.61960784310000006" green="0.63529411759999999" blue="0.6588235294" alpha="1" colorSpace="calibratedRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <textInputTraits key="textInputTraits"/>
+                                                    <textInputTraits key="textInputTraits" textContentType="username"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="image" keyPath="leftIcon" value="usernameBlack"/>
                                                     </userDefinedRuntimeAttributes>
@@ -329,7 +329,7 @@
                                                     </constraints>
                                                     <color key="textColor" red="0.61960784310000006" green="0.63529411759999999" blue="0.6588235294" alpha="1" colorSpace="calibratedRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <textInputTraits key="textInputTraits" keyboardType="emailAddress"/>
+                                                    <textInputTraits key="textInputTraits" keyboardType="emailAddress" textContentType="email"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="image" keyPath="leftIcon" value="mailBlack"/>
                                                     </userDefinedRuntimeAttributes>
@@ -362,7 +362,7 @@
                                                     </constraints>
                                                     <color key="textColor" red="0.61960784310000006" green="0.63529411759999999" blue="0.6588235294" alpha="1" colorSpace="calibratedRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
+                                                    <textInputTraits key="textInputTraits" secureTextEntry="YES" textContentType="password"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="image" keyPath="leftIcon" value="keyBlack"/>
                                                     </userDefinedRuntimeAttributes>
@@ -505,7 +505,7 @@
                                                     </constraints>
                                                     <color key="textColor" red="0.61960784313725492" green="0.63529411764705879" blue="0.6588235294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <textInputTraits key="textInputTraits" keyboardType="emailAddress"/>
+                                                    <textInputTraits key="textInputTraits" keyboardType="emailAddress" textContentType="username"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="image" keyPath="leftIcon" value="usernameBlack"/>
                                                     </userDefinedRuntimeAttributes>
@@ -551,7 +551,7 @@
                                                     </constraints>
                                                     <color key="textColor" red="0.61960784310000006" green="0.63529411759999999" blue="0.6588235294" alpha="1" colorSpace="calibratedRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
+                                                    <textInputTraits key="textInputTraits" secureTextEntry="YES" textContentType="password"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="image" keyPath="leftIcon" value="keyBlack"/>
                                                     </userDefinedRuntimeAttributes>
@@ -1174,7 +1174,7 @@ to mention you in messages</string>
                                                     </constraints>
                                                     <color key="textColor" red="0.61960784310000006" green="0.63529411759999999" blue="0.6588235294" alpha="1" colorSpace="calibratedRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <textInputTraits key="textInputTraits"/>
+                                                    <textInputTraits key="textInputTraits" textContentType="username"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="image" keyPath="leftIcon" value="usernameBlack"/>
                                                     </userDefinedRuntimeAttributes>


### PR DESCRIPTION
@RocketChat/ios

Closes #2019 
Closes #2020 

This PR introduces this changes:

- Added specific content type to each text field on the auth flow;
- Removes all whitespaces from the URL;
- Add `.rocket.chat` in the end of the URL if no `.` is present;