### PR TITLE
[FIX] Alert view for dark and black theme

### DIFF
--- a/Rocket.Chat/Helpers/Alert.swift
+++ b/Rocket.Chat/Helpers/Alert.swift
@@ -42,11 +42,12 @@ extension UIViewController: Alerter {
     }
 
     func alertSuccess(title: String, completion: (() -> Void)? = nil) {
-        let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
-        self.present(alert, animated: true, completion: nil)
-        let delay = DispatchTime.now() + 1.5
-        DispatchQueue.main.asyncAfter(deadline: delay) {
-            alert.dismiss(animated: true, completion: {() -> Void in
+        DispatchQueue.main.async {
+            let alert = UIAlertController(title: title, message: "✔️", preferredStyle: .alert)
+            self.present(alert, animated: true, completion: nil)
+            let delay = DispatchTime.now() + 1.5
+            DispatchQueue.main.asyncAfter(deadline: delay, execute: {
+                alert.dismiss(animated: true, completion: nil)
             })
         }
     }

--- a/Rocket.Chat/Helpers/Alert.swift
+++ b/Rocket.Chat/Helpers/Alert.swift
@@ -42,20 +42,11 @@ extension UIViewController: Alerter {
     }
 
     func alertSuccess(title: String, completion: (() -> Void)? = nil) {
-        DispatchQueue.main.async {
-            let successHUD = MBProgressHUD.showAdded(to: self.view, animated: true)
-            successHUD.mode = .customView
-
-            let checkmark = UIImage(named: "Check")?.withRenderingMode(.alwaysTemplate)
-            successHUD.customView = UIImageView(image: checkmark)
-            successHUD.isSquare = true
-            successHUD.label.text = title
-
-            let delay = 1.5
-
-            successHUD.hide(animated: true, afterDelay: delay)
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: {
-                completion?()
+        let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
+        self.present(alert, animated: true, completion: nil)
+        let delay = DispatchTime.now() + 1.5
+        DispatchQueue.main.asyncAfter(deadline: delay) {
+            alert.dismiss(animated: true, completion: {() -> Void in
             })
         }
     }


### PR DESCRIPTION
@RocketChat/ios

Added an alert instead of MBProgressHUD custom alert view. It does not have the check image, but is consistent with the rest of the alert views in the application.

Closes #2577 

Screenshot - 

![Simulator Screen Shot - iPhone XR - 2019-03-13 at 00 22 29](https://user-images.githubusercontent.com/30552772/54227527-1979d780-4526-11e9-8e43-20a0f413e9d5.png)

![Simulator Screen Shot - iPhone XR - 2019-03-12 at 23 44 32](https://user-images.githubusercontent.com/30552772/54227365-c56ef300-4525-11e9-88da-669d4e575930.png)
