### PR TITLE
[IMPROVEMENT] DataController fetching partial database messages and code improvements

### DIFF
--- a/Rocket.Chat/Controllers/Chat/MessagesViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewController.swift
@@ -101,7 +101,7 @@ final class MessagesViewController: RocketChatViewController {
 extension MessagesViewController {
 
     override func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        if viewModel.numberOfSections - indexPath.section < 5 {
+        if viewModel.numberOfSections - indexPath.section <= 5 {
             viewModel.fetchMessages(from: viewModel.oldestMessageDateBeingPresented)
         }
 

--- a/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
@@ -196,8 +196,9 @@ final class MessagesViewModel {
             var sections: [AnyChatSection] = []
 
             var previousSection: AnyChatSection?
-//            let messages = subscription?.fetchMessages(40, lastMessageDate: nil)
-            messagesQuery.forEach({ (object) in
+            let messages = subscription?.fetchMessages(40, lastMessageDate: nil) ?? []
+
+            messages.forEach({ (object) in
                 if let section = section(for: object, previous: previousSection) {
                     sections.append(section)
                     previousSection = section

--- a/Rocket.Chat/Managers/Model/MessageManager/MessageManager.swift
+++ b/Rocket.Chat/Managers/Model/MessageManager/MessageManager.swift
@@ -12,7 +12,7 @@ import RealmSwift
 public typealias MessagesHistoryCompletion = (Date?) -> Void
 
 struct MessageManager {
-    static let historySize = 60
+    static let historySize = 30
 }
 
 let kBlockedUsersIndentifiers = "kBlockedUsersIndentifiers"

--- a/Rocket.Chat/Models/Subscription/SubscriptionUtils.swift
+++ b/Rocket.Chat/Models/Subscription/SubscriptionUtils.swift
@@ -102,7 +102,7 @@ extension Subscription {
         for index in 0..<limit {
             let reversedIndex = totalMessagesIndexes - index
 
-            guard totalMessagesIndexes >= reversedIndex, reversedIndex > 0 else {
+            guard totalMessagesIndexes >= reversedIndex, reversedIndex >= 0 else {
                 return limitedMessages
             }
 

--- a/Rocket.Chat/Models/Subscription/SubscriptionUtils.swift
+++ b/Rocket.Chat/Models/Subscription/SubscriptionUtils.swift
@@ -98,8 +98,15 @@ extension Subscription {
             messages = messages.filter("createdAt < %@", lastMessageDate)
         }
 
-        for index in 0..<min(limit, messages.count) {
-            limitedMessages.append(messages[index])
+        let totalMessagesIndexes = messages.count - 1
+        for index in 0..<limit {
+            let reversedIndex = totalMessagesIndexes - index
+
+            guard totalMessagesIndexes >= reversedIndex, reversedIndex > 0 else {
+                return limitedMessages
+            }
+
+            limitedMessages.append(messages[reversedIndex])
         }
 
         return limitedMessages


### PR DESCRIPTION
@RocketChat/ios

This pull-request resolves couple of issues:

1. Load initial messages partially from database instead of all messages. Right now it's loading 30 messages every page;
2. It loads paginated result from database as well instead;