### PR TITLE
[FIX] Permissions API changed format on new endpoint

### DIFF
--- a/Rocket.Chat/API/Requests/General/PermissionsRequest.swift
+++ b/Rocket.Chat/API/Requests/General/PermissionsRequest.swift
@@ -11,7 +11,7 @@ import SwiftyJSON
 class PermissionsRequest: APIRequest {
     typealias APIResourceType = PermissionsResource
 
-    let requiredVersion: Version = Version(0, 61, 0)
+    let requiredVersion: Version = Version(0, 66, 0)
     let path = "/api/v1/permissions.list"
 }
 

--- a/Rocket.Chat/API/Requests/General/PermissionsRequest.swift
+++ b/Rocket.Chat/API/Requests/General/PermissionsRequest.swift
@@ -17,7 +17,7 @@ class PermissionsRequest: APIRequest {
 
 class PermissionsResource: APIResource {
     var permissions: [Permission] {
-        return raw?.arrayValue.map {
+        return raw?["permissions"].arrayValue.map {
             let permission = Permission()
             permission.map($0, realm: nil)
             return permission

--- a/Rocket.ChatTests/API/Clients/InfoClientSpec.swift
+++ b/Rocket.ChatTests/API/Clients/InfoClientSpec.swift
@@ -98,21 +98,23 @@ class InfoClientSpec: XCTestCase {
         let client = InfoClient(api: api)
 
         api.nextResult = JSON([
-            [
-                "_id": "snippet-message",
-                "roles": [
-                    "owner",
-                    "moderator",
-                    "admin"
-                ]
-            ],
-            [
-                "_id": "access-permissions",
-                "roles": [
-                    "admin"
+            "permissions": [
+                [
+                    "_id": "snippet-message",
+                    "roles": [
+                        "owner",
+                        "moderator",
+                        "admin"
+                    ]
+                ],
+                [
+                    "_id": "access-permissions",
+                    "roles": [
+                        "admin"
+                    ]
                 ]
             ]
-            ])
+        ])
 
         client.fetchPermissions()
         XCTAssertEqual(realm.objects(Rocket_Chat.Permission.self).count, 2)

--- a/Rocket.ChatTests/API/Requests/General/PermissionsRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/General/PermissionsRequestSpec.swift
@@ -22,18 +22,20 @@ class PermissionsRequestSpec: APITestCase {
 
     func testProperties() {
         let json = JSON([
-            [
-                "_id": "snippet-message",
-                "roles": [
-                    "owner",
-                    "moderator",
-                    "admin"
-                ]
-            ],
-            [
-                "_id": "access-permissions",
-                "roles": [
-                    "admin"
+            "permissions": [
+                [
+                    "_id": "snippet-message",
+                    "roles": [
+                        "owner",
+                        "moderator",
+                        "admin"
+                    ]
+                ],
+                [
+                    "_id": "access-permissions",
+                    "roles": [
+                        "admin"
+                    ]
                 ]
             ]
         ])


### PR DESCRIPTION
@RocketChat/ios

Closes #2425

New endpoint of the API now returns the permissions inside a `permissions` array.