### PR TITLE
[FIX] Background color for the search bar in EmojiPicker

### DIFF
--- a/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.xib
+++ b/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -34,7 +34,7 @@
                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                     </collectionViewFlowLayout>
                 </collectionView>
-                <searchBar contentMode="redraw" searchBarStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="9CP-Lf-X2h">
+                <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="9CP-Lf-X2h">
                     <rect key="frame" x="0.0" y="0.0" width="441" height="56"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="56" id="m1y-8s-7bv"/>

--- a/Rocket.Chat/Theme/ThemeableViews.swift
+++ b/Rocket.Chat/Theme/ThemeableViews.swift
@@ -137,16 +137,18 @@ extension UITextField {
     }
 }
 
+// Due to a possible bug in iOS, search bars with .minimal
+// style are not able to be themed. Use .prominent or .default
+// searchBarStyle instead.
 extension UISearchBar {
     override func applyTheme() {
         super.applyTheme()
-
+        guard let theme = theme else { return }
         if #available(iOS 11, *) {
-            // Do nothing
-        } else {
-            backgroundImage = UIImage()
+            barStyle = theme.appearence.barStyle
         }
 
+        backgroundImage = UIImage()
         textField?.backgroundColor = #colorLiteral(red: 0.4980838895, green: 0.4951269031, blue: 0.5003594756, alpha: 0.1525235445)
         applyThemeFromRuntimeAttributes()
     }


### PR DESCRIPTION
@RocketChat/ios

![simulator screen shot - iphone x - 2018-07-31 at 23 16 24](https://user-images.githubusercontent.com/7317008/43477031-c560a3f4-9517-11e8-9588-916ee9d371de.png)

Closes #2100 
