### PR TITLE
[WIP][BUG] Cell sizing & missing separators

### DIFF
--- a/Rocket.Chat/Controllers/Chat/ChatControllerMessageCellProtocol.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatControllerMessageCellProtocol.swift
@@ -148,6 +148,9 @@ extension ChatViewController: ChatMessageCellProtocol, UserActionSheetPresenter 
     func viewDidCollapseChange(view: UIView) {
         guard let origin = collectionView?.convert(CGPoint.zero, from: view) else { return }
         guard let indexPath = collectionView?.indexPathForItem(at: origin) else { return }
+
+        let item = dataController.itemAt(indexPath)
+        dataController.invalidateLayout(for: item?.identifier)
         collectionView?.reloadItems(at: [indexPath])
     }
 

--- a/Rocket.Chat/Controllers/Chat/ChatDataController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatDataController.swift
@@ -309,6 +309,8 @@ final class ChatDataController {
     func update(_ message: Message) -> Int {
         for (idx, obj) in data.enumerated()
             where obj.message?.identifier == message.identifier {
+                invalidateLayout(for: obj.identifier)
+
                 if obj.message?.updatedAt?.timeIntervalSince1970 == message.updatedAt?.timeIntervalSince1970 {
                    return -1
                 }
@@ -320,7 +322,6 @@ final class ChatDataController {
                 }
 
                 data[idx].message = message
-                invalidateLayout(for: obj.identifier)
                 return obj.indexPath.row
         }
 

--- a/Rocket.Chat/Controllers/Chat/ChatViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChatViewController.swift
@@ -1010,14 +1010,17 @@ extension ChatViewController {
         guard
             dataController.data.count > indexPath.row,
             let subscription = subscription,
-            let obj = dataController.itemAt(indexPath),
-            obj.message?.validated() != nil
+            let obj = dataController.itemAt(indexPath)
         else {
             return cellForEmpty(at: indexPath)
         }
 
         if obj.type == .message {
-            return cellForMessage(obj, at: indexPath)
+            if obj.message?.validated() != nil {
+                return cellForMessage(obj, at: indexPath)
+            } else {
+                return cellForEmpty(at: indexPath)
+            }
         }
 
         if obj.type == .daySeparator {
@@ -1170,7 +1173,6 @@ extension ChatViewController: UICollectionViewDelegateFlowLayout {
                 let sequential = dataController.hasSequentialMessageAt(indexPath)
                 let height = ChatMessageCell.cellMediaHeightFor(message: message, width: fullWidth, sequential: sequential)
                 dataController.cacheCellHeight(for: obj.identifier, value: height)
-
                 return CGSize(width: fullWidth, height: height)
             }
         }

--- a/Rocket.Chat/Extensions/NSAttributedStringExtensions.swift
+++ b/Rocket.Chat/Extensions/NSAttributedStringExtensions.swift
@@ -11,9 +11,12 @@ import UIKit
 extension NSAttributedString {
     func heightForView(withWidth width: CGFloat) -> CGFloat? {
         let size = CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
-        let rect = self.boundingRect(with: size,
-                                     options: [.usesLineFragmentOrigin, .usesFontLeading],
-                                     context: nil)
+
+        let rect = self.boundingRect(
+            with: size,
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            context: nil
+        )
 
         return rect.height
     }

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageAttachmentView.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageAttachmentView.swift
@@ -11,7 +11,7 @@ class ChatMessageAttachmentView: UIView {
         return 0
     }
 
-    static func heightFor(withText description: String?) -> CGFloat {
+    static func heightFor(with availableWidth: CGFloat, description: String?) -> CGFloat {
         guard let text = description, !text.isEmpty else {
             return self.defaultHeight
         }
@@ -21,7 +21,7 @@ class ChatMessageAttachmentView: UIView {
             attributes: [NSAttributedStringKey.font: UIFont.systemFont(ofSize: 14.0)]
         )
 
-        let labelWidth = UIScreen.main.bounds.size.width - 55
+        let labelWidth = availableWidth - 55
         let height = attributedString.heightForView(withWidth: labelWidth)
         return self.defaultHeight + (height ?? -1) + 1
     }

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageAudioView.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageAudioView.swift
@@ -19,9 +19,12 @@ final class ChatMessageAudioView: ChatMessageAttachmentView {
             self.titleLabel.text = attachment?.title
             self.detailText.text = attachment?.descriptionText
             self.detailTextIndicator.isHidden = attachment?.descriptionText?.isEmpty ?? true
-            let fullHeight = ChatMessageAudioView.heightFor(withText: attachment?.descriptionText)
+
+            let availableWidth = frame.size.width
+            let fullHeight = ChatMessageAudioView.heightFor(with: availableWidth, description: attachment?.descriptionText)
             fullHeightConstraint.constant = fullHeight
             detailTextHeightConstraint.constant = fullHeight - ChatMessageAudioView.defaultHeight
+
             loading = true
             playing = false
             updateAudio(attachment: attachment)

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -317,12 +317,11 @@ extension ChatMessageCell: UIGestureRecognizerDelegate {
 extension ChatMessageCell {
 
     static func cellMediaHeightFor(message: Message, width: CGFloat, sequential: Bool = true) -> CGFloat {
-        let fullWidth = width
         let attributedString = MessageTextCacheManager.shared.message(for: message, with: nil)
 
         var total = (CGFloat)(sequential ? 8 : 29) + (message.reactions.count > 0 ? 40 : 0)
         if attributedString?.string ?? "" != "" {
-            total += (attributedString?.heightForView(withWidth: fullWidth - 61) ?? 0)
+            total += (attributedString?.heightForView(withWidth: width - 61) ?? 0)
         }
 
         if message.isBroadcastReplyAvailable() {
@@ -338,24 +337,24 @@ extension ChatMessageCell {
             let type = attachment.type
 
             if type == .textAttachment {
-                total += ChatMessageTextView.heightFor(collapsed: attachment.collapsed, withText: attachment.text, isFile: attachment.isFile)
+                total += ChatMessageTextView.heightFor(with: width, collapsed: attachment.collapsed, text: attachment.text, isFile: attachment.isFile)
             }
 
             if type == .image {
-                total += ChatMessageImageView.heightFor(withText: attachment.descriptionText)
+                total += ChatMessageImageView.heightFor(with: width, description: attachment.descriptionText)
             }
 
             if type == .video {
-                total += ChatMessageVideoView.heightFor(withText: attachment.descriptionText)
+                total += ChatMessageVideoView.heightFor(with: width, description: attachment.descriptionText)
             }
 
             if type == .audio {
-                total += ChatMessageAudioView.heightFor(withText: attachment.descriptionText)
+                total += ChatMessageAudioView.heightFor(with: width, description: attachment.descriptionText)
             }
 
             if !attachment.collapsed {
                 attachment.fields.forEach {
-                    total += ChatMessageTextView.heightFor(collapsed: false, withText: $0.value)
+                    total += ChatMessageTextView.heightFor(with: width, collapsed: false, text: $0.value)
                 }
             }
         }
@@ -412,14 +411,16 @@ extension ChatMessageCell {
         view.translatesAutoresizingMaskIntoConstraints = false
 
         mediaViews.addArrangedSubview(view)
-        var attachmentHeight = ChatMessageTextView.heightFor(collapsed: attachment.collapsed, withText: attachment.text, isFile: attachment.isFile)
+
+        let availableWidth = frame.size.width
+        var attachmentHeight = ChatMessageTextView.heightFor(with: availableWidth, collapsed: attachment.collapsed, text: attachment.text, isFile: attachment.isFile)
 
         if !attachment.collapsed {
             attachment.fields.forEach {
                 guard let view = ChatMessageTextView.instantiateFromNib() else { return }
                 view.viewModel = ChatMessageAttachmentFieldViewModel(withAttachment: attachment, andAttachmentField: $0)
                 mediaViews.addArrangedSubview(view)
-                attachmentHeight += ChatMessageTextView.heightFor(collapsed: false, withText: $0.value)
+                attachmentHeight += ChatMessageTextView.heightFor(with: availableWidth, collapsed: false, text: $0.value)
             }
         }
 
@@ -431,9 +432,10 @@ extension ChatMessageCell {
         view.attachment = attachment
         view.delegate = delegate
         view.translatesAutoresizingMaskIntoConstraints = false
-
         mediaViews.addArrangedSubview(view)
-        return ChatMessageImageView.heightFor(withText: attachment.descriptionText)
+
+        let availableWidth = frame.size.width
+        return ChatMessageImageView.heightFor(with: availableWidth, description: attachment.descriptionText)
     }
 
     private func insertVideoAttachment(_ attachment: Attachment) -> CGFloat {
@@ -441,18 +443,20 @@ extension ChatMessageCell {
         view.attachment = attachment
         view.delegate = delegate
         view.translatesAutoresizingMaskIntoConstraints = false
-
         mediaViews.addArrangedSubview(view)
-        return ChatMessageVideoView.heightFor(withText: attachment.descriptionText)
+
+        let availableWidth = frame.size.width
+        return ChatMessageImageView.heightFor(with: availableWidth, description: attachment.descriptionText)
     }
 
     private func insertAudioAttachment(_ attachment: Attachment) -> CGFloat {
         guard let view = ChatMessageAudioView.instantiateFromNib() else { return 0 }
         view.attachment = attachment
         view.translatesAutoresizingMaskIntoConstraints = false
-
         mediaViews.addArrangedSubview(view)
-        return ChatMessageAudioView.heightFor(withText: attachment.descriptionText)
+
+        let availableWidth = frame.size.width
+        return ChatMessageImageView.heightFor(with: availableWidth, description: attachment.descriptionText)
     }
 }
 

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageImageView.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageImageView.swift
@@ -54,6 +54,7 @@ final class ChatMessageImageView: ChatMessageAttachmentView {
         guard let imageURL = attachment.fullImageURL() else {
             return nil
         }
+
         if imageURL.absoluteString.starts(with: "http://") {
             isLoadable = false
             detailText.text = ""
@@ -62,12 +63,16 @@ final class ChatMessageImageView: ChatMessageAttachmentView {
             imageView.image =  UIImage(named: "Resource Unavailable")
             return nil
         }
+
         labelTitle.text = attachment.title
         detailText.text = attachment.descriptionText
         detailTextIndicator.isHidden = attachment.descriptionText?.isEmpty ?? true
-        let fullHeight = ChatMessageImageView.heightFor(withText: attachment.descriptionText)
+
+        let availableWidth = frame.size.width
+        let fullHeight = ChatMessageImageView.heightFor(with: availableWidth, description: attachment.descriptionText)
         fullHeightConstraint.constant = fullHeight
         detailTextHeightConstraint.constant = fullHeight - ChatMessageImageView.defaultHeight
+
         return imageURL
     }
 

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageTextView.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageTextView.swift
@@ -80,12 +80,12 @@ final class ChatMessageTextView: UIView {
         }
     }
 
-    static func heightFor(collapsed: Bool, withText text: String?, isFile: Bool = false) -> CGFloat {
+    static func heightFor(with availableWidth: CGFloat, collapsed: Bool, text: String?, isFile: Bool = false) -> CGFloat {
         guard !isFile else {
             return defaultHeight
         }
 
-        let width = UIScreen.main.bounds.size.width - 73
+        let width = availableWidth - 73
         var textHeight: CGFloat = 1
 
         if let text = text, text.count > 0 {

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageVideoView.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageVideoView.swift
@@ -45,7 +45,9 @@ final class ChatMessageVideoView: ChatMessageAttachmentView {
         labelTitle.text = attachment.title
         detailText.text = attachment.descriptionText
         detailTextIndicator.isHidden = attachment.descriptionText?.isEmpty ?? true
-        let fullHeight = ChatMessageVideoView.heightFor(withText: attachment.descriptionText)
+
+        let availableWidth = frame.size.width
+        let fullHeight = ChatMessageVideoView.heightFor(with: availableWidth, description: attachment.descriptionText)
         fullHeightConstraint.constant = fullHeight
         detailTextHeightConstraint.constant = fullHeight - ChatMessageVideoView.defaultHeight
 


### PR DESCRIPTION
@RocketChat/ios

Closes #2039

This PR fixes couple of problems:

- Sizing of collapsed text views;
- Sizing calculation on some devices that we cannot base on UIScreen size;
- Critical bug on empty cell for any object that doesn't contain a valid message (regression from #2064);