### PR TITLE
[CI] Use iOS 11.2 in place of 11.3 for circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ jobs:
           command: ./Scripts/test_without_building.sh "10.3.1" "iPad Air 2"
       - run:
           name: Run tests on iPad iOS 11.3
-          command: ./Scripts/test_without_building.sh "11.3" "iPad Air 2"
+          command: ./Scripts/test_without_building.sh "11.2" "iPad Air 2"
       - run:
           name: Run tests on iPad iOS 11.3
           command: ./Scripts/test_without_building.sh "12.0" "iPad Air 2"
@@ -41,7 +41,7 @@ jobs:
           command: ./Scripts/test_without_building.sh "10.3.1" "iPhone 5s"
       - run:
           name: Run tests on iPhone iOS 11.3
-          command: ./Scripts/test_without_building_coverage.sh "11.3" "iPhone 8"
+          command: ./Scripts/test_without_building_coverage.sh "11.2" "iPhone 8"
       - run:
           name: Run tests on iPhone (X series) iOS 11.3
           command: ./Scripts/test_without_building_coverage.sh "12.0" "iPhone XS"      

--- a/circle.yml
+++ b/circle.yml
@@ -28,22 +28,22 @@ jobs:
           name: Build for testing
           command: ./Scripts/build_for_testing.sh
       - run:
-          name: Run tests on iPad iOS 10.3
+          name: Run tests on iPad iOS 10.3.1
           command: ./Scripts/test_without_building.sh "10.3.1" "iPad Air 2"
       - run:
-          name: Run tests on iPad iOS 11.3
+          name: Run tests on iPad iOS 11.2
           command: ./Scripts/test_without_building.sh "11.2" "iPad Air 2"
       - run:
-          name: Run tests on iPad iOS 11.3
+          name: Run tests on iPad iOS 12.0
           command: ./Scripts/test_without_building.sh "12.0" "iPad Air 2"
       - run:
-          name: Run tests on iPhone iOS 10.3
+          name: Run tests on iPhone iOS 10.3.1
           command: ./Scripts/test_without_building.sh "10.3.1" "iPhone 5s"
       - run:
-          name: Run tests on iPhone iOS 11.3
+          name: Run tests on iPhone iOS 11.2
           command: ./Scripts/test_without_building_coverage.sh "11.2" "iPhone 8"
       - run:
-          name: Run tests on iPhone (X series) iOS 11.3
+          name: Run tests on iPhone (X series) iOS 12.0
           command: ./Scripts/test_without_building_coverage.sh "12.0" "iPhone XS"      
       - run:
           name: Codecov


### PR DESCRIPTION
@RocketChat/ios

Circle CI does not support iOS 11.3 on the Xcode 10.0.0 images.
