### PR TITLE
[FIX] Roles would be cleaned on viewing the list of Members

### DIFF
--- a/Rocket.Chat/API/Clients/SubscriptionsClient.swift
+++ b/Rocket.Chat/API/Clients/SubscriptionsClient.swift
@@ -299,8 +299,13 @@ extension SubscriptionsClient {
         let request = RoomMembersRequest(roomId: subscription.rid, type: subscription.type)
         api.fetch(request, options: options) { response in
             if case let .resource(resource) = response {
-                try? realm?.write {
-                    realm?.add(resource.members?.compactMap { $0 } ?? [], update: true)
+                guard let realm = realm else { return }
+
+                try? realm.write {
+                    resource.members?.forEach({ (member) in
+                        let user = User.getOrCreate(realm: realm, values: member, updates: nil)
+                        realm.add(user, update: true)
+                    })
                 }
             }
 

--- a/Rocket.Chat/API/Requests/Room/RoomMembersRequest.swift
+++ b/Rocket.Chat/API/Requests/Room/RoomMembersRequest.swift
@@ -53,12 +53,8 @@ final class RoomMembersRequest: APIRequest {
 }
 
 class RoomMembersResource: APIResource {
-    var members: [User?]? {
-        return raw?["members"].arrayValue.map {
-            let user = User()
-            user.map($0, realm: nil)
-            return user
-        }
+    var members: [JSON]? {
+        return raw?["members"].arrayValue
     }
 
     var count: Int? {

--- a/Rocket.Chat/Models/Mapping/UserModelMapping.swift
+++ b/Rocket.Chat/Models/Mapping/UserModelMapping.swift
@@ -37,7 +37,7 @@ extension User: ModelMappeable {
                 let email = Email(value: [
                     "email": emailRaw["address"].stringValue,
                     "verified": emailRaw["verified"].boolValue
-                    ])
+                ])
 
                 guard !email.email.isEmpty else { return nil }
 
@@ -48,13 +48,12 @@ extension User: ModelMappeable {
             self.emails.append(objectsIn: emails)
         }
 
-        mapRoles(values["roles"])
-    }
+        if let rolesRaw = values["roles"].array {
+            let roles = rolesRaw.compactMap({ $0.string })
 
-    func mapRoles(_ values: JSON) {
-        if let roles = values.array?.compactMap({ $0.string }) {
             self.roles.removeAll()
             self.roles.append(objectsIn: roles)
         }
     }
+
 }

--- a/Rocket.Chat/Models/User/UserPermissions.swift
+++ b/Rocket.Chat/Models/User/UserPermissions.swift
@@ -21,7 +21,7 @@ extension User {
 
         var roles: [String] = Array(self.roles)
         if let subscription = subscription {
-            roles += rolesInSubscription(subscription)
+            roles.append(contentsOf: rolesInSubscription(subscription))
         }
 
         for userRole in roles {


### PR DESCRIPTION
@RocketChat/ios

Closes #2163

Also reported here: https://forums.rocket.chat/t/app-create-channel-fail/1952.

This one was really hard to find, but the problem was happening is: on getting the response from the API, we were simply overriding all the user data (in consequence, removing all the roles). I changed to simply update the results and create a new one only if needed.