### PR TITLE
[BUG] Mishandling message websocket updates

### DIFF
--- a/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
@@ -393,8 +393,7 @@ final class MessagesViewModel {
             let index = data.firstIndex(where: { (section) -> Bool in
                 if let object = section.object.base as? MessageSectionModel {
                     return
-                        object.differenceIdentifier == message.identifier &&
-                        !message.isContentEqual(to: object.message)
+                        object.differenceIdentifier == message.identifier
                 }
 
                 return false

--- a/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
@@ -401,7 +401,11 @@ final class MessagesViewModel {
 
             if let index = index {
                 if let newSection = section(for: message) {
+                    MessageTextCacheManager.shared.update(for: message)
                     data[index] = newSection
+                    if let indexOfDataSorted = dataSorted.firstIndex(of: newSection) {
+                        dataSorted[indexOfDataSorted] = newSection
+                    }
                 }
             } else {
                 continue

--- a/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewModel.swift
@@ -261,9 +261,20 @@ final class MessagesViewModel {
      - returns: AnyChatSection instance based on MessageSectionModel.
     */
     func section(for message: UnmanagedMessage) -> AnyChatSection? {
-        let messageSectionModel = MessageSectionModel(message: message)
-
         if let existingSection = dataNormalized.filter({ $0.model.differenceIdentifier == AnyHashable(message.differenceIdentifier) }).first {
+            let messageSectionModel: MessageSectionModel
+            if let existingSectionModel = existingSection.model.base.object.base as? MessageSectionModel {
+                messageSectionModel = MessageSectionModel(
+                    message: message,
+                    daySeparator: existingSectionModel.daySeparator,
+                    sequential: existingSectionModel.isSequential,
+                    unreadIndicator: unreadMarkerObjectIdentifier == message.identifier,
+                    loader: existingSectionModel.containsLoader
+                )
+            } else {
+                messageSectionModel = MessageSectionModel(message: message)
+            }
+
             return AnyChatSection(MessageSection(
                 object: AnyDifferentiable(messageSectionModel),
                 controllerContext: controllerContext,
@@ -272,7 +283,7 @@ final class MessagesViewModel {
         }
 
         return AnyChatSection(MessageSection(
-            object: AnyDifferentiable(messageSectionModel),
+            object: AnyDifferentiable(MessageSectionModel(message: message)),
             controllerContext: controllerContext,
             collapsibleItemsState: [:]
         ))

--- a/Rocket.Chat/Models/Message/UnmanagedMessage.swift
+++ b/Rocket.Chat/Models/Message/UnmanagedMessage.swift
@@ -46,6 +46,7 @@ struct UnmanagedMessage: UnmanagedObject, Equatable {
     var rid: String
     var text: String
     var type: MessageType
+    var internalType: String
     var attachments: [UnmanagedAttachment]
     var userIdentifier: String?
     var user: UnmanagedUser?
@@ -78,6 +79,7 @@ extension UnmanagedMessage {
         return
             lhs.identifier == rhs.identifier &&
             lhs.type == rhs.type &&
+            lhs.internalType == rhs.internalType &&
             lhs.temporary == rhs.temporary &&
             lhs.failed == rhs.failed &&
             lhs.markedForDeletion == rhs.markedForDeletion &&
@@ -107,6 +109,7 @@ extension UnmanagedMessage {
         rid = message.rid
         text = message.text
         type = message.type
+        internalType = message.internalType
         userIdentifier = message.userIdentifier
         user = message.user?.unmanaged
         subscription = message.subscription?.unmanaged


### PR DESCRIPTION
@RocketChat/ios

Part of solving this bug was to make sure that `data` and `dataSorted` were aligned with `messagesQuery`. The way we are doing it today can generate data races in some edge cases, and these data races may make us to lose some update yet. 

In other words: the bug is fixed 💯 but we need to optimize the way we sync our "data pipeline" to avoid side effects caused by data races

Closes #2434