### PR TITLE
[IMPROVEMENT] Move data processing to the background, organize better the file and fixed many bugs related to the data control

### DIFF
--- a/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
@@ -331,20 +331,23 @@ final class MessagesViewModel {
         for (idx, object) in dataSorted.enumerated() {
             guard
                 idx < dataSortedMaxIndex,
-                var messageSection1 = object.object.base as? MessageSectionModel,
+                let messageSection1 = object.object.base as? MessageSectionModel,
                 let messageSection2 = dataSorted[idx + 1].object.base as? MessageSectionModel
-                else {
-                    continue
+            else {
+                continue
             }
 
             let message = messageSection1.message
             let previousMessage = messageSection2.message
 
-            messageSection1.isSequential = isSequential(message: message, previousMessage: previousMessage)
-            messageSection1.daySeparator = daySeparator(message: message, previousMessage: previousMessage)
+            let section = MessageSectionModel(
+                message: message,
+                daySeparator: daySeparator(message: message, previousMessage: previousMessage),
+                sequential: isSequential(message: message, previousMessage: previousMessage)
+            )
 
             dataSorted[idx] = AnyChatSection(MessageSection(
-                object: AnyDifferentiable(messageSection1),
+                object: AnyDifferentiable(section),
                 controllerContext: controllerContext
             ))
         }

--- a/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
@@ -311,8 +311,8 @@ final class MessagesViewModel {
             guard
                 let object1 = section1.object.base as? MessageSectionModel,
                 let object2 = section2.object.base as? MessageSectionModel
-                else {
-                    return false
+            else {
+                return false
             }
 
             return object1.messageDate.compare(object2.messageDate) == .orderedDescending

--- a/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
@@ -293,7 +293,7 @@ final class MessagesViewModel {
      separators and unread marks.
      */
     internal func updateData() {
-        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             self?.cacheDataSorted()
             self?.normalizeDataSorted()
 

--- a/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
@@ -174,7 +174,28 @@ final class MessagesViewModel {
     /**
      */
     internal func normalizeDataSorted() {
+        let dataSortedMaxIndex = dataSorted.count - 1
 
+        for (idx, object) in dataSorted.enumerated() {
+            guard
+                idx < dataSortedMaxIndex,
+                var messageSection1 = object.object.base as? MessageSectionModel,
+                let messageSection2 = dataSorted[idx + 1].object.base as? MessageSectionModel
+            else {
+                continue
+            }
+
+            let message = messageSection1.message
+            let previousMessage = messageSection2.message
+
+            messageSection1.isSequential = isSequential(message: message, previousMessage: previousMessage)
+            messageSection1.daySeparator = daySeparator(message: message, previousMessage: previousMessage)
+
+            dataSorted[idx] = AnyChatSection(MessageSection(
+                object: AnyDifferentiable(messageSection1),
+                controllerContext: controllerContext
+            ))
+        }
     }
 
     /**

--- a/Rocket.Chat/Models/ChatModels/MessageSectionModel.swift
+++ b/Rocket.Chat/Models/ChatModels/MessageSectionModel.swift
@@ -15,8 +15,8 @@ struct MessageSectionModel: Differentiable {
     let messageDate: Date
     let message: UnmanagedMessage
 
-    var daySeparator: Date?
-    var isSequential: Bool
+    let daySeparator: Date?
+    let isSequential: Bool
 
     let containsUnreadMessageIndicator: Bool
     var containsDateSeparator: Bool { return daySeparator != nil }

--- a/Rocket.Chat/Models/ChatModels/MessageSectionModel.swift
+++ b/Rocket.Chat/Models/ChatModels/MessageSectionModel.swift
@@ -15,8 +15,8 @@ struct MessageSectionModel: Differentiable {
     let messageDate: Date
     let message: UnmanagedMessage
 
-    let daySeparator: Date?
-    let isSequential: Bool
+    var daySeparator: Date?
+    var isSequential: Bool
 
     let containsUnreadMessageIndicator: Bool
     var containsDateSeparator: Bool { return daySeparator != nil }


### PR DESCRIPTION
@RocketChat/ios

This PR includes the following changes:

1. Move most of the data processing to the background thread;
2. Organize files & methods in the right position;
3. Only process the day markers and sequential once per data update; Also make the verifications in the whole dataset to make sure there's no duplicated separators;

**WARNING: There's still stuff being processed on the main thread and the CollectionView is being updated with animations, we'll resolve this problems in another PR.**
