### PR TITLE
[IMPROVEMENT] Use opaque cells for subscriptions table view

### DIFF
--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
@@ -77,16 +77,14 @@ final class SubscriptionsViewController: BaseViewController {
                     tableView.performBatchUpdates({
                         tableView.deleteRows(at: changes.deletions, with: .automatic)
                         tableView.insertRows(at: changes.insertions, with: .automatic)
+                        tableView.reloadRows(at: changes.modifications, with: .none)
                     }, completion: nil)
                 } else {
                     tableView.beginUpdates()
                     tableView.deleteRows(at: changes.deletions, with: .automatic)
                     tableView.insertRows(at: changes.insertions, with: .automatic)
+                    tableView.reloadRows(at: changes.modifications, with: .none)
                     tableView.endUpdates()
-                }
-
-                UIView.performWithoutAnimation {
-                    tableView.reloadRows(at: changes.modifications, with: .automatic)
                 }
             }
         }

--- a/Rocket.Chat/Views/Cells/Subscription/BaseSubscriptionCell.swift
+++ b/Rocket.Chat/Views/Cells/Subscription/BaseSubscriptionCell.swift
@@ -163,7 +163,7 @@ extension BaseSubscriptionCell {
         let transition = {
             switch selected {
             case true:
-                self.backgroundColor = self.selectedBackgroundColor
+                self.backgroundColor = self.theme?.bannerBackground ?? self.selectedBackgroundColor
             case false:
                 self.backgroundColor = self.theme?.backgroundColor ?? self.defaultBackgroundColor
             }
@@ -180,7 +180,7 @@ extension BaseSubscriptionCell {
         let transition = {
             switch highlighted {
             case true:
-                self.backgroundColor = self.highlightedBackgroundColor
+                self.backgroundColor = self.theme?.auxiliaryBackground ?? self.highlightedBackgroundColor
             case false:
                 self.backgroundColor = self.theme?.backgroundColor ?? self.defaultBackgroundColor
             }


### PR DESCRIPTION
@RocketChat/ios

Currently, the table view cells for `SubscriptionsViewController` have a transparent background when they are selected. This causes the cells to flicker when they are reloaded.

This will solve the flickering issue, without the need of `UIView.performWithoutAnimation`, which may also be responsible for a crash we recently started experiencing.

Possibly Closes #2036 
This issue can be closed after beta testing, or a public release, if the crash no longer occurs.