### PR TITLE
[CHORE] Add script to validate localizable strings files

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -3689,6 +3689,7 @@
 				FC8FBCDB0132F52FB242368E /* [CP] Embed Pods Frameworks */,
 				FD5E5CD0D343F2BAB726ADF9 /* 📦 Embed Pods Frameworks */,
 				807FB5672046E7DD00E21429 /* Embed App Extensions */,
+				805378D121344458004A3D16 /* Validate Strings */,
 			);
 			buildRules = (
 			);
@@ -4066,6 +4067,20 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
+		};
+		805378D121344458004A3D16 /* Validate Strings */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Validate Strings";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "${SRCROOT}/Scripts/Localize.swift";
 		};
 		D37272A11E13E60E00A25E1A /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Rocket.Chat/Resources/cs.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/cs.lproj/Localizable.strings
@@ -285,7 +285,6 @@
 "chat.info.item.pinned" = "Připnuto";
 "chat.info.item.starred" = "S hvězdičkou";
 "chat.info.item.mentions" = "Mentions"; // TODO
-"chat.info.item.notifications" = "Notifications"; // TODO
 "chat.info.item.files" = "Files"; // TODO
 "chat.info.item.share" = "Share"; // TODO
 

--- a/Rocket.Chat/Resources/de.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/de.lproj/Localizable.strings
@@ -286,7 +286,6 @@
 "chat.info.item.starred" = "Favorisiert";
 "chat.info.item.files" = "Dateien";
 "chat.info.item.mentions" = "Erwähnungen";
-"chat.info.item.notifications" = "Notifications"; // TODO
 "chat.info.item.share" = "Teilen";
 
 // Members List

--- a/Rocket.Chat/Resources/el.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/el.lproj/Localizable.strings
@@ -284,7 +284,6 @@
 "chat.info.item.members" = "Μέλη";
 "chat.info.item.pinned" = "Καρφιτσωμένα";
 "chat.info.item.starred" = "Αστερωμένα";
-"chat.info.item.notifications" = "Notifications"; // TODO
 "chat.info.item.mentions" = "Αναφέρθηκαν";
 "chat.info.item.files" = "Αρχεία";
 "chat.info.item.share" = "Κοινή Χρήση";

--- a/Rocket.Chat/Resources/es.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/es.lproj/Localizable.strings
@@ -272,6 +272,7 @@
 "chat.message.type.subscription_role_removed" = "%@ ya no es%@ por %@";
 "chat.message.type.room_archived" = "Esta habitación ha sido archivada por %@";
 "chat.message.type.room_unarchived" = "Esta habitación ha sido desarchivada por %@";
+"chat.message.type.message_pinned" = "Pinned a message:"; // TODO
 
 // Chat Information
 "chat.info.title" = "Información";
@@ -284,7 +285,6 @@
 "chat.info.item.pinned" = "Fijado";
 "chat.info.item.starred" = "Sembrado de estrellas";
 "chat.info.item.mentions" = "Mentions"; // TODO
-"chat.info.item.notifications" = "Notifications"; // TODO
 "chat.info.item.files" = "Files"; // TODO
 "chat.info.item.share" = "Share"; // TODO
 

--- a/Rocket.Chat/Resources/fr.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/fr.lproj/Localizable.strings
@@ -272,6 +272,7 @@
 "chat.message.type.subscription_role_removed" = "%@ n'est plus %@ par %@";
 "chat.message.type.room_archived" = "Cette salle a été archivée par %@";
 "chat.message.type.room_unarchived" = "Cette salle a été désarchivée par %@";
+"chat.message.type.message_pinned" = "Pinned a message:"; // TODO
 
 // Chat Information
 "chat.info.title" = "Info";

--- a/Rocket.Chat/Resources/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pl.lproj/Localizable.strings
@@ -272,6 +272,7 @@
 "chat.message.type.subscription_role_removed" = "%@ utracił rolę %@ przez %@";
 "chat.message.type.room_archived" = "Kanał został zarchiwizowany przez %@";
 "chat.message.type.room_unarchived" = "Kanał został od archiwizowany przez %@";
+"chat.message.type.message_pinned" = "Pinned a message:"; // TODO
 
 // Chat Information
 "chat.info.title" = "Informacje";
@@ -283,7 +284,6 @@
 "chat.info.item.members" = "Członkowie";
 "chat.info.item.pinned" = "Przypięte";
 "chat.info.item.starred" = "Oznaczone gwiazdką";
-"chat.info.item.notifications" = "Notifications"; // TODO
 "chat.info.item.mentions" = "Wzmianki";
 "chat.info.item.files" = "Pliki";
 "chat.info.item.share" = "Udostępnij";

--- a/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
@@ -285,7 +285,6 @@
 "chat.info.item.pinned" = "Pinadas";
 "chat.info.item.starred" = "Favoritas";
 "chat.info.item.mentions" = "Menções";
-"chat.info.item.notifications" = "Notificações";
 "chat.info.item.files" = "Arquivos";
 "chat.info.item.share" = "Compartilhar";
 

--- a/Rocket.Chat/Resources/pt-PT.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/Localizable.strings
@@ -145,6 +145,7 @@
 "subscriptions.unreads" = "Não lidas";
 "subscriptions.favorites" = "Favoritos";
 "subscriptions.channels" = "Canais";
+"subscriptions.groups" = "Private Groups"; //TODO
 "subscriptions.direct_messages" = "Mensagens Diretas";
 "subscriptions.conversations" = "Conversas";
 "subscriptions.you" = "você";
@@ -167,6 +168,7 @@
 "status.online" = "Online";
 "status.away" = "Ausente";
 "status.busy" = "Ocupado";
+"status.offline" = "Offline"; //TODO
 "status.invisible" = "Invisível";
 
 // New Room View
@@ -420,10 +422,21 @@
 "myaccount.settings.profile.new_password.password_required.placeholder" = "Palavra-passe";
 
 // User Action Sheet
-"user_action_sheet.conversation" = "Conversação";
+"user_action_sheet.info" = "Information"; // TODO
 "user_action_sheet.remove" = "Remover da sala";
 "user_action_sheet.remove_confirm.title" = "Remover este utilizador?";
 "user_action_sheet.remove_confirm.message" = "Você tem certeza que deseja remover '%@' da sala?";
+
+// User Details
+"user_details.status" = "Status"; // TODO
+"user_details.role" = "Role"; // TODO
+"user_details.roles" = "Roles"; // TODO
+"user_details.email" = "Email"; // TODO
+"user_details.emails" = "Emails"; // TODO
+"user_details.timezone" = "Timezone"; // TODO
+"user_details.message_button" = "Message"; // TODO
+"user_details.voice_call_button" = "Voice Call"; // TODO
+"user_details.video_call_button" = "Video Call"; // TODO
 
 // Theme
 "theme.settings.title" = "Tema";

--- a/Rocket.Chat/Resources/ru.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/ru.lproj/Localizable.strings
@@ -427,6 +427,17 @@
 "user_action_sheet.remove_confirm.title" = "Удалить этого пользователя";
 "user_action_sheet.remove_confirm.message" = "Вы действительно хотите удалить '%@' с канала?";
 
+// User Details
+"user_details.status" = "Status"; // TODO
+"user_details.role" = "Role"; // TODO
+"user_details.roles" = "Roles"; // TODO
+"user_details.email" = "Email"; // TODO
+"user_details.emails" = "Emails"; // TODO
+"user_details.timezone" = "Timezone"; // TODO
+"user_details.message_button" = "Message"; // TODO
+"user_details.voice_call_button" = "Voice Call"; // TODO
+"user_details.video_call_button" = "Video Call"; // TODO
+
 // Theme
 "theme.settings.title" = "Тема";
 "theme.settings.header" = "ВСЕ ТЕМЫ";

--- a/Scripts/Localize.swift
+++ b/Scripts/Localize.swift
@@ -1,0 +1,330 @@
+#!/usr/bin/env xcrun --sdk macosx swift
+
+// swiftlint:disable all
+
+import Foundation
+
+
+// WHAT
+// 1. Find Missing keys in other Localisation files
+// 2. Find potentially untranslated keys
+// 3. Find Duplicate keys
+// 4. Find Unused keys and generate script to delete them all at once
+
+
+// MARK: Start Of Configurable Section
+
+/*
+ You can enable or disable the script whenever you want
+ */
+let enabled = true
+
+/*
+ Flag to determine whether unused strings should be an error
+ */
+let careAboutUnused = false
+
+/*
+ Flag to determine whether potentially untranslated strings should be a warning
+ */
+let careAboutUntranslated = false
+
+/*
+ Put your path here, example ->  Resources/Localizations/Languages
+ */
+let relativeLocalizableFolders = "/Rocket.Chat/Resources"
+
+/*
+ This is the path of your source folder which will be used in searching
+ for the localization keys you actually use in your project
+ */
+let relativeSourceFolder = "/Rocket.Chat"
+
+/*
+ Those are the regex patterns to recognize localizations.
+ */
+let patterns = [
+    "NSLocalized(Format)?String\\(\\s*@?\"([\\w\\.]+)\"", // Swift and Objc Native
+    "Localizations\\.((?:[A-Z]{1}[a-z]*[A-z]*)*(?:\\.[A-Z]{1}[a-z]*[A-z]*)*)", // Laurine Calls
+    "L10n.tr\\(key: \"(\\w+)\"", // SwiftGen generation
+    "ypLocalized\\(\"(.*)\"\\)",
+    "\"(.*)\".localized" // "key".localized pattern
+]
+
+/*
+ Those are the keys you don't want to be recognized as "unused"
+ For instance, Keys that you concatenate will not be detected by the parsing
+ so you want to add them here in order not to create false positives :)
+ */
+let ignoredFromUnusedKeys = [String]()
+/* example
+let ignoredFromUnusedKeys = [
+    "NotificationNoOne",
+    "NotificationCommentPhoto",
+    "NotificationCommentHisPhoto",
+    "NotificationCommentHerPhoto"
+]
+*/
+
+let masterLanguage = "en"
+
+/*
+ Sanitizing files will remove comments, empty lines and order your keys alphabetically.
+ */
+let sanitizeFiles = false
+
+/*
+ Determines if there are multiple localizations or not.
+ */
+let singleLanguage = false
+
+// MARK: End Of Configurable Section
+// MARK: -
+
+
+
+
+
+
+
+
+
+
+
+if enabled == false {
+    print("Localization check cancelled")
+    exit(000)
+}
+
+// Detect list of supported languages automatically
+func listSupportedLanguages() -> [String] {
+    var sl = [String]()
+    let path = FileManager.default.currentDirectoryPath + relativeLocalizableFolders
+    if !FileManager.default.fileExists(atPath: path) {
+        print("Invalid configuration: \(path) does not exist.")
+        exit(1)
+    }
+    let enumerator: FileManager.DirectoryEnumerator? = FileManager.default.enumerator(atPath: path)
+    let extensionName = "lproj"
+    print("Found these languages:")
+    while let element = enumerator?.nextObject() as? String {
+        if element.hasSuffix(extensionName) {
+            print(element)
+            let name = element.replacingOccurrences(of: ".\(extensionName)", with: "")
+            sl.append(name)
+        }
+    }
+    return sl
+}
+
+
+let supportedLanguages = listSupportedLanguages()
+var ignoredFromSameTranslation = [String:[String]]()
+let path = FileManager.default.currentDirectoryPath + relativeLocalizableFolders
+var numberOfWarnings = 0
+var numberOfErrors = 0
+
+struct LocalizationFiles {
+    var name = ""
+    var keyValue = [String:String]()
+    var linesNumbers = [String:Int]()
+    
+    init(name: String) {
+        self.name = name
+        process()
+    }
+    
+    mutating func process() {
+        if sanitizeFiles {
+            removeCommentsFromFile()
+            removeEmptyLinesFromFile()
+            sortLinesAlphabetically()
+        }
+        let location = singleLanguage ? "\(path)/Localizable.strings" : "\(path)/\(name).lproj/Localizable.strings"
+        if let string = try? String(contentsOfFile: location, encoding: .utf8) {
+            let lines =  string.components(separatedBy: CharacterSet.newlines)
+            keyValue = [String:String]()
+            let pattern = "\"(.*)\" = \"(.+)\";"
+            let regex = try? NSRegularExpression(pattern: pattern, options: [])
+            var ignoredTranslation = [String]()
+            
+            for (lineNumber, line) in lines.enumerated() {
+                let range = NSRange(location:0, length:(line as NSString).length)
+                
+                
+                // Ignored pattern
+                let ignoredPattern = "\"(.*)\" = \"(.+)\"; *\\/\\/ *ignore-same-translation-warning"
+                let ignoredRegex = try? NSRegularExpression(pattern: ignoredPattern, options: [])
+                if let ignoredMatch = ignoredRegex?.firstMatch(in:line,
+                                                               options: [],
+                                                               range: range) {
+                    let key = (line as NSString).substring(with: ignoredMatch.range(at:1))
+                    ignoredTranslation.append(key)
+                }
+                if let firstMatch = regex?.firstMatch(in: line, options: [], range: range) {
+                    let key = (line as NSString).substring(with: firstMatch.range(at:1))
+                    let value = (line as NSString).substring(with: firstMatch.range(at:2))
+                    if let _ =  keyValue[key] {
+                        let str = "\(path)/\(name).lproj"
+                            + "/Localizable.strings:\(linesNumbers[key]!): "
+                            + "error: [Redundance] \"\(key)\" "
+                            + "is redundant in \(name.uppercased()) file"
+                        print(str)
+                        numberOfErrors += 1
+                    } else {
+                        keyValue[key] = value
+                        linesNumbers[key] = lineNumber+1
+                    }
+                }
+            }
+            print(ignoredFromSameTranslation)
+            ignoredFromSameTranslation[name] = ignoredTranslation
+        }
+    }
+    
+    func rebuildFileString(from lines: [String]) -> String {
+        return lines.reduce("") { (r: String, s: String) -> String in
+            return (r == "") ? (r + s) : (r + "\n" + s)
+        }
+    }
+    
+    func removeEmptyLinesFromFile() {
+        let location = "\(path)/\(name).lproj/Localizable.strings"
+        if let string = try? String(contentsOfFile: location, encoding: .utf8) {
+            var lines = string.components(separatedBy: CharacterSet.newlines)
+            lines = lines.filter { $0.trimmingCharacters(in: CharacterSet.whitespaces) != "" }
+            let s = rebuildFileString(from: lines)
+            try? s.write(toFile:location, atomically:false, encoding:String.Encoding.utf8)
+        }
+    }
+    
+    func removeCommentsFromFile() {
+        let location = "\(path)/\(name).lproj/Localizable.strings"
+        if let string = try? String(contentsOfFile: location, encoding: .utf8) {
+            var lines = string.components(separatedBy: CharacterSet.newlines)
+            lines = lines.filter { !$0.hasPrefix("//") }
+            let s = rebuildFileString(from: lines)
+            try? s.write(toFile:location, atomically:false, encoding:String.Encoding.utf8)
+        }
+    }
+    
+    func sortLinesAlphabetically() {
+        let location = "\(path)/\(name).lproj/Localizable.strings"
+        if let string = try? String(contentsOfFile: location, encoding: .utf8) {
+            let lines = string.components(separatedBy: CharacterSet.newlines)
+            
+            var s = ""
+            for (i,l) in sortAlphabetically(lines).enumerated() {
+                s += l
+                if (i != lines.count - 1) {
+                    s += "\n"
+                }
+            }
+            try? s.write(toFile:location, atomically:false, encoding:String.Encoding.utf8)
+        }
+    }
+    
+    func removeEmptyLinesFromLines(_ lines:[String]) -> [String] {
+        return lines.filter { $0.trimmingCharacters(in: CharacterSet.whitespaces) != "" }
+    }
+    
+    func sortAlphabetically(_ lines:[String]) -> [String] {
+        return lines.sorted()
+    }
+}
+
+// MARK: - Load Localisation Files in memory
+
+let masterLocalizationfile = LocalizationFiles(name: masterLanguage)
+let localizationFiles = supportedLanguages
+    .filter { $0 != masterLanguage }
+    .map { LocalizationFiles(name: $0) }
+
+// MARK: - Detect Unused Keys
+let sourcesPath = FileManager.default.currentDirectoryPath + relativeSourceFolder
+let fileManager = FileManager.default
+let enumerator = fileManager.enumerator(atPath:sourcesPath)
+var localizedStrings = [String]()
+while let swiftFileLocation = enumerator?.nextObject() as? String {
+    // checks the extension // TODO OBJC?
+    if swiftFileLocation.hasSuffix(".swift") ||  swiftFileLocation.hasSuffix(".m") || swiftFileLocation.hasSuffix(".mm") {
+        let location = "\(sourcesPath)/\(swiftFileLocation)"
+        if let string = try? String(contentsOfFile: location, encoding: .utf8) {
+            for p in patterns {
+                let regex = try? NSRegularExpression(pattern: p, options: [])
+                let range = NSRange(location:0, length:(string as NSString).length) //Obj c wa
+                regex?.enumerateMatches(in: string,
+                                        options: [],
+                                        range: range,
+                                        using: { (result, _, _) in
+                                            if let r = result {
+                                                let value = (string as NSString).substring(with:r.range(at:r.numberOfRanges-1))
+                                                localizedStrings.append(value)
+                                            }
+                })
+            }
+        }
+    }
+}
+
+var masterKeys = Set(masterLocalizationfile.keyValue.keys)
+let usedKeys = Set(localizedStrings)
+let ignored = Set(ignoredFromUnusedKeys)
+let unused = masterKeys.subtracting(usedKeys).subtracting(ignored)
+
+// Here generate Xcode regex Find and replace script to remove dead keys all at once!
+var replaceCommand = "\"("
+var counter = 0
+
+if careAboutUnused {
+    for v in unused {
+        var str = "\(path)/\(masterLocalizationfile.name).lproj/Localizable.strings:\(masterLocalizationfile.linesNumbers[v]!): "
+        str += "error: [Unused Key] \"\(v)\" is never used"
+        print(str)
+        numberOfErrors += 1
+        if counter != 0 {
+            replaceCommand += "|"
+        }
+        replaceCommand += v
+        if counter == unused.count-1 {
+            replaceCommand += ")\" = \".*\";"
+        }
+        counter += 1
+    }
+}
+
+print(replaceCommand)
+
+
+// MARK: - Compare each translation file against master (en)
+for file in localizationFiles {
+    for k in masterLocalizationfile.keyValue.keys {
+        if let v = file.keyValue[k] {
+            if careAboutUntranslated && v == masterLocalizationfile.keyValue[k] {
+                file.
+                if !ignoredFromSameTranslation[file.name]!.contains(k) {
+                    let str = "\(path)/\(file.name).lproj/Localizable.strings"
+                        + ":\(file.linesNumbers[k]!): "
+                        + "warning: [Potentialy Untranslated] \"\(k)\""
+                        + "in \(file.name.uppercased()) file doesn't seem to be localized"
+                    print(str)
+                    numberOfWarnings += 1
+                }
+            }
+        } else {
+            var str = "\(path)/\(file.name).lproj/Localizable.strings:\(masterLocalizationfile.linesNumbers[k]!): "
+            str += "error: [Missing] \"\(k)\" missing form \(file.name.uppercased()) file"
+            print(str)
+            numberOfErrors += 1
+        }
+    }
+}
+
+print("Number of warnings : \(numberOfWarnings)")
+print("Number of errors : \(numberOfErrors)")
+
+if numberOfErrors > 0 {
+    exit(1)
+}
+
+// swiftlint:enable all

--- a/Scripts/Localize.swift
+++ b/Scripts/Localize.swift
@@ -301,7 +301,6 @@ for file in localizationFiles {
     for k in masterLocalizationfile.keyValue.keys {
         if let v = file.keyValue[k] {
             if careAboutUntranslated && v == masterLocalizationfile.keyValue[k] {
-                file.
                 if !ignoredFromSameTranslation[file.name]!.contains(k) {
                     let str = "\(path)/\(file.name).lproj/Localizable.strings"
                         + ":\(file.linesNumbers[k]!): "


### PR DESCRIPTION
@RocketChat/ios

I used this script: https://github.com/freshOS/Localize

But made some changes:
- Don't error with unused strings because we build some in runtime
- Don't report possible untranslated strings because we have many 'TODOs'

It will report missing and duplicate strings

Closes #972