### PR TITLE
[FIX] Refactor EmojiPickerViewController and fix memory leak on iPhone

### DIFF
--- a/Rocket.Chat/Controllers/Chat/MessagesViewControllerMessageCellProtocol.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewControllerMessageCellProtocol.swift
@@ -391,14 +391,6 @@ extension MessagesViewController {
         self.composerView.resignFirstResponder()
 
         let controller = EmojiPickerController()
-        controller.modalPresentationStyle = .popover
-        controller.preferredContentSize = CGSize(width: 600.0, height: 400.0)
-
-        if let presenter = controller.popoverPresentationController {
-            presenter.sourceView = view
-            presenter.sourceRect = view.bounds
-            presenter.backgroundColor = view.theme?.focusedBackground
-        }
 
         controller.emojiPicked = { emoji in
             API.current()?.client(MessagesClient.self).reactMessage(message, emoji: emoji)
@@ -406,11 +398,19 @@ extension MessagesViewController {
         }
 
         controller.customEmojis = CustomEmoji.emojis()
-        ThemeManager.addObserver(controller.view)
 
         if UIDevice.current.userInterfaceIdiom == .phone {
             self.navigationController?.pushViewController(controller, animated: true)
         } else {
+            controller.modalPresentationStyle = .popover
+            controller.preferredContentSize = CGSize(width: 600.0, height: 400.0)
+
+            if let presenter = controller.popoverPresentationController {
+                presenter.sourceView = view
+                presenter.sourceRect = view.bounds
+                presenter.backgroundColor = view.theme?.focusedBackground
+            }
+
             self.present(controller, animated: true)
         }
     }

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
@@ -48,7 +48,9 @@ final class SubscriptionsViewController: BaseViewController {
     weak var serversView: ServersListView?
     weak var titleView: SubscriptionsTitleView?
     weak var searchController: UISearchController?
-    weak var searchBar: UISearchBar?
+    var searchBar: UISearchBar? {
+        return searchController?.searchBar
+    }
 
     var assigned = false
     var viewModel = SubscriptionsViewModel()
@@ -209,7 +211,6 @@ final class SubscriptionsViewController: BaseViewController {
         searchController.dimsBackgroundDuringPresentation = false
         searchController.hidesNavigationBarDuringPresentation = UIDevice.current.userInterfaceIdiom != .pad
 
-        searchBar = searchController.searchBar
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.searchController = searchController

--- a/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPicker.swift
@@ -13,8 +13,6 @@ private typealias EmojiCategory = (name: String, emojis: [Emoji])
 final class EmojiPicker: UIView, RCEmojiKitLocalizable {
     static let defaults = UserDefaults(suiteName: "EmojiPicker")
 
-    var isPopover = false
-
     var customEmojis: [Emoji] = []
     var customCategory: (name: String, emojis: [Emoji]) {
         return (name: "custom", emojis: self.customEmojis)

--- a/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPickerController.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/EmojiPicker/EmojiPickerController.swift
@@ -13,52 +13,36 @@ final class EmojiPickerController: UIViewController, RCEmojiKitLocalizable {
     var emojiPicked: ((String) -> Void)?
     var customEmojis: [Emoji] = []
 
-    private var emojiPicker: EmojiPicker! {
-        didSet {
-            emojiPicker.emojiPicked = { emoji in
-                self.emojiPicked?(emoji)
-
-                if self.navigationController?.topViewController == self {
-                    self.navigationController?.popViewController(animated: true)
-                } else {
-                    self.dismiss(animated: true)
-                }
-            }
-
-            emojiPicker.isPopover = presentationController?.presentationStyle == .popover
-
-            emojiPicker.customEmojis = customEmojis
-        }
+    override func loadView() {
+        view = EmojiPicker()
     }
 
-    override func loadView() {
-        super.loadView()
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
-        emojiPicker = EmojiPicker(frame: view.frame)
-        emojiPicker.translatesAutoresizingMaskIntoConstraints = false
+        ThemeManager.addObserver(view)
 
-        view.addSubview(emojiPicker)
-
-        view.addConstraints(
-            NSLayoutConstraint.constraints(
-                withVisualFormat: "|-0-[view]-0-|", options: [], metrics: nil, views: ["view": emojiPicker]
-            )
-        )
-        view.addConstraints(
-            NSLayoutConstraint.constraints(
-                withVisualFormat: "V:|-0-[view]-0-|", options: [], metrics: nil, views: ["view": emojiPicker]
-            )
-        )
+        guard let picker = view as? EmojiPicker else {
+            fatalError("View should be an instance of EmojiPicker!")
+        }
 
         title = localized("emojipicker.title")
-    }
 
-    override func viewWillAppear(_ animated: Bool) {
+        picker.emojiPicked = { [unowned self] emoji in
+            self.emojiPicked?(emoji)
+
+            if self.navigationController?.topViewController == self {
+                self.navigationController?.popViewController(animated: true)
+            } else {
+                self.dismiss(animated: true)
+            }
+        }
+
+        picker.customEmojis = customEmojis
+
         let center = NotificationCenter.default
         center.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         center.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
-
-        // remove title from back button
 
         if self.navigationController?.topViewController == self {
             navigationController?.navigationBar.topItem?.title = ""
@@ -66,9 +50,13 @@ final class EmojiPickerController: UIViewController, RCEmojiKitLocalizable {
     }
 
     override func viewWillDisappear(_ animated: Bool) {
-        let center = NotificationCenter.default
-        center.removeObserver(self)
-        emojiPicker.endEditing(true)
+        super.viewWillDisappear(animated)
+
+        view.endEditing(true)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     override func keyboardWillShow(_ notification: Notification) {

--- a/Rocket.Chat/External/RCEmojiKit/Views/Reaction/ReactorListView.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/Reaction/ReactorListView.swift
@@ -54,7 +54,6 @@ final class ReactorListView: UIView {
         }
     }
 
-    var isPopover = false
     var selectedReactor: (String, CGRect) -> Void = { _, _ in }
     var configureCell: (ReactorCell) -> Void = { _ in }
 

--- a/Rocket.Chat/External/RCEmojiKit/Views/Reaction/ReactorListViewController.swift
+++ b/Rocket.Chat/External/RCEmojiKit/Views/Reaction/ReactorListViewController.swift
@@ -29,7 +29,6 @@ final class ReactorListViewController: UIViewController, Closeable {
 
     var reactorListView: ReactorListView! {
         didSet {
-            reactorListView.isPopover = presentationController?.presentationStyle == .popover
             reactorListView.model = model
         }
     }

--- a/Rocket.Chat/External/RCEmojiKit/pl.lproj/RCEmojiKit.strings
+++ b/Rocket.Chat/External/RCEmojiKit/pl.lproj/RCEmojiKit.strings
@@ -6,7 +6,7 @@
  Copyright © 2017 Rocket.Chat. All rights reserved.
  */
 
-"controller.title" = "Wybierz reakcję";
+"emojipicker.title" = "Wybierz reakcję";
 "searchbar.placeholder" = "Wyszukaj emoji";
 
 "categories.recent" = "CZĘSTO UŻYWANE";


### PR DESCRIPTION
@RocketChat/ios

Closes #2423 

I have refactored `EmojiPickerViewController` a little bit since there were a few issues with it (like calling a `super` of `loadView` - it should never be called while subclassing directly from `UIViewController`).

Moved presenter-related code to 'iPad only' since it was causing leaks on iPhones.

Please, double-check my changes since it was kinda tricky and not sure if it's the best solution.

NOTE: All tests succeed locally on my machine.