### PR TITLE
[IMPROVEMENT] Enabled clearButton on the email TextField at ForgotPassword

### DIFF
--- a/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
@@ -216,6 +216,7 @@ class LoginTableViewController: BaseTableViewController {
             textField.placeholder = "john.appleseed@apple.com"
             textField.textContentType = UITextContentType.emailAddress
             textField.keyboardType = .emailAddress
+            textField.clearButtonMode = .whileEditing
 
             _ = NotificationCenter.default.addObserver(forName: UITextField.textDidChangeNotification, object: textField, queue: OperationQueue.main) { _ in
                 sendAction.isEnabled = textField.text?.isValidEmail ?? false


### PR DESCRIPTION
Enabled clearButton at the TextField inside the Alert that is presented on forgotPasswordPressed action at LoginTableViewController.

@RocketChat/ios

![img_1a2c87e54ccf-1](https://user-images.githubusercontent.com/17304151/46327772-cfd1ac00-c5d9-11e8-9cce-5b7c33f696b4.jpeg)

Closes #2162 