### PR TITLE
[IMPROVEMENT] Auto suggesting slash commands even when not first character

### DIFF
--- a/Rocket.Chat/Controllers/Chat/MessagesViewControllerComposerDelegate.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewControllerComposerDelegate.swift
@@ -36,6 +36,12 @@ extension MessagesViewController: ComposerViewExpandedDelegate {
     // MARK: Hints
 
     func composerView(_ composerView: ComposerView, didChangeHintPrefixedWord word: String) {
+
+        // Don't generate hints if it is a slash command and not the first word
+        if word.first == "/" && composerView.textView.text != word {
+            return
+        }
+
         composerViewModel.didChangeHintPrefixedWord(word: word)
 
         if composerViewModel.hints.count > 0 {


### PR DESCRIPTION
@RocketChat/ios

Closes #2530 

No hints will be generated if it is detected that the word containing the "/" character is not the first word.

Screenshots after fix:
<img src="https://user-images.githubusercontent.com/39292809/54745326-2f615980-4c04-11e9-8572-8a9e577b18b8.png" alt="not-first-word" width="220" /> <img src="https://user-images.githubusercontent.com/39292809/54745323-2e302c80-4c04-11e9-83ea-5f21ab3cd234.png" alt="first-word" width="220" />

