### PR TITLE
[CRASH] AuthTableViewController.swift line 128 AuthTableViewController.viewDidLoad()

### DIFF
--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -82,7 +82,7 @@ final class AuthTableViewController: BaseTableViewController {
     var shouldRetrieveLoginServices = false
 
     var serverVersion: Version?
-    var serverURL: URL!
+    var serverURL: URL?
     var serverPublicSettings: AuthSettings?
 
     var api: API? {
@@ -125,7 +125,7 @@ final class AuthTableViewController: BaseTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = serverURL.host
+        title = serverURL?.host
         setupTableView()
 
         guard let settings = serverPublicSettings else { return }

--- a/Rocket.Chat/Controllers/Auth/AuthTableViewControllerLoginServices.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewControllerLoginServices.swift
@@ -28,6 +28,10 @@ extension AuthTableViewController {
     }
 
     func presentOAuthViewController(for loginService: LoginService) {
+        guard let serverURL = serverURL else {
+            return
+        }
+
         OAuthManager.authorize(loginService: loginService, at: serverURL, viewController: self, success: { [weak self] credentials in
             guard let self = self else { return }
             self.startLoading()
@@ -47,9 +51,9 @@ extension AuthTableViewController {
         guard
             let loginUrlString = loginService.loginUrl,
             let loginUrl = URL(string: loginUrlString),
-            let host = serverURL.host,
+            let host = serverURL?.host,
             let callbackUrl = URL(string: "https://\(host)/_cas/\(String.random(17))")
-            else {
+        else {
                 return
         }
 
@@ -67,7 +71,7 @@ extension AuthTableViewController {
     func presentSAMLViewController(for loginService: LoginService) {
         guard
             let provider = loginService.provider,
-            let host = serverURL.host,
+            let host = serverURL?.host,
             let serverUrl = URL(string: "https://\(host)")
         else {
             return

--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -186,7 +186,7 @@ final class ConnectServerViewController: BaseViewController {
         if let controller = segue.destination as? LoginTableViewController {
             controller.shouldShowCreateAccount = true
             controller.serverVersion = infoRequestHandler.version
-            controller.serverURL = url
+            controller.serverURL = infoRequestHandler.url
             controller.serverPublicSettings = serverPublicSettings
 
             if let credentials = deepLinkCredentials {
@@ -198,7 +198,7 @@ final class ConnectServerViewController: BaseViewController {
 
         if let controller = segue.destination as? AuthTableViewController, segue.identifier == "Auth" {
             controller.serverVersion = infoRequestHandler.version
-            controller.serverURL = url
+            controller.serverURL = infoRequestHandler.url
             controller.serverPublicSettings = serverPublicSettings
 
             if let credentials = deepLinkCredentials {
@@ -268,6 +268,7 @@ final class ConnectServerViewController: BaseViewController {
                 if connected {
                     API(host: serverURL, version: serverVersion ?? .zero).client(InfoClient.self).fetchLoginServices(completion: { loginServices, shouldRetrieveLoginServices in
                         self?.stopConnecting()
+
                         if shouldRetrieveLoginServices {
                             self?.performSegue(withIdentifier: "Auth", sender: shouldRetrieveLoginServices)
                         } else {

--- a/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
@@ -78,7 +78,7 @@ class LoginTableViewController: BaseTableViewController {
     }
 
     var serverVersion: Version?
-    var serverURL: URL!
+    var serverURL: URL?
     var serverPublicSettings: AuthSettings?
     var temporary2FACode: String?
 
@@ -101,7 +101,7 @@ class LoginTableViewController: BaseTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationItem.title = serverURL.host
+        navigationItem.title = serverURL?.host
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)


### PR DESCRIPTION
@RocketChat/ios

This crash is caused due to a nil serverURL when loading an AuthTableViewController. I couldn't reproduce it, so I took some actions that will prevent this crash from happening on any given scenario:

- Stop forcing unwrap of `AuthTableViewController` and `LoginTableViewController` serverURL properties  
- Stop recomputing the url property from `ConnectViewController` at the time of injecting it into Auth or Login screens. Instead of doing that I just used the stored version of the URL that we set right after connecting and validating it, i.e. it will never be nil if the connection is working properly.


Closes #2385
