### PR TITLE
[FIX] Not being able to close reactor list in iPad compact mode

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChatControllerMessageCellProtocol.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerMessageCellProtocol.swift
@@ -44,7 +44,7 @@ extension ChatViewController: ChatMessageCellProtocol, UserActionSheetPresenter 
 
         // present (push on iPhone, popover on iPad)
 
-        if UIDevice.current.userInterfaceIdiom == .phone {
+        if traitCollection.horizontalSizeClass == .compact {
             self.navigationController?.pushViewController(controller, animated: true)
         } else {
             if let presenter = controller.popoverPresentationController {


### PR DESCRIPTION
@RocketChat/ios

It was opening a modal with no close button or back button.
