### PR TITLE
[FIX] Do not return NaN values or negative values from the sizing manager

### DIFF
--- a/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
@@ -281,6 +281,7 @@ class LoginTableViewController: BaseTableViewController {
 }
 
 extension LoginTableViewController {
+
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         if indexPath.row == createAccountRow && !shouldShowCreateAccount {
             return 0
@@ -288,6 +289,7 @@ extension LoginTableViewController {
 
         return super.tableView(tableView, heightForRowAt: indexPath)
     }
+
 }
 
 extension LoginTableViewController: UITextFieldDelegate {

--- a/Rocket.Chat/Controllers/Chat/MessagesSizingManager.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesSizingManager.swift
@@ -29,7 +29,15 @@ final class MessagesSizingManager {
      Returns the cached size for the IndexPath.
      */
     func size(for identifier: AnyHashable) -> CGSize? {
-        return cache[identifier]?.cgSizeValue
+        guard
+            let size = cache[identifier]?.cgSizeValue,
+            !size.width.isNaN && size.width >= 0,
+            !size.height.isNaN && size.height >= 0
+        else {
+            return nil
+        }
+
+        return size
     }
 
     /**

--- a/Rocket.Chat/Views/Cells/Auth/AuthSeparatorTableViewCell.swift
+++ b/Rocket.Chat/Views/Cells/Auth/AuthSeparatorTableViewCell.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-class AuthSeparatorTableViewCell: UITableViewCell {
+final class AuthSeparatorTableViewCell: UITableViewCell {
 
-    static let rowHeight: CGFloat = 31
+    static let rowHeight: CGFloat = 31.0
 
 }
 

--- a/Rocket.Chat/Views/Cells/Auth/LoginServiceTableViewCell.swift
+++ b/Rocket.Chat/Views/Cells/Auth/LoginServiceTableViewCell.swift
@@ -8,12 +8,12 @@
 
 import UIKit
 
-class LoginServiceTableViewCell: UITableViewCell {
+final class LoginServiceTableViewCell: UITableViewCell {
 
     static let identifier = "LoginService"
-    static let rowHeight: CGFloat = 56
-    static let firstRowHeight: CGFloat = 82
-    static let lastRowHeight: CGFloat = 52
+    static let rowHeight: CGFloat = 56.0
+    static let firstRowHeight: CGFloat = 82.0
+    static let lastRowHeight: CGFloat = 52.0
 
     @IBOutlet weak var loginServiceButton: StyledButton!
     @IBOutlet weak var loginServiceBottomConstraint: NSLayoutConstraint!

--- a/Rocket.Chat/Views/Cells/Auth/ShowMoreSeparatorTableViewCell.swift
+++ b/Rocket.Chat/Views/Cells/Auth/ShowMoreSeparatorTableViewCell.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-class ShowMoreSeparatorTableViewCell: UITableViewCell {
+final class ShowMoreSeparatorTableViewCell: UITableViewCell {
 
-    static let rowHeight: CGFloat = 76
+    static let rowHeight: CGFloat = 76.0
 
     @IBOutlet weak var showMoreButton: UIButton!
 

--- a/Rocket.Chat/Views/Cells/Chat/ChatMessageDaySeparator.swift
+++ b/Rocket.Chat/Views/Cells/Chat/ChatMessageDaySeparator.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 final class ChatMessageDaySeparator: UICollectionViewCell {
-    static let minimumHeight = CGFloat(40)
+    static let minimumHeight: CGFloat = 40.0
     static let identifier = "ChatMessageDaySeparator"
 
     @IBOutlet weak var labelTitle: UILabel!

--- a/Rocket.ChatTests/Controllers/MessagesSizingViewModelSpec.swift
+++ b/Rocket.ChatTests/Controllers/MessagesSizingViewModelSpec.swift
@@ -26,6 +26,22 @@ final class MessagesSizingViewModelSpec: XCTestCase {
         XCTAssertEqual(model.cache.count, 1)
     }
 
+    func testCacheNegativeValues() {
+        let model = MessagesSizingManager()
+        let identifier = "identifier"
+        model.set(size: CGSize(width: 0, height: -1), for: identifier)
+        XCTAssertNil(model.size(for: identifier))
+        XCTAssertEqual(model.cache.count, 1)
+    }
+
+    func testCacheNotValidValues() {
+        let model = MessagesSizingManager()
+        let identifier = "identifier"
+        model.set(size: CGSize(width: 0.0, height: Double.nan), for: identifier)
+        XCTAssertNil(model.size(for: identifier))
+        XCTAssertEqual(model.cache.count, 1)
+    }
+
     func testClearCache() {
         let model = MessagesSizingManager()
         model.set(size: CGSize(width: 0, height: 150), for: "identifier.1")


### PR DESCRIPTION
@RocketChat/ios

Fixes a crash happening on iOS 11 devices, wasn't able to reproduce the issue but figured a way to prevent this from happening again (and updated tests for it).
