### PR TITLE
[FIX] Status not updated immediately after selecting

### DIFF
--- a/Rocket.Chat/Controllers/Preferences/Profile/EditProfileTableViewController.swift
+++ b/Rocket.Chat/Controllers/Preferences/Profile/EditProfileTableViewController.swift
@@ -129,8 +129,8 @@ final class EditProfileTableViewController: BaseTableViewController, MediaPicker
         fetchUserData()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         updateUserStatus()
     }
 


### PR DESCRIPTION
@RocketChat/ios

**Problem** - After selecting a status in the Profile, `popviewcontroller()` pops the top view controller from the navigation stack _before_ the statusValueLabel be updated.

Before - 

![status_update_before](https://user-images.githubusercontent.com/30552772/54320447-0c86e200-4613-11e9-8c8d-fc38d216f6cb.gif)

I came up with two solutions - 

- `viewDidAppear()` instead of `viewWillAppear()`
- add a delay using `DisplayQueue.main.asyncafter()` when popping the top view controller.

After (using the former solution) -

![status_update_after](https://user-images.githubusercontent.com/30552772/54321040-540e6d80-4615-11e9-9763-98f72c5742f4.gif)

Closes #2075 