### PR TITLE
[FIX] Clear listeners for dynamic value in notifications

### DIFF
--- a/Rocket.Chat/Controllers/Preferences/Notifications/NotificationsChooseCell.swift
+++ b/Rocket.Chat/Controllers/Preferences/Notifications/NotificationsChooseCell.swift
@@ -41,10 +41,12 @@ final class NotificationsChooseCell: UITableViewCell, NotificationsCellProtocol 
 
         titleLabel.text = model.title
 
+        model.value.clearListeners()
         model.value.bindAndFire { [unowned self] value in
             self.valueLabel.text = value.localizedCase
         }
 
+        model.pickerVisible.clearListeners()
         model.pickerVisible.bindAndFire { [unowned self] visible in
             self.pickerView.isHidden = !visible
 
@@ -65,10 +67,12 @@ final class NotificationsChooseCell: UITableViewCell, NotificationsCellProtocol 
 
         titleLabel.text = model.title
 
+        model.value.clearListeners()
         model.value.bindAndFire { [unowned self] value in
             self.valueLabel.text = value.localizedCase
         }
 
+        model.pickerVisible.clearListeners()
         model.pickerVisible.bindAndFire { [unowned self] visible in
             self.pickerView.isHidden = !visible
 
@@ -89,10 +93,12 @@ final class NotificationsChooseCell: UITableViewCell, NotificationsCellProtocol 
 
         titleLabel.text = model.title
 
+        model.value.clearListeners()
         model.value.bindAndFire { [unowned self] value in
             self.valueLabel.text = value == 0 ? localized("myaccount.settings.notifications.duration.default") : "\(value) \(localized("myaccount.settings.notifications.duration.seconds"))"
         }
 
+        model.pickerVisible.clearListeners()
         model.pickerVisible.bindAndFire { [unowned self] visible in
             self.pickerView.isHidden = !visible
 

--- a/Rocket.Chat/Helpers/Dynamic.swift
+++ b/Rocket.Chat/Helpers/Dynamic.swift
@@ -10,15 +10,19 @@ import Foundation
 
 class Dynamic<T> {
     typealias Listener = (T) -> Void
-    var listeners = [Listener?]()
+    private var listeners = [Listener?]()
 
     func bind(_ listener: Listener?) {
-        self.listeners.append(listener)
+        listeners.append(listener)
     }
 
     func bindAndFire(_ listener: Listener?) {
-        self.listeners.append(listener)
+        listeners.append(listener)
         listener?(value)
+    }
+
+    func clearListeners() {
+        listeners.removeAll()
     }
 
     var value: T {


### PR DESCRIPTION
Clear listeners for dynamic value in notifications before setting them again

Reloading cells caused multiple listeners to be registered which had a huge impact on performance and might cause other issues

@RocketChat/ios