### PR TITLE
Update PreferencesViewController.swift

### DIFF
--- a/Rocket.Chat/Controllers/Preferences/PreferencesViewController.swift
+++ b/Rocket.Chat/Controllers/Preferences/PreferencesViewController.swift
@@ -239,7 +239,7 @@ final class PreferencesViewController: BaseTableViewController {
                 cellContactDidPressed()
             } else if indexPath.row == 1 {
                 cellLanguageDidPressed()
-            } else if indexPath.row == 5 {
+            } else if indexPath.row == 4 {
                 cellAppIconDidPressed()
             }
         } else if indexPath.section == kSectionInformation {


### PR DESCRIPTION
Use correct value of indexPath.row to call cellAppIconDidPressed() .
The value was 4 in version 3.0.1 and is 5 in version 3.1.0 , but kSectionSettings has not changed in the meantime.

@RocketChat/ios

Closes #ISSUE_NUMBER
