### PR TITLE
[FIX] Current user looses roles

### DIFF
--- a/Rocket.Chat/Models/Mapping/SubscriptionModelMapping.swift
+++ b/Rocket.Chat/Models/Mapping/SubscriptionModelMapping.swift
@@ -131,7 +131,10 @@ extension Subscription: ModelMappeable {
         if values["lastMessage"].dictionary != nil {
             let user = User()
             user.map(values["lastMessage"]["u"], realm: realm)
-            realm?.add(user, update: true)
+            if let currentUser = AuthManager.currentUser(), let currentUserId = currentUser.identifier, let newUserId = user.identifier, currentUserId == newUserId {
+            } else {
+                realm?.add(user, update: true)
+            }
 
             let message = Message()
             message.map(values["lastMessage"], realm: realm)


### PR DESCRIPTION
Current user looses its roles (which impacts access to admin menu and ability to create rooms) after he writes a message.

I don't know if this is the most elegant way to solve the issue but it worked.

Closes #2572
