### PR TITLE
[FIX] iPad losing right-side controller after becoming fullscreen on multitasking

### DIFF
--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
@@ -490,7 +490,7 @@ extension SubscriptionsViewController: UITableViewDelegate {
 
         // When using iPads, we override the detail controller creating
         // a new instance.
-        if splitViewController?.detailViewController as? BaseNavigationController != nil {
+        if UIDevice.current.userInterfaceIdiom == .pad {
             controller.subscription = subscription
 
             let nav = BaseNavigationController(rootViewController: controller)


### PR DESCRIPTION
@RocketChat/ios

This is reproducible by:

1. Putting App in small size on multitasking
2. Entering a room
3. Making App Fullscreen
- Loses control and navigation bar of right side
- Left-side works like iPhone

Closes #2031
