### PR TITLE
[IMPROVEMENT] Minor improvements to theming on RCVC

### DIFF
--- a/Rocket.Chat/Controllers/Chat/MessagesViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewController.swift
@@ -78,14 +78,11 @@ final class MessagesViewController: RocketChatViewController {
             self.updateData(with: self.viewModel.dataNormalized)
         }
 
+        ThemeManager.addObserver(self)
+
         viewSubscriptionModel.onDataChanged = {
             // TODO: handle updates on the Subscription object, such like title view
         }
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        applyTheme()
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Rocket.Chat/Managers/MarkdownManager.swift
+++ b/Rocket.Chat/Managers/MarkdownManager.swift
@@ -19,7 +19,7 @@ struct MarkdownColorAttributes {
         quoteBackgroundColor = theme.bannerBackground
         codeBackgroundColor = theme.bannerBackground
         codeTextColor = theme.controlText
-        linkColor = theme.brightBlue
+        linkColor = theme.actionTintColor
     }
 }
 

--- a/Rocket.Chat/Resources/Assets.xcassets/Chat/Cells/Audio/Player Pause.imageset/Contents.json
+++ b/Rocket.Chat/Resources/Assets.xcassets/Chat/Cells/Audio/Player Pause.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Rocket.Chat/Resources/Assets.xcassets/Chat/Cells/Audio/Player Play.imageset/Contents.json
+++ b/Rocket.Chat/Resources/Assets.xcassets/Chat/Cells/Audio/Player Play.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Rocket.Chat/Resources/Assets.xcassets/Chat/Cells/Audio/Player Progress Button.imageset/Contents.json
+++ b/Rocket.Chat/Resources/Assets.xcassets/Chat/Cells/Audio/Player Progress Button.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Rocket.Chat/Theme/Theme.swift
+++ b/Rocket.Chat/Theme/Theme.swift
@@ -1,5 +1,5 @@
 //
-//  Themeable.swift
+//  Theme.swift
 //  Rocket.Chat
 //
 //  Created by Samar Sunkaria on 3/25/18.
@@ -28,7 +28,7 @@ class Theme: NSObject {
     @objc let auxiliaryText: UIColor
     @objc let tintColor: UIColor
     @objc let auxiliaryTintColor: UIColor
-    @objc let brightBlue: UIColor
+    @objc let actionTintColor: UIColor
     @objc let mutedAccent: UIColor
     @objc let strongAccent: UIColor
     let appearence: Appearence
@@ -65,7 +65,7 @@ class Theme: NSObject {
          auxiliaryText: UIColor,
          tintColor: UIColor,
          auxiliaryTintColor: UIColor,
-         brightBlue: UIColor,
+         actionTintColor: UIColor,
          mutedAccent: UIColor,
          strongAccent: UIColor?,
          appearence: Appearence) {
@@ -81,7 +81,7 @@ class Theme: NSObject {
         self.auxiliaryText = auxiliaryText
         self.tintColor = tintColor
         self.auxiliaryTintColor = auxiliaryTintColor
-        self.brightBlue = brightBlue
+        self.actionTintColor = actionTintColor
         self.mutedAccent = mutedAccent
 
         if let strongAccent = strongAccent {
@@ -105,7 +105,7 @@ class Theme: NSObject {
         auxiliaryText: #colorLiteral(red: 0.6117647059, green: 0.6352941176, blue: 0.6588235294, alpha: 1),
         tintColor: .RCBlue(),
         auxiliaryTintColor: #colorLiteral(red: 0.03921568627, green: 0.2666666667, blue: 0.4117647059, alpha: 1),
-        brightBlue: #colorLiteral(red: 0.1137254902, green: 0.4549019608, blue: 0.9607843137, alpha: 1),
+        actionTintColor: #colorLiteral(red: 0.1137254902, green: 0.4549019608, blue: 0.9607843137, alpha: 1),
         mutedAccent: #colorLiteral(red: 0.7960784314, green: 0.7960784314, blue: 0.8, alpha: 1),
         strongAccent: nil,
         appearence: .light
@@ -123,7 +123,7 @@ class Theme: NSObject {
         auxiliaryText: #colorLiteral(red: 0.5732198682, green: 0.5927470883, blue: 0.638310602, alpha: 1),
         tintColor: #colorLiteral(red: 0.1137254902, green: 0.4549019608, blue: 0.9607843137, alpha: 1),
         auxiliaryTintColor: #colorLiteral(red: 0.8039215803, green: 0.8039215803, blue: 0.8039215803, alpha: 1),
-        brightBlue: #colorLiteral(red: 0.1137254902, green: 0.4549019608, blue: 0.9607843137, alpha: 1),
+        actionTintColor: #colorLiteral(red: 0.1137254902, green: 0.4549019608, blue: 0.9607843137, alpha: 1),
         mutedAccent: #colorLiteral(red: 0.1672673633, green: 0.1672673633, blue: 0.1769603646, alpha: 1),
         strongAccent: nil,
         appearence: .dark
@@ -139,9 +139,9 @@ class Theme: NSObject {
         bodyText: #colorLiteral(red: 0.9111283446, green: 0.9229556015, blue: 0.9294117647, alpha: 1),
         controlText: #colorLiteral(red: 0.8549193462, green: 0.8697612629, blue: 0.903159703, alpha: 1),
         auxiliaryText: #colorLiteral(red: 0.6980392157, green: 0.7224261515, blue: 0.7773035386, alpha: 1),
-        tintColor: #colorLiteral(red: 0.1176899746, green: 0.6068716645, blue: 0.9971964955, alpha: 1),
+        tintColor: #colorLiteral(red: 0.1176470588, green: 0.6078431373, blue: 0.9960784314, alpha: 1),
         auxiliaryTintColor: #colorLiteral(red: 0.8039215803, green: 0.8039215803, blue: 0.8039215803, alpha: 1),
-        brightBlue: #colorLiteral(red: 0.1137254902, green: 0.4549019608, blue: 0.9607843137, alpha: 1),
+        actionTintColor: #colorLiteral(red: 0.1176470588, green: 0.631372549, blue: 0.9960784314, alpha: 1),
         mutedAccent: #colorLiteral(red: 0.156862745, green: 0.156862745, blue: 0.16, alpha: 1),
         strongAccent: nil,
         appearence: .dark

--- a/Rocket.Chat/Theme/Theme.swift
+++ b/Rocket.Chat/Theme/Theme.swift
@@ -114,7 +114,7 @@ class Theme: NSObject {
     static let dark = Theme(
         backgroundColor: #colorLiteral(red: 0.01176470588, green: 0.0431372549, blue: 0.1058823529, alpha: 1),
         focusedBackground: #colorLiteral(red: 0.0431372549, green: 0.09411764706, blue: 0.1725490196, alpha: 1),
-        chatComponentBackground: #colorLiteral(red: 0.9098039216, green: 0.9490196078, blue: 1, alpha: 0.1),
+        chatComponentBackground: #colorLiteral(red: 0.1007164493, green: 0.1329644322, blue: 0.1973000765, alpha: 1),
         auxiliaryBackground: #colorLiteral(red: 0.02950551261, green: 0.06437566387, blue: 0.1180220504, alpha: 1),
         bannerBackground: #colorLiteral(red: 0.05490196078, green: 0.1215686275, blue: 0.2196078431, alpha: 1),
         titleText: #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1),
@@ -132,7 +132,7 @@ class Theme: NSObject {
     static let black = Theme(
         backgroundColor: #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1),
         focusedBackground: #colorLiteral(red: 0.05332512842, green: 0.05332512842, blue: 0.05332512842, alpha: 1),
-        chatComponentBackground: #colorLiteral(red: 0.9098039216, green: 0.9490196078, blue: 1, alpha: 0.1),
+        chatComponentBackground: #colorLiteral(red: 0.08947405964, green: 0.09412670881, blue: 0.1027644202, alpha: 1),
         auxiliaryBackground: #colorLiteral(red: 0.03411494007, green: 0.03411494007, blue: 0.03411494007, alpha: 1),
         bannerBackground: #colorLiteral(red: 0.1215686275, green: 0.137254902, blue: 0.1607843137, alpha: 1),
         titleText: #colorLiteral(red: 0.9785086513, green: 0.9786720872, blue: 0.9784870744, alpha: 1),

--- a/Rocket.Chat/Theme/ThemeableViews.swift
+++ b/Rocket.Chat/Theme/ThemeableViews.swift
@@ -84,7 +84,7 @@ extension UIView: ThemeProvider {
             auxiliaryText: theme.auxiliaryText,
             tintColor: theme.tintColor,
             auxiliaryTintColor: theme.auxiliaryTintColor,
-            brightBlue: theme.brightBlue,
+            actionTintColor: theme.actionTintColor,
             mutedAccent: theme.mutedAccent,
             strongAccent: theme.strongAccent,
             appearence: theme.appearence
@@ -256,7 +256,7 @@ extension UITextView {
     override func applyTheme() {
         super.applyTheme()
         guard let theme = theme else { return }
-        tintColor = theme.brightBlue
+        tintColor = theme.actionTintColor
         applyThemeFromRuntimeAttributes()
     }
 }
@@ -315,6 +315,15 @@ extension UIScrollView {
         super.applyTheme()
         guard let theme = theme else { return }
         indicatorStyle = theme.appearence.scrollViewIndicatorStyle
+        applyThemeFromRuntimeAttributes()
+    }
+}
+
+extension UISlider {
+    override func applyTheme() {
+        super.applyTheme()
+        guard let theme = theme else { return }
+        tintColor = theme.actionTintColor
         applyThemeFromRuntimeAttributes()
     }
 }

--- a/Rocket.Chat/Views/Chat/New Chat/Cells/BaseAudioMessageCell.swift
+++ b/Rocket.Chat/Views/Chat/New Chat/Cells/BaseAudioMessageCell.swift
@@ -53,12 +53,12 @@ class BaseAudioMessageCell: BaseMessageCell {
 
         if playing {
             let image = UIImage(named: "Player Pause")?.withRenderingMode(.alwaysTemplate)
-            buttonPlay.imageView?.tintColor = theme.brightBlue
+            buttonPlay.imageView?.tintColor = theme.actionTintColor
             buttonPlay.setImage(image, for: .normal)
             player?.play()
         } else {
             let image = UIImage(named: "Player Play")?.withRenderingMode(.alwaysTemplate)
-            buttonPlay.imageView?.tintColor = theme.brightBlue
+            buttonPlay.imageView?.tintColor = theme.actionTintColor
             buttonPlay.setImage(image, for: .normal)
             player?.stop()
         }

--- a/Rocket.Chat/Views/Chat/New Chat/Cells/MessageActionsCell.swift
+++ b/Rocket.Chat/Views/Chat/New Chat/Cells/MessageActionsCell.swift
@@ -48,6 +48,6 @@ extension MessageActionsCell {
     override func applyTheme() {
         super.applyTheme()
         replyButton.setTitleColor(.white, for: .normal)
-        replyButton.backgroundColor = theme?.brightBlue
+        replyButton.backgroundColor = theme?.actionTintColor
     }
 }

--- a/Rocket.Chat/Views/Chat/New Chat/Cells/MessageURLCell.swift
+++ b/Rocket.Chat/Views/Chat/New Chat/Cells/MessageURLCell.swift
@@ -102,7 +102,7 @@ extension MessageURLCell {
         let theme = self.theme ?? .light
         containerView.backgroundColor = theme.chatComponentBackground
         host.textColor = theme.auxiliaryText
-        title.textColor = theme.brightBlue
+        title.textColor = theme.actionTintColor
         subtitle.textColor = theme.controlText
     }
 }

--- a/Rocket.Chat/Views/Chat/New Chat/Cells/QuoteCell.swift
+++ b/Rocket.Chat/Views/Chat/New Chat/Cells/QuoteCell.swift
@@ -93,7 +93,7 @@ extension QuoteCell {
 
         let theme = self.theme ?? .light
         containerView.backgroundColor = theme.chatComponentBackground
-        username.textColor = theme.brightBlue
+        username.textColor = theme.actionTintColor
         text.textColor = theme.bodyText
     }
 }

--- a/Rocket.Chat/Views/Chat/New Chat/Cells/QuoteMessageCell.swift
+++ b/Rocket.Chat/Views/Chat/New Chat/Cells/QuoteMessageCell.swift
@@ -117,7 +117,7 @@ extension QuoteMessageCell {
         containerView.backgroundColor = theme.chatComponentBackground
         messageUsername.textColor = theme.titleText
         date.textColor = theme.auxiliaryText
-        username.textColor = theme.brightBlue
+        username.textColor = theme.actionTintColor
         text.textColor = theme.bodyText
     }
 }

--- a/Rocket.Chat/Views/Subscriptions/ServersListView.swift
+++ b/Rocket.Chat/Views/Subscriptions/ServersListView.swift
@@ -220,7 +220,7 @@ extension ServersListView {
             auxiliaryText: theme.auxiliaryText,
             tintColor: theme.tintColor,
             auxiliaryTintColor: theme.auxiliaryTintColor,
-            brightBlue: theme.brightBlue,
+            actionTintColor: theme.actionTintColor,
             mutedAccent: theme.mutedAccent,
             strongAccent: theme.strongAccent,
             appearence: theme.appearence

--- a/Rocket.Chat/Views/Subscriptions/SubscriptionsSortingHeaderView.swift
+++ b/Rocket.Chat/Views/Subscriptions/SubscriptionsSortingHeaderView.swift
@@ -23,7 +23,7 @@ class SubscriptionsSortingHeaderView: UIView {
             auxiliaryText: theme.auxiliaryText,
             tintColor: theme.tintColor,
             auxiliaryTintColor: theme.auxiliaryTintColor,
-            brightBlue: theme.brightBlue,
+            actionTintColor: theme.actionTintColor,
             mutedAccent: theme.mutedAccent,
             strongAccent: theme.strongAccent,
             appearence: theme.appearence

--- a/Rocket.Chat/Views/Subscriptions/SubscriptionsSortingView.swift
+++ b/Rocket.Chat/Views/Subscriptions/SubscriptionsSortingView.swift
@@ -209,7 +209,7 @@ extension SubscriptionsSortingView {
             auxiliaryText: theme.auxiliaryText,
             tintColor: theme.tintColor,
             auxiliaryTintColor: theme.auxiliaryTintColor,
-            brightBlue: theme.brightBlue,
+            actionTintColor: theme.actionTintColor,
             mutedAccent: theme.mutedAccent,
             strongAccent: theme.strongAccent,
             appearence: theme.appearence


### PR DESCRIPTION
@RocketChat/ios

- Add MessagesViewController as an observer for theming
- Use colors without transparency to improve performance
- Rename brightBlue to actionTintColor so that it matches the naming convention