### PR TITLE
[IMPROVEMENT] Add editing changed handler to UITextField in connect screen

### DIFF
--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -59,7 +59,11 @@ final class ConnectServerViewController: BaseViewController {
         }
     }
 
-    @IBOutlet weak var textFieldServerURL: UITextField!
+    @IBOutlet weak var textFieldServerURL: UITextField! {
+        didSet {
+            textFieldServerURL.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+        }
+    }
 
     lazy var keyboardConstraint: NSLayoutConstraint = {
         var bottomGuide: NSLayoutYAxisAnchor
@@ -294,25 +298,16 @@ final class ConnectServerViewController: BaseViewController {
 
 extension ConnectServerViewController: UITextFieldDelegate {
 
-    func textFieldDidChange() {
-        buttonConnect.isEnabled = !(textFieldServerURL.text?.isEmpty ?? true)
+    @objc func textFieldDidChange() {
+        if !connecting {
+            buttonConnect.isEnabled = !(textFieldServerURL.text?.isEmpty ?? true)
+        }
     }
 
     func textFieldShouldClear(_ textField: UITextField) -> Bool {
         textFieldServerURL.text = ""
         textFieldDidChange()
         return true
-    }
-
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if !connecting {
-            if let text = textField.text, let textRange = Range(range, in: text) {
-                textField.text = text.replacingCharacters(in: textRange, with: string)
-                textFieldDidChange()
-            }
-        }
-
-        return false
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/Rocket.Chat/Storyboards/Auth.storyboard
+++ b/Rocket.Chat/Storyboards/Auth.storyboard
@@ -1362,7 +1362,7 @@ to mention you in messages</string>
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="cXi-ex-hQo"/>
-        <segue reference="jjd-tI-Nfg"/>
+        <segue reference="Ivf-BH-9zE"/>
         <segue reference="B9E-PP-gIC"/>
         <segue reference="9kY-lU-ad7"/>
         <segue reference="yUJ-js-l73"/>


### PR DESCRIPTION
@RocketChat/ios

Closes #2477 

This PR address the issue of the `UITextField` in the connect screen not behaving as expected, where the cursor jumps to the end of the text when editing in the middle of the text.

This problem was mainly caused by the delegate method `shouldChangeCharactersIn` where the whole text was replaced with every edit. I noticed that this was primarily to trigger the `textFieldDidChange()` method to toggle the connect button. 

My solution was to instead add a listener to the textField for whenever a change was detected, and the handler function being the same `textFieldDidChange()` method. As a result the `shouldChangeCharactersIn` method is unused and I have removed it.

Hope my solution is ideal for the problem. Please let me know if there are any changes needed to be made. Thank you! 😊