### PR TITLE
[IMPROVEMENT] Improve theming popovers

### DIFF
--- a/Rocket.Chat/Controllers/Base/BaseTableViewController.swift
+++ b/Rocket.Chat/Controllers/Base/BaseTableViewController.swift
@@ -22,6 +22,11 @@ class BaseTableViewController: UITableViewController {
         )
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        ThemeManager.addObserver(self)
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 

--- a/Rocket.Chat/Controllers/Base/BaseTableViewController.swift
+++ b/Rocket.Chat/Controllers/Base/BaseTableViewController.swift
@@ -22,11 +22,6 @@ class BaseTableViewController: UITableViewController {
         )
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        ThemeManager.addObserver(self)
-    }
-
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 

--- a/Rocket.Chat/Controllers/Base/BaseViewController.swift
+++ b/Rocket.Chat/Controllers/Base/BaseViewController.swift
@@ -53,6 +53,7 @@ class BaseViewController: UIViewController, PopPushDelegate, NavigationBarTransp
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        ThemeManager.addObserver(self)
 
         navigationItem.backBarButtonItem = UIBarButtonItem(
             title: "",
@@ -74,12 +75,6 @@ class BaseViewController: UIViewController, PopPushDelegate, NavigationBarTransp
 
         let screenName = String(describing: type(of: self))
         AnalyticsManager.log(event: .screenView(screenName: screenName))
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        ThemeManager.addObserver(self)
-//        view.applyTheme()
     }
 
     override func applyTheme() {

--- a/Rocket.Chat/Controllers/Base/BaseViewController.swift
+++ b/Rocket.Chat/Controllers/Base/BaseViewController.swift
@@ -53,7 +53,6 @@ class BaseViewController: UIViewController, PopPushDelegate, NavigationBarTransp
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        ThemeManager.addObserver(self)
 
         navigationItem.backBarButtonItem = UIBarButtonItem(
             title: "",
@@ -61,6 +60,8 @@ class BaseViewController: UIViewController, PopPushDelegate, NavigationBarTransp
             target: nil,
             action: nil
         )
+
+        popoverPresentationController?.backgroundColor = view.theme?.focusedBackground
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -73,6 +74,12 @@ class BaseViewController: UIViewController, PopPushDelegate, NavigationBarTransp
 
         let screenName = String(describing: type(of: self))
         AnalyticsManager.log(event: .screenView(screenName: screenName))
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        ThemeManager.addObserver(self)
+//        view.applyTheme()
     }
 
     override func applyTheme() {

--- a/Rocket.Chat/Controllers/User/UserDetail/UserDetailViewController.swift
+++ b/Rocket.Chat/Controllers/User/UserDetail/UserDetailViewController.swift
@@ -75,10 +75,10 @@ class UserDetailViewController: BaseViewController, StoryboardInitializable {
         super.viewDidLoad()
     }
 
-//    override func viewDidLayoutSubviews() {
-//        super.viewDidLayoutSubviews()
-//        view.applyTheme()
-//    }
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        view.applyTheme()
+    }
 
     @IBAction func messageDidPress(_ sender: UIButton) {
         AppManager.openDirectMessage(username: model.username)

--- a/Rocket.Chat/Controllers/User/UserDetail/UserDetailViewController.swift
+++ b/Rocket.Chat/Controllers/User/UserDetail/UserDetailViewController.swift
@@ -71,9 +71,14 @@ class UserDetailViewController: BaseViewController, StoryboardInitializable {
     }
 
     override func viewDidLoad() {
-        super.viewDidLoad()
         updateForModel()
+        super.viewDidLoad()
     }
+
+//    override func viewDidLayoutSubviews() {
+//        super.viewDidLayoutSubviews()
+//        view.applyTheme()
+//    }
 
     @IBAction func messageDidPress(_ sender: UIButton) {
         AppManager.openDirectMessage(username: model.username)

--- a/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.swift
@@ -196,7 +196,6 @@ final class EmojiPicker: UIView, RCEmojiKitLocalizable {
         super.didMoveToSuperview()
         setupCategoriesView()
         setupCollectionView()
-//        applyTheme()
     }
 
     override func layoutSubviews() {
@@ -352,28 +351,6 @@ private class EmojiPickerSectionHeaderView: UICollectionReusableView {
 // MARK: Themeable
 
 extension EmojiPicker {
-//    override var theme: Theme? {
-//        guard let theme = super.theme else { return nil }
-//        guard isPopover else { return theme }
-//        let popoverTheme = Theme(
-//            backgroundColor: theme.focusedBackground,
-//            focusedBackground: theme.focusedBackground,
-//            auxiliaryBackground: theme.auxiliaryBackground,
-//            bannerBackground: theme.bannerBackground,
-//            titleText: theme.titleText,
-//            bodyText: theme.bodyText,
-//            controlText: theme.controlText,
-//            auxiliaryText: theme.auxiliaryText,
-//            tintColor: theme.tintColor,
-//            auxiliaryTintColor: theme.auxiliaryTintColor,
-//            hyperlink: theme.hyperlink,
-//            mutedAccent: theme.mutedAccent,
-//            strongAccent: theme.strongAccent,
-//            appearence: theme.appearence
-//        )
-//        return popoverTheme
-//    }
-
     override func applyTheme() {
         super.applyTheme()
         skinToneButton.backgroundColor = currentSkinTone.color

--- a/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.swift
@@ -196,6 +196,12 @@ final class EmojiPicker: UIView, RCEmojiKitLocalizable {
         super.didMoveToSuperview()
         setupCategoriesView()
         setupCollectionView()
+//        applyTheme()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        applyTheme()
     }
 }
 
@@ -346,27 +352,27 @@ private class EmojiPickerSectionHeaderView: UICollectionReusableView {
 // MARK: Themeable
 
 extension EmojiPicker {
-    override var theme: Theme? {
-        guard let theme = super.theme else { return nil }
-        guard isPopover else { return theme }
-        let popoverTheme = Theme(
-            backgroundColor: theme.focusedBackground,
-            focusedBackground: theme.focusedBackground,
-            auxiliaryBackground: theme.auxiliaryBackground,
-            bannerBackground: theme.bannerBackground,
-            titleText: theme.titleText,
-            bodyText: theme.bodyText,
-            controlText: theme.controlText,
-            auxiliaryText: theme.auxiliaryText,
-            tintColor: theme.tintColor,
-            auxiliaryTintColor: theme.auxiliaryTintColor,
-            hyperlink: theme.hyperlink,
-            mutedAccent: theme.mutedAccent,
-            strongAccent: theme.strongAccent,
-            appearence: theme.appearence
-        )
-        return popoverTheme
-    }
+//    override var theme: Theme? {
+//        guard let theme = super.theme else { return nil }
+//        guard isPopover else { return theme }
+//        let popoverTheme = Theme(
+//            backgroundColor: theme.focusedBackground,
+//            focusedBackground: theme.focusedBackground,
+//            auxiliaryBackground: theme.auxiliaryBackground,
+//            bannerBackground: theme.bannerBackground,
+//            titleText: theme.titleText,
+//            bodyText: theme.bodyText,
+//            controlText: theme.controlText,
+//            auxiliaryText: theme.auxiliaryText,
+//            tintColor: theme.tintColor,
+//            auxiliaryTintColor: theme.auxiliaryTintColor,
+//            hyperlink: theme.hyperlink,
+//            mutedAccent: theme.mutedAccent,
+//            strongAccent: theme.strongAccent,
+//            appearence: theme.appearence
+//        )
+//        return popoverTheme
+//    }
 
     override func applyTheme() {
         super.applyTheme()

--- a/Rocket.Chat/External/RCEmojiKit/Views/Reaction/ReactorListView.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/Reaction/ReactorListView.swift
@@ -161,27 +161,3 @@ extension ReactorListView: UITableViewDelegate {
         selectedReactor(model.reactionViewModels[indexPath.section].reactors[indexPath.row], rect)
     }
 }
-
-extension ReactorListView {
-//    override var theme: Theme? {
-//        guard let theme = super.theme else { return nil }
-//        guard isPopover else { return theme }
-//        let popoverTheme = Theme(
-//            backgroundColor: theme.focusedBackground,
-//            focusedBackground: theme.focusedBackground,
-//            auxiliaryBackground: theme.auxiliaryBackground,
-//            bannerBackground: theme.backgroundColor,
-//            titleText: theme.titleText,
-//            bodyText: theme.bodyText,
-//            controlText: theme.controlText,
-//            auxiliaryText: theme.auxiliaryText,
-//            tintColor: theme.tintColor,
-//            auxiliaryTintColor: theme.auxiliaryTintColor,
-//            hyperlink: theme.hyperlink,
-//            mutedAccent: theme.mutedAccent,
-//            strongAccent: theme.strongAccent,
-//            appearence: theme.appearence
-//        )
-//        return popoverTheme
-//    }
-}

--- a/Rocket.Chat/External/RCEmojiKit/Views/Reaction/ReactorListView.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/Reaction/ReactorListView.swift
@@ -82,6 +82,11 @@ final class ReactorListView: UIView {
         super.init(coder: aDecoder)
         commonInit()
     }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        applyTheme()
+    }
 }
 
 // MARK: Initialization
@@ -140,8 +145,8 @@ extension ReactorListView: UITableViewDelegate {
 
         view.addSubview(stackView)
 
+        view.setThemeColor("backgroundColor: bannerBackground")
         view.applyTheme()
-        view.backgroundColor = view.theme?.auxiliaryBackground
 
         return view
     }
@@ -158,25 +163,25 @@ extension ReactorListView: UITableViewDelegate {
 }
 
 extension ReactorListView {
-    override var theme: Theme? {
-        guard let theme = super.theme else { return nil }
-        guard isPopover else { return theme }
-        let popoverTheme = Theme(
-            backgroundColor: theme.focusedBackground,
-            focusedBackground: theme.focusedBackground,
-            auxiliaryBackground: theme.auxiliaryBackground,
-            bannerBackground: theme.backgroundColor,
-            titleText: theme.titleText,
-            bodyText: theme.bodyText,
-            controlText: theme.controlText,
-            auxiliaryText: theme.auxiliaryText,
-            tintColor: theme.tintColor,
-            auxiliaryTintColor: theme.auxiliaryTintColor,
-            hyperlink: theme.hyperlink,
-            mutedAccent: theme.mutedAccent,
-            strongAccent: theme.strongAccent,
-            appearence: theme.appearence
-        )
-        return popoverTheme
-    }
+//    override var theme: Theme? {
+//        guard let theme = super.theme else { return nil }
+//        guard isPopover else { return theme }
+//        let popoverTheme = Theme(
+//            backgroundColor: theme.focusedBackground,
+//            focusedBackground: theme.focusedBackground,
+//            auxiliaryBackground: theme.auxiliaryBackground,
+//            bannerBackground: theme.backgroundColor,
+//            titleText: theme.titleText,
+//            bodyText: theme.bodyText,
+//            controlText: theme.controlText,
+//            auxiliaryText: theme.auxiliaryText,
+//            tintColor: theme.tintColor,
+//            auxiliaryTintColor: theme.auxiliaryTintColor,
+//            hyperlink: theme.hyperlink,
+//            mutedAccent: theme.mutedAccent,
+//            strongAccent: theme.strongAccent,
+//            appearence: theme.appearence
+//        )
+//        return popoverTheme
+//    }
 }

--- a/Rocket.Chat/Theme/ThemeableViews.swift
+++ b/Rocket.Chat/Theme/ThemeableViews.swift
@@ -53,6 +53,25 @@ extension UIView: ThemeProvider {
     var theme: Theme? {
         guard type(of: self).description() != "_UIAlertControllerView" else { return nil }
         guard let superview = superview else { return ThemeManager.theme }
+        if type(of: self).description() == "_UIPopoverView" {
+            guard let theme = superview.theme else { return nil }
+            return Theme(
+                backgroundColor: theme.focusedBackground,
+                focusedBackground: theme.focusedBackground,
+                auxiliaryBackground: theme.auxiliaryBackground,
+                bannerBackground: theme.bannerBackground,
+                titleText: theme.titleText,
+                bodyText: theme.bodyText,
+                controlText: theme.controlText,
+                auxiliaryText: theme.auxiliaryText,
+                tintColor: theme.tintColor,
+                auxiliaryTintColor: theme.auxiliaryTintColor,
+                hyperlink: theme.hyperlink,
+                mutedAccent: theme.mutedAccent,
+                strongAccent: theme.strongAccent,
+                appearence: theme.appearence
+            )
+        }
         return superview.theme
     }
 }

--- a/Rocket.Chat/Theme/ThemeableViews.swift
+++ b/Rocket.Chat/Theme/ThemeableViews.swift
@@ -53,26 +53,28 @@ extension UIView: ThemeProvider {
     var theme: Theme? {
         guard type(of: self).description() != "_UIAlertControllerView" else { return nil }
         guard let superview = superview else { return ThemeManager.theme }
-        if type(of: self).description() == "_UIPopoverView" {
-            guard let theme = superview.theme else { return nil }
-            return Theme(
-                backgroundColor: theme.focusedBackground,
-                focusedBackground: theme.focusedBackground,
-                auxiliaryBackground: theme.auxiliaryBackground,
-                bannerBackground: theme.bannerBackground,
-                titleText: theme.titleText,
-                bodyText: theme.bodyText,
-                controlText: theme.controlText,
-                auxiliaryText: theme.auxiliaryText,
-                tintColor: theme.tintColor,
-                auxiliaryTintColor: theme.auxiliaryTintColor,
-                hyperlink: theme.hyperlink,
-                mutedAccent: theme.mutedAccent,
-                strongAccent: theme.strongAccent,
-                appearence: theme.appearence
-            )
-        }
+        if type(of: self).description() == "_UIPopoverView" { return themeForPopover }
         return superview.theme
+    }
+
+    private var themeForPopover: Theme? {
+        guard let theme = superview?.theme else { return nil }
+        return Theme(
+            backgroundColor: theme.focusedBackground,
+            focusedBackground: theme.focusedBackground,
+            auxiliaryBackground: theme.auxiliaryBackground,
+            bannerBackground: theme.bannerBackground,
+            titleText: theme.titleText,
+            bodyText: theme.bodyText,
+            controlText: theme.controlText,
+            auxiliaryText: theme.auxiliaryText,
+            tintColor: theme.tintColor,
+            auxiliaryTintColor: theme.auxiliaryTintColor,
+            hyperlink: theme.hyperlink,
+            mutedAccent: theme.mutedAccent,
+            strongAccent: theme.strongAccent,
+            appearence: theme.appearence
+        )
     }
 }
 

--- a/Rocket.Chat/Views/Subscriptions/ServersListView.swift
+++ b/Rocket.Chat/Views/Subscriptions/ServersListView.swift
@@ -209,7 +209,7 @@ extension ServersListView {
     override var theme: Theme? {
         guard let theme = super.theme else { return nil }
         return Theme(
-            backgroundColor: theme == .light ? theme.backgroundColor : theme.focusedBackground,
+            backgroundColor: theme.appearence == .light ? theme.backgroundColor : theme.focusedBackground,
             focusedBackground: theme.focusedBackground,
             auxiliaryBackground: theme.auxiliaryBackground,
             bannerBackground: theme.bannerBackground,

--- a/Rocket.Chat/Views/Subscriptions/SubscriptionsSortingHeaderView.swift
+++ b/Rocket.Chat/Views/Subscriptions/SubscriptionsSortingHeaderView.swift
@@ -12,7 +12,7 @@ class SubscriptionsSortingHeaderView: UIView {
     override var theme: Theme? {
         guard let theme = super.theme else { return nil }
         return Theme(
-            backgroundColor: theme == .light ? theme.backgroundColor : theme.focusedBackground,
+            backgroundColor: theme.appearence == .light ? theme.backgroundColor : theme.focusedBackground,
             focusedBackground: theme.focusedBackground,
             auxiliaryBackground: theme.auxiliaryBackground,
             bannerBackground: theme.bannerBackground,

--- a/Rocket.Chat/Views/Subscriptions/SubscriptionsSortingView.swift
+++ b/Rocket.Chat/Views/Subscriptions/SubscriptionsSortingView.swift
@@ -198,7 +198,7 @@ extension SubscriptionsSortingView {
     override var theme: Theme? {
         guard let theme = super.theme else { return nil }
         return Theme(
-            backgroundColor: theme == .light ? theme.backgroundColor : theme.focusedBackground,
+            backgroundColor: theme.appearence == .light ? theme.backgroundColor : theme.focusedBackground,
             focusedBackground: theme.focusedBackground,
             auxiliaryBackground: theme.auxiliaryBackground,
             bannerBackground: theme.bannerBackground,


### PR DESCRIPTION
@RocketChat/ios

Theming popovers should now be easier. It's still not completely automatic, for performance reasons, but all that is required is to call applyTheme in `layoutSubviews` for a `UIView` or `viewDidLayoutSubviews` in a `UIViewController`.

The popovers now have a higher contrast with the background of the presenting view.

<img width="308" alt="screen shot 2018-07-21 at 12 32 27 am" src="https://user-images.githubusercontent.com/7317008/43020417-910e1296-8c7d-11e8-9e43-b57ed28aef05.png">

Closes #2022 