### PR TITLE
[IMPROVEMENT] Performance improvements, code simplification & prefetch one more page from database

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -158,7 +158,7 @@ CHECKOUT OPTIONS:
     :commit: c34d9ccef689c55b9eae69f3c65283da8d8b0c6c
     :git: https://github.com/RocketChat/RCMarkdownParser.git
   RocketChatViewController:
-    :commit: 1bc096d666b541a86914f1080d1f2d3e4247bf30
+    :commit: 654a877ab748c92ad171b80f2143183b9eabfeb9
     :git: https://github.com/RocketChat/RocketChatViewController
   SimpleImageViewer:
     :commit: 8222c338de0f285ca0c2d556c5d8dedd4a365b52

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -158,7 +158,7 @@ CHECKOUT OPTIONS:
     :commit: c34d9ccef689c55b9eae69f3c65283da8d8b0c6c
     :git: https://github.com/RocketChat/RCMarkdownParser.git
   RocketChatViewController:
-    :commit: 654a877ab748c92ad171b80f2143183b9eabfeb9
+    :commit: 0e9a630ed072882d4893a6216d5a22d1af8b0c2c
     :git: https://github.com/RocketChat/RocketChatViewController
   SimpleImageViewer:
     :commit: 8222c338de0f285ca0c2d556c5d8dedd4a365b52

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -158,7 +158,7 @@ CHECKOUT OPTIONS:
     :commit: c34d9ccef689c55b9eae69f3c65283da8d8b0c6c
     :git: https://github.com/RocketChat/RCMarkdownParser.git
   RocketChatViewController:
-    :commit: 1bc096d666b541a86914f1080d1f2d3e4247bf30
+    :commit: 654a877ab748c92ad171b80f2143183b9eabfeb9
     :git: https://github.com/RocketChat/RocketChatViewController
   SimpleImageViewer:
     :commit: 8222c338de0f285ca0c2d556c5d8dedd4a365b52

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -158,7 +158,7 @@ CHECKOUT OPTIONS:
     :commit: c34d9ccef689c55b9eae69f3c65283da8d8b0c6c
     :git: https://github.com/RocketChat/RCMarkdownParser.git
   RocketChatViewController:
-    :commit: 654a877ab748c92ad171b80f2143183b9eabfeb9
+    :commit: 0e9a630ed072882d4893a6216d5a22d1af8b0c2c
     :git: https://github.com/RocketChat/RocketChatViewController
   SimpleImageViewer:
     :commit: 8222c338de0f285ca0c2d556c5d8dedd4a365b52

--- a/Pods/RocketChatViewController/Composer/Classes/Addons/Hints/HintsView.swift
+++ b/Pods/RocketChatViewController/Composer/Classes/Addons/Hints/HintsView.swift
@@ -53,9 +53,9 @@ public class HintsView: UITableView {
         didSet {
             invalidateIntrinsicContentSize()
 
-            /*UIView.animate(withDuration: 0.2) {
+            UIView.animate(withDuration: 0.2) {
                 self.layoutIfNeeded()
-            }*/
+            }
         }
     }
 
@@ -168,7 +168,7 @@ extension HintsView: UITableViewDelegate {
             return
         }
 
-        header.backgroundView?.backgroundColor = .white
+        header.backgroundView?.backgroundColor = backgroundColor
         header.textLabel?.text = currentDelegate.title(for: self)
         header.textLabel?.textColor = #colorLiteral(red: 0.6196078431, green: 0.6352941176, blue: 0.6588235294, alpha: 1)
     }

--- a/Pods/RocketChatViewController/Composer/Classes/Addons/Hints/TextHintCell.swift
+++ b/Pods/RocketChatViewController/Composer/Classes/Addons/Hints/TextHintCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class TextHintCell<PrefixView: UIView>: UITableViewCell {
+open class TextHintCell<PrefixView: UIView>: UITableViewCell {
     /*
      The hint's prefix view
      */
@@ -38,7 +38,7 @@ public class TextHintCell<PrefixView: UIView>: UITableViewCell {
         $0.adjustsFontForContentSizeCategory = true
     }
 
-    public override var intrinsicContentSize: CGSize {
+    open override var intrinsicContentSize: CGSize {
         let height = layoutMargins.top + layoutMargins.bottom + valueLabel.intrinsicContentSize.height
         return CGSize(width: super.intrinsicContentSize.width, height: height)
     }

--- a/Pods/RocketChatViewController/Composer/Classes/Addons/Hints/UserHintCell.swift
+++ b/Pods/RocketChatViewController/Composer/Classes/Addons/Hints/UserHintCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class UserHintCell<AvatarView: UIView>: UITableViewCell {
+open class UserHintCell<AvatarView: UIView>: UITableViewCell {
     /*
      The user's avatar image view
      */
@@ -46,11 +46,11 @@ public class UserHintCell<AvatarView: UIView>: UITableViewCell {
         $0.textColor = Consts.usernameColor
     }
 
-    public override var intrinsicContentSize: CGSize {
+    open override var intrinsicContentSize: CGSize {
         let height = layoutMargins.top +
-                     layoutMargins.bottom +
-                     nameLabel.intrinsicContentSize.height +
-                     usernameLabel.intrinsicContentSize.height
+            layoutMargins.bottom +
+            nameLabel.intrinsicContentSize.height +
+            usernameLabel.intrinsicContentSize.height
 
         return CGSize(width: super.intrinsicContentSize.width, height: height)
     }
@@ -94,7 +94,7 @@ public class UserHintCell<AvatarView: UIView>: UITableViewCell {
             avatarView.centerYAnchor.constraint(equalTo: centerYAnchor),
 
             // nameLabel
-            
+
             nameLabel.leadingAnchor.constraint(equalTo: avatarView.trailingAnchor, constant: Consts.nameLeading),
             nameLabel.bottomAnchor.constraint(equalTo: centerYAnchor, constant: Consts.nameBottom),
 

--- a/Pods/RocketChatViewController/RocketChatViewController/Classes/RocketChatViewController.swift
+++ b/Pods/RocketChatViewController/RocketChatViewController/Classes/RocketChatViewController.swift
@@ -215,7 +215,7 @@ open class RocketChatViewController: UICollectionViewController {
     private let updateDataQueue: OperationQueue = {
         let operationQueue = OperationQueue()
         operationQueue.maxConcurrentOperationCount = 1
-        operationQueue.qualityOfService = .utility
+        operationQueue.qualityOfService = .userInitiated
 
         return operationQueue
     }()

--- a/Pods/RocketChatViewController/RocketChatViewController/Classes/RocketChatViewController.swift
+++ b/Pods/RocketChatViewController/RocketChatViewController/Classes/RocketChatViewController.swift
@@ -148,7 +148,7 @@ public protocol ChatCell {
 }
 
 public protocol ChatDataUpdateDelegate: class {
-    func didUpdateChatData(newData: [AnyChatSection])
+    func didUpdateChatData(newData: [AnyChatSection], updatedItems: [AnyHashable])
 }
 
 /**
@@ -215,7 +215,7 @@ open class RocketChatViewController: UICollectionViewController {
     private let updateDataQueue: OperationQueue = {
         let operationQueue = OperationQueue()
         operationQueue.maxConcurrentOperationCount = 1
-        operationQueue.qualityOfService = .userInitiated
+        operationQueue.qualityOfService = .userInteractive
 
         return operationQueue
     }()
@@ -266,22 +266,38 @@ open class RocketChatViewController: UICollectionViewController {
 
     open func updateData(with target: [ArraySection<AnyChatSection, AnyChatItem>]) {
         updateDataQueue.addOperation { [weak self] in
-            guard
-                let strongSelf = self,
-                let collectionView = strongSelf.collectionView
-            else {
-                return
-            }
-
-            let changeset = StagedChangeset(source: strongSelf.internalData, target: target)
-
             DispatchQueue.main.async {
+                guard
+                    let strongSelf = self,
+                    let collectionView = strongSelf.collectionView
+                else {
+                    return
+                }
+
                 UIView.performWithoutAnimation {
-                    collectionView.reload(using: changeset, interrupt: { $0.changeCount > 100 }) { newData in
+                    let changeset = StagedChangeset(source: strongSelf.internalData, target: target)
+                    collectionView.reload(using: changeset, interrupt: { $0.changeCount > 100 }) { newData, changes in
                         strongSelf.internalData = newData
 
                         let newSections = newData.map { $0.model }
-                        strongSelf.dataUpdateDelegate?.didUpdateChatData(newData: newSections)
+                        var updatedItems = [AnyHashable]()
+
+                        for (sectionIndex, section) in newSections.enumerated() {
+                            guard let changes = changes else {
+                                break
+                            }
+
+                            if changes.sectionUpdated.contains(sectionIndex) {
+                                for (itemIndex, item) in changes.elementUpdated.enumerated() {
+                                    if item.section == sectionIndex {
+                                        let elementIdentifier = section.viewModels()[itemIndex].differenceIdentifier
+                                        updatedItems.append(elementIdentifier)
+                                    }
+                                }
+                            }
+                        }
+
+                        strongSelf.dataUpdateDelegate?.didUpdateChatData(newData: newSections, updatedItems: updatedItems)
 
                         assert(newSections.count == newData.count)
                     }

--- a/Pods/RocketChatViewController/RocketChatViewController/Classes/UIKitExtension.swift
+++ b/Pods/RocketChatViewController/RocketChatViewController/Classes/UIKitExtension.swift
@@ -26,21 +26,21 @@ public extension UICollectionView {
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
-        setData: (C) -> Void
+        setData: (C, Changeset<C>?) -> Void
         ) {
         if case .none = window, let data = stagedChangeset.last?.data {
-            setData(data)
+            setData(data, nil)
             return reloadData()
         }
 
         for changeset in stagedChangeset {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
-                setData(data)
+                setData(data, changeset)
                 return reloadData()
             }
 
             performBatchUpdates({
-                setData(changeset.data)
+                setData(changeset.data, changeset)
 
                 if !changeset.sectionDeleted.isEmpty {
                     deleteSections(IndexSet(changeset.sectionDeleted))

--- a/Rocket.Chat/Controllers/Chat/MessagesViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewController.swift
@@ -197,6 +197,17 @@ final class MessagesViewController: RocketChatViewController {
         }
     }
 
+    // MARK: Pagination
+
+    func loadNextPageIfNeeded() {
+        guard let collectionView = collectionView else { return }
+
+        let bottomEdge = collectionView.contentOffset.y + collectionView.frame.size.height
+        if bottomEdge >= collectionView.contentSize.height {
+            viewModel.fetchMessages(from: viewModel.oldestMessageDateBeingPresented)
+        }
+    }
+
     // MARK: TitleView
 
     private func setupTitleView() {
@@ -255,14 +266,6 @@ extension MessagesViewController {
         return .zero
     }
 
-    override func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        if viewModel.numberOfSections - indexPath.section <= 5 {
-            viewModel.fetchMessages(from: viewModel.oldestMessageDateBeingPresented)
-        }
-
-        super.collectionView(collectionView, willDisplay: cell, forItemAt: indexPath)
-    }
-
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         guard let item = viewModel.item(for: indexPath) else {
             return .zero
@@ -308,6 +311,7 @@ extension MessagesViewController {
 
     override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         resetScrollToBottomButtonPosition()
+        loadNextPageIfNeeded()
     }
 
 }

--- a/Rocket.Chat/Controllers/Chat/MessagesViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewController.swift
@@ -300,7 +300,7 @@ extension MessagesViewController {
 
 extension MessagesViewController: ChatDataUpdateDelegate {
 
-    func didUpdateChatData(newData: [AnyChatSection]) {
+    func didUpdateChatData(newData: [AnyChatSection], updatedItems: [AnyHashable]) {
         viewModel.data = newData
         viewModel.updateData(shouldUpdateUI: false)
     }

--- a/Rocket.Chat/Controllers/Chat/MessagesViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewController.swift
@@ -203,7 +203,7 @@ final class MessagesViewController: RocketChatViewController {
         guard let collectionView = collectionView else { return }
 
         let bottomEdge = collectionView.contentOffset.y + collectionView.frame.size.height
-        if bottomEdge >= collectionView.contentSize.height {
+        if bottomEdge >= collectionView.contentSize.height - 200 {
             viewModel.fetchMessages(from: viewModel.oldestMessageDateBeingPresented)
         }
     }

--- a/Rocket.Chat/Controllers/Chat/MessagesViewControllerComposerDelegate.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewControllerComposerDelegate.swift
@@ -46,7 +46,7 @@ extension MessagesViewController: ComposerViewExpandedDelegate {
         switch hint {
         case .user(let user):
             let cell = hintsView.dequeueReusableCell(withType: UserHintCell<AvatarView>.self)
-            cell.avatarView.user = user
+            cell.avatarView.username = user.username
             cell.usernameLabel.text = user.username
             cell.nameLabel.text = user.name
             return cell

--- a/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
@@ -307,7 +307,8 @@ final class MessagesViewModel {
                 return
             }
 
-            let messagesFromDatabase = subscriptionValid.fetchMessages(20, lastMessageDate: oldestMessage)
+            let pageSize = self.data.isEmpty || !prepareAnotherPage ? 30 : 10
+            let messagesFromDatabase = subscriptionValid.fetchMessages(pageSize, lastMessageDate: oldestMessage)
             messagesFromDatabase.forEach {
                 guard let message = $0.validated()?.unmanaged else { return }
 
@@ -330,7 +331,7 @@ final class MessagesViewModel {
                 self.updateData()
 
                 if prepareAnotherPage {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: { [weak self] in
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: { [weak self] in
                         self?.fetchMessages(
                             from: self?.oldestMessageDateBeingPresented,
                             prepareAnotherPage: false

--- a/Rocket.Chat/Controllers/Preferences/PreferencesViewController.swift
+++ b/Rocket.Chat/Controllers/Preferences/PreferencesViewController.swift
@@ -149,7 +149,7 @@ final class PreferencesViewController: BaseTableViewController {
     }
 
     private func updateUserInformation() {
-        avatarView.user = viewModel.user
+        avatarView.username = viewModel.user?.username
         labelProfileName.text = viewModel.userName
         labelProfileStatus.text = viewModel.userStatus.lowercased()
     }

--- a/Rocket.Chat/Controllers/Preferences/Profile/EditProfileTableViewController.swift
+++ b/Rocket.Chat/Controllers/Preferences/Profile/EditProfileTableViewController.swift
@@ -188,7 +188,7 @@ final class EditProfileTableViewController: BaseTableViewController, MediaPicker
     }
 
     func bindUserData() {
-        avatarView.user = user
+        avatarView.username = user?.username
         name.text = user?.name
         username.text = user?.username
         email.text = user?.emails.first?.email

--- a/Rocket.Chat/Managers/Model/MessageManager/MessageManager.swift
+++ b/Rocket.Chat/Managers/Model/MessageManager/MessageManager.swift
@@ -45,31 +45,12 @@ extension MessageManager {
             }
 
             let list = response.result["result"]["messages"].array
-            let subscriptionIdentifier = subscription.identifier
 
             currentRealm?.execute({ (realm) in
-                guard let detachedSubscription = realm.object(
-                    ofType: Subscription.self,
-                    forPrimaryKey: subscriptionIdentifier
-                ) else {
-                    return
-                }
-
                 list?.forEach { object in
-                    let mockNewMessage = Message()
-                    mockNewMessage.map(object, realm: realm)
-
-                    if let existingMessage = realm.object(ofType: Message.self, forPrimaryKey: object["identifier"].stringValue) {
-                        if existingMessage.updatedAt?.timeIntervalSince1970 == mockNewMessage.updatedAt?.timeIntervalSince1970 {
-                            return
-                        }
-                    }
-
-                    let message = Message.getOrCreate(realm: realm, values: object, updates: { (object) in
-                        object?.rid = detachedSubscription.rid
-                    })
-
+                    let message = Message.getOrCreate(realm: realm, values: object, updates: nil)
                     realm.add(message, update: true)
+
                     lastMessageDate = message.createdAt
                 }
             }, completion: {

--- a/Rocket.Chat/Models/User/UnmanagedUser.swift
+++ b/Rocket.Chat/Models/User/UnmanagedUser.swift
@@ -18,6 +18,7 @@ struct UnmanagedUser: UnmanagedObject, Equatable {
     var privateStatus: String
     var status: UserStatus
     var utcOffset: Double
+    var avatarURL: URL?
 
     var managedObject: User? {
         return User.find(withIdentifier: identifier)?.validated()
@@ -39,6 +40,7 @@ extension UnmanagedUser {
         privateStatus = user.privateStatus
         status = user.status
         utcOffset = user.utcOffset
+        avatarURL = user.avatarURL()
     }
 }
 

--- a/Rocket.Chat/Models/User/User.swift
+++ b/Rocket.Chat/Models/User/User.swift
@@ -54,3 +54,33 @@ extension User: UnmanagedConvertible {
         return UnmanagedUser(self)
     }
 }
+
+// MARK: Avatar URL
+
+extension User {
+
+    func avatarURL(_ auth: Auth? = nil) -> URL? {
+        guard
+            !isInvalidated,
+            let username = username,
+            let auth = auth ?? AuthManager.isAuthenticated()
+        else {
+            return nil
+        }
+
+        return User.avatarURL(forUsername: username, auth: auth)
+    }
+
+    static func avatarURL(forUsername username: String, auth: Auth? = nil) -> URL? {
+        guard
+            let auth = auth ?? AuthManager.isAuthenticated(),
+            let baseURL = auth.baseURL(),
+            let encodedUsername = username.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
+        else {
+            return nil
+        }
+
+        return URL(string: "\(baseURL)/avatar/\(encodedUsername)?format=jpeg")
+    }
+
+}

--- a/Rocket.Chat/Models/User/UserUtils.swift
+++ b/Rocket.Chat/Models/User/UserUtils.swift
@@ -29,18 +29,6 @@ extension User {
         return username
     }
 
-    func avatarURL(_ auth: Auth? = nil) -> URL? {
-        guard
-            !isInvalidated,
-            let username = username,
-            let auth = auth ?? AuthManager.isAuthenticated()
-        else {
-            return nil
-        }
-
-        return User.avatarURL(forUsername: username, auth: auth)
-    }
-
     func canViewAdminPanel(realm: Realm? = Realm.current) -> Bool {
         return hasPermission(.viewPrivilegedSetting, realm: realm) ||
             hasPermission(.viewStatistics, realm: realm) ||
@@ -48,15 +36,4 @@ extension User {
             hasPermission(.viewRoomAdministration, realm: realm)
     }
 
-    static func avatarURL(forUsername username: String, auth: Auth? = nil) -> URL? {
-        guard
-            let auth = auth ?? AuthManager.isAuthenticated(),
-            let baseURL = auth.baseURL(),
-            let encodedUsername = username.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
-        else {
-            return nil
-        }
-
-        return URL(string: "\(baseURL)/avatar/\(encodedUsername)?format=jpeg")
-    }
 }

--- a/Rocket.Chat/Views/Avatar/AvatarView.swift
+++ b/Rocket.Chat/Views/Avatar/AvatarView.swift
@@ -33,22 +33,6 @@ final class AvatarView: UIView {
         }
     }
 
-    var subscription: Subscription? {
-        didSet {
-            if subscription != nil {
-                updateAvatar()
-            }
-        }
-    }
-
-    var user: User? {
-        didSet {
-            if user != nil {
-                updateAvatar()
-            }
-        }
-    }
-
     var emoji: String? {
         didSet {
             if emoji != nil {
@@ -78,17 +62,12 @@ final class AvatarView: UIView {
             backgroundColor = .clear
         } else if let avatarURL = avatarURL {
             imageURL = avatarURL
-        } else if let user = user?.validated() {
-            setAvatarWithInitials(forUsername: user.username)
+        } else if let username = username {
+            setAvatarWithInitials(forUsername: username)
 
-            if let avatarURL = user.avatarURL() {
+            if let avatarURL = User.avatarURL(forUsername: username) {
                 imageURL = avatarURL
             }
-        } else if let avatarURL = subscription?.avatarURL() {
-            setAvatarWithInitials(forUsername: subscription?.name)
-            imageURL = avatarURL
-        } else if let username = username, let avatarURL = User.avatarURL(forUsername: username) {
-            imageURL = avatarURL
         }
     }
 
@@ -202,8 +181,7 @@ final class AvatarView: UIView {
         avatarPlaceholder = nil
         avatarURL = nil
         imageURL = nil
-        user = nil
-        subscription = nil
+        username = nil
         emoji = nil
 
         imageView.image = nil

--- a/Rocket.Chat/Views/Cells/Chat/ChatDirectMessageHeaderCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatDirectMessageHeaderCell.swift
@@ -43,7 +43,7 @@ final class ChatDirectMessageHeaderCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
 
-        avatarView.user = nil
+        avatarView.username = nil
         labelUser.text = ""
         labelStartConversation.text = ""
     }
@@ -56,7 +56,7 @@ final class ChatDirectMessageHeaderCell: UICollectionViewCell {
         }
 
         labelUser.text = user.displayName()
-        avatarView.user = user
+        avatarView.username = user.username
 
         let startText = localized("chat.dm.start_conversation")
         labelStartConversation.text = String(format: startText, user.displayName())

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageCell.swift
@@ -245,7 +245,7 @@ final class ChatMessageCell: UICollectionViewCell {
         }
 
         avatarView.emoji = message.emoji
-        avatarView.user = message.user
+        avatarView.username = message.user?.username
 
         if let avatar = message.avatar {
             avatarView.avatarURL = URL(string: avatar)

--- a/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoUserCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/Info/ChannelInfoUserCell.swift
@@ -23,7 +23,7 @@ final class ChannelInfoUserCell: UITableViewCell, ChannelInfoCellProtocol {
         didSet {
             labelTitle.text = data?.user?.name
             labelSubtitle.text = data?.user?.username
-            avatarView.user = data?.user
+            avatarView.username = data?.user?.username
         }
     }
 

--- a/Rocket.Chat/Views/Cells/Chat/Info/MemberCell.swift
+++ b/Rocket.Chat/Views/Cells/Chat/Info/MemberCell.swift
@@ -74,7 +74,7 @@ final class MemberCell: UITableViewCell {
         didSet {
             statusView.backgroundColor = data?.statusColor
             nameLabel.text = data?.nameText
-            avatarView.user = data?.member
+            avatarView.username = data?.member.username
         }
     }
 

--- a/Rocket.Chat/Views/Cells/Subscription/BaseSubscriptionCell.swift
+++ b/Rocket.Chat/Views/Cells/Subscription/BaseSubscriptionCell.swift
@@ -80,11 +80,9 @@ class BaseSubscriptionCell: SwipeTableViewCell, SubscriptionCellProtocol {
         updateStatus(subscription: subscription, user: user)
 
         if let user = user {
-            avatarView.subscription = nil
-            avatarView.user = user
+            avatarView.username = user.username
         } else {
-            avatarView.user = nil
-            avatarView.subscription = subscription
+            avatarView.username = subscription.name
         }
 
         labelName.text = subscription.displayName()

--- a/Rocket.Chat/Views/Chat/New Chat/Cells/BaseMessageCell.swift
+++ b/Rocket.Chat/Views/Chat/New Chat/Cells/BaseMessageCell.swift
@@ -39,10 +39,12 @@ class BaseMessageCell: UICollectionViewCell, ChatCell {
         date.text = viewModel.dateFormatted
         username.text = user.username
         avatarView.emoji = viewModel.emoji
-        avatarView.user = user.managedObject
+        avatarView.username = user.username
 
         if let avatar = viewModel.avatar {
             avatarView.avatarURL = URL(string: avatar)
+        } else {
+            avatarView.avatarURL = user.avatarURL
         }
     }
 


### PR DESCRIPTION
@RocketChat/ios

This pull-request was suppose to fix the empty cells, but I still didn't figure out what's happening (still investigating, but will send another PR once this is fixed). For now, this one includes:

- Removed all managed objects from AvatarView;
- Reduced the complexity of AvatarView to rely only in one String and one URL object;
- Prepare another page from database after loading one page from scrolling to the top and present it;
- Changed the size of the page to 10 on scrolling and 30 on first page and pre-fetched page;
- Changed the method being used to start pagination to scrollView delegate instead of UICollectionView method (willDisplay:);
