### PR TITLE
[FIX] Notification reply not working when app is open and in other server

### DIFF
--- a/Rocket.Chat/Managers/PushManager.swift
+++ b/Rocket.Chat/Managers/PushManager.swift
@@ -159,13 +159,17 @@ extension PushManager {
              }
         }
 
+        guard let realm = DatabaseManager.databaseInstace(index: index) else {
+            return false
+        }
+
         if let reply = reply {
             let appendage = notification.roomType == .directMessage ? "" : " @\(notification.username)"
 
             let message = "\(reply)\(appendage)"
 
             let backgroundTask = UIApplication.shared.beginBackgroundTask(expirationHandler: nil)
-            API.current()?.fetch(PostMessageRequest(roomId: notification.roomId, text: message)) { response in
+            API.current(realm: realm)?.fetch(PostMessageRequest(roomId: notification.roomId, text: message)) { response in
                 switch response {
                 case .resource:
                     UIApplication.shared.endBackgroundTask(backgroundTask)


### PR DESCRIPTION
@RocketChat/ios

Replying to a notification was not working in this specific case.

1. App is in background
2. It's in another server
3. You try to reply to a notification from a server different from the one currently selected
