### PR TITLE
[NEW] Support announcements

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -895,6 +895,7 @@
 		D32E28251DFD86C300D6019C /* LauncherProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32E28221DFD86C300D6019C /* LauncherProtocol.swift */; };
 		D32E28261DFD86C300D6019C /* PersistencyCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32E28231DFD86C300D6019C /* PersistencyCoordinator.swift */; };
 		D3CFAFBD1E907D8900BADC0A /* ChatMessageTextViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3CFAFBC1E907D8900BADC0A /* ChatMessageTextViewModel.swift */; };
+		DB926AFD21FA0AEE0046F53F /* ChatAnnouncementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB926AFC21FA0AEE0046F53F /* ChatAnnouncementView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1848,6 +1849,7 @@
 		D32E28221DFD86C300D6019C /* LauncherProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LauncherProtocol.swift; sourceTree = "<group>"; };
 		D32E28231DFD86C300D6019C /* PersistencyCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistencyCoordinator.swift; sourceTree = "<group>"; };
 		D3CFAFBC1E907D8900BADC0A /* ChatMessageTextViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageTextViewModel.swift; sourceTree = "<group>"; };
+		DB926AFC21FA0AEE0046F53F /* ChatAnnouncementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAnnouncementView.swift; sourceTree = "<group>"; };
 		E05A718A50D61E3E547007AF /* Pods-Rocket.Chat.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rocket.Chat.test.xcconfig"; path = "Pods/Target Support Files/Pods-Rocket.Chat/Pods-Rocket.Chat.test.xcconfig"; sourceTree = "<group>"; };
 		F87E8221BEB77AF190F06201 /* Pods-Rocket.Chat.ShareExtension.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rocket.Chat.ShareExtension.beta.xcconfig"; path = "Pods/Target Support Files/Pods-Rocket.Chat.ShareExtension/Pods-Rocket.Chat.ShareExtension.beta.xcconfig"; sourceTree = "<group>"; };
 		FEDACA44BBB1C0633DEA6F3D /* Pods-Rocket.ChatTests.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rocket.ChatTests.beta.xcconfig"; path = "Pods/Target Support Files/Pods-Rocket.ChatTests/Pods-Rocket.ChatTests.beta.xcconfig"; sourceTree = "<group>"; };
@@ -3028,6 +3030,7 @@
 				411498E21FC7A99C00D66542 /* ChatTitleViewModel.swift */,
 				339B6929205042D300F97392 /* KeyboardFrameView.swift */,
 				1435BFA21F9B601600FB2768 /* RCTextView.swift */,
+				DB926AFC21FA0AEE0046F53F /* ChatAnnouncementView.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -4827,6 +4830,7 @@
 				4190694321D0E82F00FE2573 /* MessageVideoCallCell.swift in Sources */,
 				9987B5992093E526007D277C /* FileTableViewCell.swift in Sources */,
 				99BE4D8A2153162A001A43E2 /* UnmanagedMessage.swift in Sources */,
+				DB926AFD21FA0AEE0046F53F /* ChatAnnouncementView.swift in Sources */,
 				41FC9E0C209B3BAA00FED485 /* UploadMessageRequest.swift in Sources */,
 				800FCD501F728EC800D9A692 /* MemberCell.swift in Sources */,
 				997FE19C210BA5B8000F6836 /* SubscriptionHideRequest.swift in Sources */,

--- a/Rocket.Chat/Controllers/Chat/ChannelActionsViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChannelActionsViewController.swift
@@ -47,8 +47,10 @@ class ChannelActionsViewController: BaseViewController {
                         descriptionText: hasDescription ? subscription.roomDescription : localized("chat.info.item.no_description")
                     ),
                     ChannelInfoDescriptionCellData(
-                        title: "Announcement",
-                        descriptionText: hasAnnouncement ? subscription.roomAnnouncement : "No announcement"
+                        title: localized("chat.info.item.announcement"),
+                        descriptionText: hasAnnouncement ?
+                            subscription.roomAnnouncement :
+                            localized("chat.info.item.no_announcement")
                     ),
                     ChannelInfoDescriptionCellData(
                         title: localized("chat.info.item.topic"),

--- a/Rocket.Chat/Controllers/Chat/ChannelActionsViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/ChannelActionsViewController.swift
@@ -37,6 +37,7 @@ class ChannelActionsViewController: BaseViewController {
                 header = [ChannelInfoUserCellData(user: subscription.directMessageUser)]
             } else {
                 let hasDescription = !(subscription.roomDescription?.isEmpty ?? true)
+                let hasAnnouncement = !(subscription.roomAnnouncement?.isEmpty ?? true)
                 let hasTopic = !(subscription.roomTopic?.isEmpty ?? true)
 
                 header = [
@@ -44,6 +45,10 @@ class ChannelActionsViewController: BaseViewController {
                     ChannelInfoDescriptionCellData(
                         title: localized("chat.info.item.description"),
                         descriptionText: hasDescription ? subscription.roomDescription : localized("chat.info.item.no_description")
+                    ),
+                    ChannelInfoDescriptionCellData(
+                        title: "Announcement",
+                        descriptionText: hasAnnouncement ? subscription.roomAnnouncement : "No announcement"
                     ),
                     ChannelInfoDescriptionCellData(
                         title: localized("chat.info.item.topic"),

--- a/Rocket.Chat/Controllers/Chat/MessagesViewController.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewController.swift
@@ -79,6 +79,12 @@ final class MessagesViewController: RocketChatViewController {
         }
     }
 
+    lazy var announcementBannerView: UIView = {
+        let announcementBannerView = ChatAnnouncementView()
+        announcementBannerView.subscription = subscription?.unmanaged
+        return announcementBannerView
+    }()
+
     private let buttonScrollToBottomSize = CGFloat(70)
     var keyboardHeight: CGFloat = 0
     var buttonScrollToBottomConstraint: NSLayoutConstraint!
@@ -131,7 +137,7 @@ final class MessagesViewController: RocketChatViewController {
 
         registerCells()
         setupScrollToBottom()
-
+        setupAnnouncementBanner()
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillShow(_:)),
@@ -197,6 +203,7 @@ final class MessagesViewController: RocketChatViewController {
         super.viewDidAppear(animated)
         markAsRead()
         becomeFirstResponder()
+        updateAnnouncementBanner()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -271,6 +278,35 @@ final class MessagesViewController: RocketChatViewController {
 
         collectionViewCells.forEach {
             collectionView?.register($0.nib, forCellWithReuseIdentifier: $0.cellIdentifier)
+        }
+    }
+
+    // MARK: Announcement
+
+    func setupAnnouncementBanner() {
+        // Start as invisible first, alpha will be set to 1 if a valid announcement is fetched
+        announcementBannerView.alpha = 0
+
+        view.addSubview(announcementBannerView)
+        view.bringSubviewToFront(announcementBannerView)
+        NSLayoutConstraint.activate([
+            announcementBannerView.topAnchor.constraint(equalTo: view.topAnchor),
+            announcementBannerView.leftAnchor.constraint(equalTo: view.leftAnchor),
+            announcementBannerView.rightAnchor.constraint(equalTo: view.rightAnchor),
+            announcementBannerView.heightAnchor.constraint(equalToConstant: 50)
+        ])
+
+        announcementBannerView.applyTheme()
+    }
+
+    func updateAnnouncementBanner() {
+        guard let announcement = subscription?.unmanaged?.roomAnnouncement else { return }
+        let hasAnnouncement = announcement == "" ? false : true
+
+        if hasAnnouncement {
+            announcementBannerView.alpha = 1
+        } else {
+            announcementBannerView.alpha = 0
         }
     }
 

--- a/Rocket.Chat/Models/Mapping/SubscriptionModelMapping.swift
+++ b/Rocket.Chat/Models/Mapping/SubscriptionModelMapping.swift
@@ -95,6 +95,7 @@ extension Subscription: ModelMappeable {
 
     func mapRoom(_ values: JSON, realm: Realm?) {
         self.roomDescription = values["description"].stringValue
+        self.roomAnnouncement = values["announcement"].stringValue
         self.roomTopic = values["topic"].stringValue
 
         if let broadcast = values["broadcast"].bool {

--- a/Rocket.Chat/Models/Subscription/Subscription.swift
+++ b/Rocket.Chat/Models/Subscription/Subscription.swift
@@ -67,6 +67,7 @@ final class Subscription: BaseModel {
 
     @objc dynamic var roomTopic: String?
     @objc dynamic var roomDescription: String?
+    @objc dynamic var roomAnnouncement: String?
     @objc dynamic var roomReadOnly = false
     @objc dynamic var roomUpdatedAt: Date?
     @objc dynamic var roomLastMessage: Message?

--- a/Rocket.Chat/Models/Subscription/UnmanagedSubscription.swift
+++ b/Rocket.Chat/Models/Subscription/UnmanagedSubscription.swift
@@ -28,6 +28,7 @@ struct UnmanagedSubscription: UnmanagedObject, Equatable {
     var lastSeen: Date?
     var roomTopic: String?
     var roomDescription: String?
+    var roomAnnouncement: String?
     var roomReadOnly: Bool
     var roomUpdatedAt: Date?
     var roomLastMessage: Message?
@@ -82,6 +83,7 @@ extension UnmanagedSubscription {
         lastSeen = subscription.lastSeen
         roomTopic = subscription.roomTopic
         roomDescription = subscription.roomDescription
+        roomAnnouncement = subscription.roomAnnouncement
         roomReadOnly = subscription.roomReadOnly
         roomUpdatedAt = subscription.roomUpdatedAt
         roomLastMessage = subscription.roomLastMessage

--- a/Rocket.Chat/Resources/cs.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/cs.lproj/Localizable.strings
@@ -302,6 +302,8 @@
 "chat.info.item.no_topic" = "Bez tématu";
 "chat.info.item.description" = "Popis";
 "chat.info.item.no_description" = "Žádný popis";
+"chat.info.item.announcement" = "Announcement"; // TODO
+"chat.info.item.no_announcement" = "No announcement"; // TODO
 "chat.info.item.notifications" = "Upozornění";
 "chat.info.item.members" = "Členové";
 "chat.info.item.pinned" = "Připnuto";

--- a/Rocket.Chat/Resources/de.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/de.lproj/Localizable.strings
@@ -301,6 +301,8 @@
 "chat.info.item.no_topic" = "Ohne Thema";
 "chat.info.item.description" = "Beschreibung";
 "chat.info.item.no_description" = "Ohne Beschreibung";
+"chat.info.item.announcement" = "Announcement"; // TODO
+"chat.info.item.no_announcement" = "No announcement"; // TODO
 "chat.info.item.notifications" = "Benachrichtigungen";
 "chat.info.item.members" = "Teilnehmer";
 "chat.info.item.pinned" = "Angeheftet";

--- a/Rocket.Chat/Resources/el.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/el.lproj/Localizable.strings
@@ -301,6 +301,8 @@
 "chat.info.item.no_topic" = "Όχι θέμα";
 "chat.info.item.description" = "Περιγραφή";
 "chat.info.item.no_description" = "Έλλειψη περιγραφής";
+"chat.info.item.announcement" = "Announcement"; // TODO
+"chat.info.item.no_announcement" = "No announcement"; // TODO
 "chat.info.item.notifications" = "Ειδοποιήσεις";
 "chat.info.item.members" = "Μέλη";
 "chat.info.item.pinned" = "Καρφιτσωμένα";

--- a/Rocket.Chat/Resources/en.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/en.lproj/Localizable.strings
@@ -301,6 +301,8 @@
 "chat.info.item.no_topic" = "No topic";
 "chat.info.item.description" = "Description";
 "chat.info.item.no_description" = "No description";
+"chat.info.item.announcement" = "Announcement";
+"chat.info.item.no_announcement" = "No announcement";
 "chat.info.item.members" = "Members";
 "chat.info.item.pinned" = "Pinned";
 "chat.info.item.starred" = "Starred";

--- a/Rocket.Chat/Resources/es.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/es.lproj/Localizable.strings
@@ -301,6 +301,8 @@
 "chat.info.item.no_topic" = "No tema";
 "chat.info.item.description" = "Descripción";
 "chat.info.item.no_description" = "No descripción";
+"chat.info.item.announcement" = "Announcement"; // TODO
+"chat.info.item.no_announcement" = "No announcement"; // TODO
 "chat.info.item.notifications" = "Notificaciones";
 "chat.info.item.members" = "Miembros";
 "chat.info.item.pinned" = "Fijado";

--- a/Rocket.Chat/Resources/fr.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/fr.lproj/Localizable.strings
@@ -301,6 +301,8 @@
 "chat.info.item.no_topic" = "Pas de sujet";
 "chat.info.item.description" = "Description";
 "chat.info.item.no_description" = "Pas de description";
+"chat.info.item.announcement" = "Announcement"; // TODO
+"chat.info.item.no_announcement" = "No announcement"; // TODO
 "chat.info.item.members" = "Membres";
 "chat.info.item.pinned" = "Épinglé";
 "chat.info.item.starred" = "Mis en favoris";

--- a/Rocket.Chat/Resources/it.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/it.lproj/Localizable.strings
@@ -302,6 +302,8 @@
 "chat.info.item.no_topic" = "Nessun argomento";
 "chat.info.item.description" = "Descrizione";
 "chat.info.item.no_description" = "Nessuna descrizione";
+"chat.info.item.announcement" = "Announcement"; // TODO
+"chat.info.item.no_announcement" = "No announcement"; // TODO
 "chat.info.item.members" = "Componenti";
 "chat.info.item.pinned" = "Evidenziati";
 "chat.info.item.starred" = "Speciali";

--- a/Rocket.Chat/Resources/ja.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/ja.lproj/Localizable.strings
@@ -302,6 +302,8 @@
 "chat.info.item.no_topic" = "トッピックはありません";
 "chat.info.item.description" = "説明";
 "chat.info.item.no_description" = "説明はありません";
+"chat.info.item.announcement" = "Announcement"; // TODO
+"chat.info.item.no_announcement" = "No announcement"; // TODO
 "chat.info.item.members" = "メンバー";
 "chat.info.item.pinned" = "ピン留め";
 "chat.info.item.starred" = "スター";

--- a/Rocket.Chat/Resources/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pl.lproj/Localizable.strings
@@ -301,6 +301,8 @@
 "chat.info.item.no_topic" = "Brak tematu";
 "chat.info.item.description" = "Opis";
 "chat.info.item.no_description" = "Brak opisu";
+"chat.info.item.announcement" = "Announcement"; // TODO
+"chat.info.item.no_announcement" = "No announcement"; // TODO
 "chat.info.item.notifications" = "Powiadomienia";
 "chat.info.item.members" = "Członkowie";
 "chat.info.item.pinned" = "Przypięte";

--- a/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
@@ -301,6 +301,8 @@
 "chat.info.item.no_topic" = "Sem tópico";
 "chat.info.item.description" = "Descrição";
 "chat.info.item.no_description" = "Sem descrição";
+"chat.info.item.announcement" = "Anúncio"; // TODO
+"chat.info.item.no_announcement" = "Sem anúncio"; // TODO
 "chat.info.item.notifications" = "Notificações";
 "chat.info.item.members" = "Membros";
 "chat.info.item.pinned" = "Pinadas";

--- a/Rocket.Chat/Resources/pt-PT.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/Localizable.strings
@@ -301,6 +301,8 @@
 "chat.info.item.no_topic" = "Sem tópico";
 "chat.info.item.description" = "Descrição";
 "chat.info.item.no_description" = "Sem descrição";
+"chat.info.item.announcement" = "Announcement"; // TODO
+"chat.info.item.no_announcement" = "No announcement"; // TODO
 "chat.info.item.notifications" = "Notificações";
 "chat.info.item.members" = "Membros";
 "chat.info.item.pinned" = "Fixar";

--- a/Rocket.Chat/Resources/ru.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/ru.lproj/Localizable.strings
@@ -301,6 +301,8 @@
 "chat.info.item.no_topic" = "Нет темы";
 "chat.info.item.description" = "Описание";
 "chat.info.item.no_description" = "Нет описания";
+"chat.info.item.announcement" = "Announcement"; // TODO
+"chat.info.item.no_announcement" = "No announcement"; // TODO
 "chat.info.item.notifications" = "Уведомления";
 "chat.info.item.members" = "Пользователи";
 "chat.info.item.pinned" = "Прикрепленные";

--- a/Rocket.Chat/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/zh-Hans.lproj/Localizable.strings
@@ -301,6 +301,8 @@
 "chat.info.item.no_topic" = "没有话题";
 "chat.info.item.description" = "描述";
 "chat.info.item.no_description" = "没有描述";
+"chat.info.item.announcement" = "Announcement"; // TODO
+"chat.info.item.no_announcement" = "No announcement"; // TODO
 "chat.info.item.members" = "成员";
 "chat.info.item.pinned" = "固定信息";
 "chat.info.item.starred" = "标记信息";

--- a/Rocket.Chat/Views/Chat/ChatAnnouncementView.swift
+++ b/Rocket.Chat/Views/Chat/ChatAnnouncementView.swift
@@ -1,0 +1,61 @@
+//
+//  ChatAnnouncementView.swift
+//  Rocket.Chat
+//
+//  Created by Bryan Lew on 24/1/19.
+//  Copyright © 2019 Rocket.Chat. All rights reserved.
+//
+
+import UIKit
+
+final class ChatAnnouncementView: UIView {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    var subscription: UnmanagedSubscription? {
+        didSet {
+            guard let subscription = subscription else { return }
+            guard let announcement = subscription.roomAnnouncement else { return }
+            let attributedString = NSAttributedString(string: announcement)
+            announcementLabel.attributedText = MarkdownManager.shared.transformAttributedString(attributedString)
+        }
+    }
+
+    let announcementLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    fileprivate func setupUI() {
+        translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(announcementLabel)
+        NSLayoutConstraint.activate([
+            announcementLabel.topAnchor.constraint(equalTo: topAnchor),
+            announcementLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+            announcementLabel.leftAnchor.constraint(equalTo: leftAnchor, constant: 12),
+            announcementLabel.rightAnchor.constraint(equalTo: rightAnchor, constant: -12)
+        ])
+    }
+}
+
+// MARK: Themeable
+
+extension ChatAnnouncementView {
+
+    override func applyTheme() {
+        super.applyTheme()
+        backgroundColor = theme?.bannerBackground
+        announcementLabel.textColor = theme?.auxiliaryText
+    }
+
+}

--- a/Rocket.ChatTests/Models/SubscriptionSpec.swift
+++ b/Rocket.ChatTests/Models/SubscriptionSpec.swift
@@ -165,7 +165,8 @@ class SubscriptionSpec: XCTestCase {
             "jitsiTimeout": [ "$date": 1480377601 ],
             "ro": true,
             "broadcast": true,
-            "description": "room-description"
+            "description": "room-description",
+            "announcement": "room-announcement"
         ])
 
         let subscription = Subscription()
@@ -174,6 +175,7 @@ class SubscriptionSpec: XCTestCase {
 
         XCTAssertEqual(subscription.roomTopic, "room-topic")
         XCTAssertEqual(subscription.roomDescription, "room-description")
+        XCTAssertEqual(subscription.roomAnnouncement, "room-announcement")
         XCTAssertEqual(subscription.roomReadOnly, true)
         XCTAssertEqual(subscription.roomBroadcast, true)
         XCTAssertEqual(subscription.roomOwnerId, "user-id")


### PR DESCRIPTION
@RocketChat/ios

Closes #1593.

Two main additions to the application:

1. Announcement can be seen on `ChannelActionsView` as one of the channel's information. Placed between Description and Topic, similar to the desktop client.

![annoucement-action-view](https://user-images.githubusercontent.com/39292809/51694840-a3381900-203c-11e9-960d-f27e6f3c5132.png)

2. Announcement can also be seen on the main chat view pinned to the top as a banner, similar to the desktop client as well. Implemented as a new `UIView` class, `ChatAnnouncementView`. This banner will follow the colour scheme of the current active theme, with the background being `bannerBackground` and label text `auxiliaryText`. 

Light theme - iPhone XS Max
![announcement-light](https://user-images.githubusercontent.com/39292809/51695022-02962900-203d-11e9-9311-7528df7332b9.png)

Dark theme - iPad Pro 12.9 inch (Please ignore the test channels... :P)
![announcement-dark-ipad](https://user-images.githubusercontent.com/39292809/51695025-0629b000-203d-11e9-9716-e90dc880f53d.png)

Black theme - iPhone SE (also a deliberately long announcement to see the text formatting when the label overflows the screen.)
![announcement-black-se](https://user-images.githubusercontent.com/39292809/51695181-5f91df00-203d-11e9-8596-dfb37c5f307d.png)

Lastly, I have also updated the subscription test to include testing for this new feature.

Please feel free to let me know if there are any changes to be made. Cheers!




