### PR TITLE
[IMPROVEMENT] Chat theming performance

### DIFF
--- a/Rocket.Chat/Managers/MessageTextCacheManager.swift
+++ b/Rocket.Chat/Managers/MessageTextCacheManager.swift
@@ -8,10 +8,20 @@
 
 import Foundation
 
+final class MessageAttributedString {
+    let string: NSAttributedString
+    let theme: Theme?
+
+    init(string: NSAttributedString, theme: Theme?) {
+        self.string = string
+        self.theme = theme
+    }
+}
+
 final class MessageTextCacheManager {
 
     static let shared = MessageTextCacheManager()
-    let cache = NSCache<NSString, NSAttributedString>()
+    let cache = NSCache<NSString, MessageAttributedString>()
 
     internal func cachedKey(for identifier: String) -> NSString {
         return NSString(string: "\(identifier)-cachedattrstring")
@@ -55,7 +65,8 @@ final class MessageTextCacheManager {
         finalText.highlightMentions(mentions, currentUsername: username)
         finalText.highlightChannels(channels)
 
-        cache.setObject(finalText, forKey: key)
+        let cachedObject = MessageAttributedString(string: finalText, theme: theme)
+        cache.setObject(cachedObject, forKey: key)
         return finalText
     }
 
@@ -65,8 +76,8 @@ final class MessageTextCacheManager {
         var resultText: NSAttributedString?
         let key = cachedKey(for: identifier)
 
-        if let cachedVersion = cache.object(forKey: key) {
-            resultText = cachedVersion
+        if let cachedVersion = cache.object(forKey: key), cachedVersion.theme == theme {
+            resultText = cachedVersion.string
         } else if let result = update(for: message, with: theme) {
             resultText = result
         }

--- a/Rocket.Chat/Views/Chat/New Chat/Cells/BasicMessageCell.swift
+++ b/Rocket.Chat/Views/Chat/New Chat/Cells/BasicMessageCell.swift
@@ -96,12 +96,12 @@ final class BasicMessageCell: UICollectionViewCell, ChatCell, SizingCell {
         updateText()
     }
 
-    func updateText(force: Bool = false) {
+    func updateText() {
         guard let viewModel = viewModel?.base as? BasicMessageChatItem else {
             return
         }
 
-        if let message = force ? MessageTextCacheManager.shared.update(for: viewModel.message.managedObject, with: theme) : MessageTextCacheManager.shared.message(for: viewModel.message.managedObject, with: theme) {
+        if let message = MessageTextCacheManager.shared.message(for: viewModel.message.managedObject, with: theme) {
             if viewModel.message.temporary {
                 message.setFontColor(MessageTextFontAttributes.systemFontColor(for: theme))
             } else if viewModel.message.failed {

--- a/Rocket.Chat/Views/Chat/New Chat/Cells/BasicMessageCell.swift
+++ b/Rocket.Chat/Views/Chat/New Chat/Cells/BasicMessageCell.swift
@@ -196,7 +196,6 @@ extension BasicMessageCell {
         let theme = self.theme ?? .light
         date.textColor = theme.auxiliaryText
         username.textColor = theme.titleText
-        updateText(force: true)
+        updateText()
     }
-
 }

--- a/Rocket.Chat/Views/Chat/New Chat/Cells/SequentialMessageCell.swift
+++ b/Rocket.Chat/Views/Chat/New Chat/Cells/SequentialMessageCell.swift
@@ -54,12 +54,12 @@ final class SequentialMessageCell: UICollectionViewCell, ChatCell, SizingCell {
         updateText()
     }
 
-    func updateText(force: Bool = false) {
+    func updateText() {
         guard let viewModel = viewModel?.base as? SequentialMessageChatItem else {
             return
         }
 
-        if let message = force ? MessageTextCacheManager.shared.update(for: viewModel.message.managedObject, with: theme) : MessageTextCacheManager.shared.message(for: viewModel.message.managedObject, with: theme) {
+        if let message = MessageTextCacheManager.shared.message(for: viewModel.message.managedObject, with: theme) {
             if viewModel.message.temporary {
                 message.setFontColor(MessageTextFontAttributes.systemFontColor(for: theme))
             } else if viewModel.message.failed {
@@ -116,8 +116,10 @@ extension SequentialMessageCell: UIGestureRecognizerDelegate {
 }
 
 extension SequentialMessageCell {
+
     override func applyTheme() {
         super.applyTheme()
-        updateText(force: true)
+        updateText()
     }
+
 }


### PR DESCRIPTION
@RocketChat/ios

Now the theme is cached with the message to avoid repeated work. This allows us to not force update the message every time `applyTheme` is called.