### PR TITLE
[FIX] Not opening correct room after tapping notification when in other server

### DIFF
--- a/Rocket.Chat/Managers/AppManager.swift
+++ b/Rocket.Chat/Managers/AppManager.swift
@@ -117,10 +117,10 @@ struct AppManager {
 
 extension AppManager {
 
-    static func changeSelectedServer(index: Int) {
+    static func changeSelectedServer(index: Int, completion: (() -> Void)? = nil) {
         guard index != DatabaseManager.selectedIndex else {
             DatabaseManager.changeDatabaseInstance(index: index)
-            reloadApp()
+            reloadApp(completion: completion)
             return
         }
 
@@ -131,7 +131,7 @@ extension AppManager {
             AuthSettingsManager.shared.updateCachedSettings()
             AuthManager.recoverAuthIfNeeded()
 
-            reloadApp()
+            reloadApp(completion: completion)
         }
     }
 
@@ -185,7 +185,7 @@ extension AppManager {
         }
     }
 
-    static func reloadApp() {
+    static func reloadApp(completion: (() -> Void)? = nil) {
         SocketManager.sharedInstance.connectionHandlers.removeAllObjects()
         SocketManager.disconnect { (_, _) in
             DispatchQueue.main.async {
@@ -212,6 +212,8 @@ extension AppManager {
                 } else {
                     WindowManager.open(.auth(serverUrl: "", credentials: nil))
                 }
+
+                completion?()
             }
         }
     }

--- a/Rocket.Chat/Managers/PushManager.swift
+++ b/Rocket.Chat/Managers/PushManager.swift
@@ -149,15 +149,21 @@ extension PushManager {
         // side effect: needed for Subscription.notificationSubscription()
         AppManager.initialRoomId = notification.roomId
 
-        if index != DatabaseManager.selectedIndex {
-            AppManager.changeSelectedServer(index: index)
-        } else {
-             if let auth = AuthManager.isAuthenticated() {
+        func openRoom() {
+            if let auth = AuthManager.isAuthenticated() {
                 let openSubscription = MainSplitViewController.chatViewController?.subscription
                 if let subscription = Subscription.notificationSubscription(auth: auth), subscription != openSubscription {
                     AppManager.open(room: subscription, animated: false)
                 }
-             }
+            }
+        }
+
+        if index != DatabaseManager.selectedIndex {
+            AppManager.changeSelectedServer(index: index) {
+                openRoom()
+            }
+        } else {
+            openRoom()
         }
 
         guard let realm = DatabaseManager.databaseInstace(index: index) else {


### PR DESCRIPTION
If you put the App in background in server A and receive notification from server B and tap it, the App will open in the correct server but not in the correct room.

@RocketChat/ios
