### PR TITLE
[IMPROVEMENT] Remove defaults to open.rocket.chat & add a new placeholder to the connection field

### DIFF
--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -55,6 +55,7 @@ final class ConnectServerViewController: BaseViewController {
     @IBOutlet weak var buttonConnect: StyledButton! {
         didSet {
             buttonConnect.setTitle(localized("connection.button_connect"), for: .normal)
+            buttonConnect.isEnabled = false
         }
     }
 
@@ -288,8 +289,25 @@ final class ConnectServerViewController: BaseViewController {
 
 extension ConnectServerViewController: UITextFieldDelegate {
 
+    func textFieldDidChange() {
+        buttonConnect.isEnabled = !(textFieldServerURL.text?.isEmpty ?? true)
+    }
+
+    func textFieldShouldClear(_ textField: UITextField) -> Bool {
+        textFieldServerURL.text = ""
+        textFieldDidChange()
+        return true
+    }
+
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        return !connecting
+        if !connecting {
+            if let text = textField.text, let textRange = Range(range, in: text) {
+                textField.text = text.replacingCharacters(in: textRange, with: string)
+                textFieldDidChange()
+            }
+        }
+
+        return false
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -12,7 +12,6 @@ import semver
 
 final class ConnectServerViewController: BaseViewController {
 
-    internal let defaultURL = "https://open.rocket.chat"
     internal var connecting = false
     internal let infoRequestHandler = InfoRequestHandler()
     internal let buttonConnectBottomSpacing: CGFloat = 24
@@ -22,10 +21,11 @@ final class ConnectServerViewController: BaseViewController {
 
     var shouldAutoConnect = false
     var url: URL? {
-        guard var urlText = textFieldServerURL.text else { return URL(string: defaultURL, scheme: "https") }
+        guard var urlText = textFieldServerURL.text else { return nil }
 
+        // Do not return URL in case text is nil
         if urlText.isEmpty {
-            urlText = defaultURL
+            return nil
         }
 
         // Remove all the whitespaces from the string
@@ -89,7 +89,7 @@ final class ConnectServerViewController: BaseViewController {
 
         selectedServer = DatabaseManager.selectedIndex
         infoRequestHandler.delegate = self
-        textFieldServerURL.placeholder = defaultURL
+        textFieldServerURL.placeholder = localized("connection.server_url.placeholder")
 
         if let nav = navigationController as? AuthNavigationController {
             nav.setTransparentTheme()

--- a/Rocket.Chat/Resources/cs.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/cs.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 // Socket Connection
 "connection.title" = "Sign in to your server"; // TODO
 "connection.button_connect" = "Connect"; // TODO
+"connection.server_url.placeholder" = "your-company.rocket.chat"; // TODO
 "connection.offline.banner.message" = "Jste offline, zkuste se znovu připojit";
 "connection.connecting.banner.message" = "Connecting..."; // TODO
 "connection.waiting_for_network.banner.message" = "Waiting for network"; // TODO

--- a/Rocket.Chat/Resources/de.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/de.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 // Socket Connection
 "connection.title" = "Bei Server anmelden";
 "connection.button_connect" = "Verbinden";
+"connection.server_url.placeholder" = "your-company.rocket.chat"; // TODO
 "connection.offline.banner.message" = "Sie sind offline. Versuche neu zu verbinden...";
 "connection.connecting.banner.message" = "Verbinde...";
 "connection.waiting_for_network.banner.message" = "Warte auf Netzwerk";

--- a/Rocket.Chat/Resources/el.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/el.lproj/Localizable.strings
@@ -96,7 +96,8 @@
 
 // Socket Connection
 "connection.title" = "Συνδεθείτε στον εξυπηρετητή σας"; 
-"connection.button_connect" = "Σύνδεση"; 
+"connection.button_connect" = "Σύνδεση";
+"connection.server_url.placeholder" = "your-company.rocket.chat"; // TODO
 "connection.offline.banner.message" = "Βρίσκεστε εκτός σύνδεσης, προσπαθήστε να συνδεθείτε ξανά";
 "connection.connecting.banner.message" = "Συνδεόμαστε...";
 "connection.waiting_for_network.banner.message" = "Περιμένετε για το δίκτυο"; 

--- a/Rocket.Chat/Resources/en.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/en.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 // Socket Connection
 "connection.title" = "Sign in to your server";
 "connection.button_connect" = "Connect";
+"connection.server_url.placeholder" = "your-company.rocket.chat";
 "connection.offline.banner.message" = "You're offline, try connecting again";
 "connection.connecting.banner.message" = "Connecting...";
 "connection.waiting_for_network.banner.message" = "Waiting for network";

--- a/Rocket.Chat/Resources/es.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/es.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 // Socket Connection
 "connection.title" = "Sign in to your server"; // TODO
 "connection.button_connect" = "Connect"; // TODO
+"connection.server_url.placeholder" = "your-company.rocket.chat"; // TODO
 "connection.offline.banner.message" = "Estás fuera de línea, intenta conectarte de nuevo";
 "connection.connecting.banner.message" = "Conectando ...";
 "connection.waiting_for_network.banner.message" = "Waiting for network"; // TODO

--- a/Rocket.Chat/Resources/fr.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/fr.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 // Socket Connection
 "connection.title" = "Connectez-vous à votre serveur";
 "connection.button_connect" = "Connexion";
+"connection.server_url.placeholder" = "your-company.rocket.chat"; // TODO
 "connection.offline.banner.message" = "Vous êtes déconnecté, veuillez réessayer";
 "connection.connecting.banner.message" = "Connexion en cours...";
 "connection.waiting_for_network.banner.message" = "En attente du réseau...";

--- a/Rocket.Chat/Resources/ja.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/ja.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 // Socket Connection
 "connection.title" = "サーバーに接続";
 "connection.button_connect" = "接続";
+"connection.server_url.placeholder" = "your-company.rocket.chat"; // TODO
 "connection.offline.banner.message" = "現在オフライン状態です。もう一度接続してください。";
 "connection.connecting.banner.message" = "接続中...";
 "connection.waiting_for_network.banner.message" = "接続を待っています";

--- a/Rocket.Chat/Resources/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pl.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 // Socket Connection
 "connection.title" = "Zaloguj się na serwer";
 "connection.button_connect" = "Połącz";
+"connection.server_url.placeholder" = "your-company.rocket.chat"; // TODO
 "connection.offline.banner.message" = "Jesteś w trybie offline, połącz się ponownie";
 "connection.connecting.banner.message" = "Łączenie...";
 "connection.waiting_for_network.banner.message" = "Oczekiwanie na sieć";

--- a/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 // Socket Connection
 "connection.title" = "Conecte seu servidor";
 "connection.button_connect" = "Conectar";
+"connection.server_url.placeholder" = "sua-empresa.rocket.chat";
 "connection.offline.banner.message" = "Você está offline, conecte novamente";
 "connection.connecting.banner.message" = "Conectando...";
 "connection.waiting_for_network.banner.message" = "Aguardando conexão";

--- a/Rocket.Chat/Resources/pt-PT.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 // Socket Connection
 "connection.title" = "Entre no seu servidor";
 "connection.button_connect" = "Ligar";
+"connection.server_url.placeholder" = "sua-empresa.rocket.chat";
 "connection.offline.banner.message" = "Você está off-line, tente ligar-se novamente";
 "connection.connecting.banner.message" = "A ligar...";
 "connection.waiting_for_network.banner.message" = "Esperando por rede";

--- a/Rocket.Chat/Resources/ru.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/ru.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 // Socket Connection
 "connection.title" = "Войдите на ваш сервер";
 "connection.button_connect" = "Соединение";
+"connection.server_url.placeholder" = "your-company.rocket.chat"; // TODO
 "connection.offline.banner.message" = "Вы в автономном режиме, попробуйте подключиться снова";
 "connection.connecting.banner.message" = "Соединение...";
 "connection.waiting_for_network.banner.message" = "Ожидание сети";

--- a/Rocket.Chat/Views/Buttons/StyledButton.swift
+++ b/Rocket.Chat/Views/Buttons/StyledButton.swift
@@ -38,6 +38,7 @@ final class StyledButton: UIButton {
     }
     @IBInspectable var cornerRadius: CGFloat = 2
     @IBInspectable var borderWidth: CGFloat = 1
+    @IBInspectable var buttonColorDisabled: UIColor = UIColor(red: 225/255, green: 229/255, blue: 232/255, alpha: 1)
     @IBInspectable var buttonColor: UIColor = UIColor.RCSkyBlue()
     @IBInspectable var borderColor: UIColor = UIColor.RCSkyBlue()
     @IBInspectable var textColor: UIColor = UIColor.white
@@ -81,6 +82,15 @@ final class StyledButton: UIButton {
         layer.cornerRadius = cornerRadius
         clipsToBounds = true
 
+        if !isEnabled {
+            backgroundColor = buttonColorDisabled
+            layer.borderColor = UIColor.clear.cgColor
+            layer.borderWidth = 0
+            setTitleColor(.white, for: UIControlState())
+            setTitleShadowColor(nil, for: UIControlState())
+            return
+        }
+
         switch style {
         case .solid:
             backgroundColor = buttonColor
@@ -95,6 +105,12 @@ final class StyledButton: UIButton {
             layer.borderWidth = borderWidth
             setTitleColor(textColor, for: UIControlState())
             titleLabel?.font = UIFont.systemFont(ofSize: fontSize, weight: fontWeight)
+        }
+    }
+
+    override var isEnabled: Bool {
+        didSet {
+            applyStyle()
         }
     }
 


### PR DESCRIPTION
@RocketChat/ios

This was a decision we made internally for both iOS and Android to avoid users getting automatically connected to our community server. Now the user will be forced to enter an URL in order to connect.

![2018-09-14 08 48 17](https://user-images.githubusercontent.com/551004/45548543-fe3e4180-b7fa-11e8-9af5-80f96fc73f64.gif)
