### PR TITLE
[IMPROVEMENT] Change theme for MBProgressHUD

### DIFF
--- a/Rocket.Chat/Theme/ThemeableViews.swift
+++ b/Rocket.Chat/Theme/ThemeableViews.swift
@@ -449,6 +449,10 @@ extension ComposerTextView {
 
 extension MBProgressHUD {
     override var theme: Theme? { return nil }
+    override func applyTheme() {
+        super.applyTheme()
+        bezelView.color = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+    }
 }
 
 // MARK: Subclasses


### PR DESCRIPTION
@RocketChat/ios

Closes #2577 

Added the bezel.view = white, so that the view is visible in dark and black themes.

Before / After :

![Screenshot 2019-03-21 at 8 21 51 PM](https://user-images.githubusercontent.com/30552772/54760980-3a71b500-4c17-11e9-838f-f9718f15f32d.png)
![Screenshot 2019-03-21 at 8 19 45 PM](https://user-images.githubusercontent.com/30552772/54760983-3c3b7880-4c17-11e9-9fd0-65223e097bf5.png)

