### PR TITLE
[NEW] Authentication screen more accessible

### DIFF
--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -23,7 +23,8 @@
 		0BC0E8612032DB20004BFAAF /* DrawingBrushColorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC0E8602032DB20004BFAAF /* DrawingBrushColorSpec.swift */; };
 		0BC0E8632032DD95004BFAAF /* DrawingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC0E8622032DD95004BFAAF /* DrawingViewModel.swift */; };
 		0BC0E8652032DF9B004BFAAF /* DrawingViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC0E8642032DF9B004BFAAF /* DrawingViewModelSpec.swift */; };
-		0D91D922224DA570003B3966 /* UINavigationItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D91D921224DA570003B3966 /* UINavigationItem.swift */; };
+		0D1D8A60225F5FB7007CAF4B /* UIButtonAccessibilityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D1D8A5F225F5FB7007CAF4B /* UIButtonAccessibilityExtension.swift */; };
+		0D91D922224DA570003B3966 /* UINavigationItemAccessibilityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D91D921224DA570003B3966 /* UINavigationItemAccessibilityExtension.swift */; };
 		140A95DE202F1E6F003FD564 /* ChangeAppIconViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140A95DD202F1E6F003FD564 /* ChangeAppIconViewModelSpec.swift */; };
 		140A95E1202F526C003FD564 /* Drawing.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 140A95E0202F526C003FD564 /* Drawing.storyboard */; };
 		140A95E4202F536D003FD564 /* DrawingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140A95E3202F536D003FD564 /* DrawingViewController.swift */; };
@@ -986,7 +987,8 @@
 		0BC0E8602032DB20004BFAAF /* DrawingBrushColorSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingBrushColorSpec.swift; sourceTree = "<group>"; };
 		0BC0E8622032DD95004BFAAF /* DrawingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingViewModel.swift; sourceTree = "<group>"; };
 		0BC0E8642032DF9B004BFAAF /* DrawingViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingViewModelSpec.swift; sourceTree = "<group>"; };
-		0D91D921224DA570003B3966 /* UINavigationItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationItem.swift; sourceTree = "<group>"; };
+		0D1D8A5F225F5FB7007CAF4B /* UIButtonAccessibilityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButtonAccessibilityExtension.swift; sourceTree = "<group>"; };
+		0D91D921224DA570003B3966 /* UINavigationItemAccessibilityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationItemAccessibilityExtension.swift; sourceTree = "<group>"; };
 		0F5191CD6C53AEA006C82524 /* Pods_Rocket_Chat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rocket_Chat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		140A95DD202F1E6F003FD564 /* ChangeAppIconViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeAppIconViewModelSpec.swift; sourceTree = "<group>"; };
 		140A95E0202F526C003FD564 /* Drawing.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Drawing.storyboard; sourceTree = "<group>"; };
@@ -3651,6 +3653,7 @@
 			isa = PBXGroup;
 			children = (
 				809D577520EBAE5F0014C364 /* UIButtonCenterImage.swift */,
+				0D1D8A5F225F5FB7007CAF4B /* UIButtonAccessibilityExtension.swift */,
 			);
 			path = UIButton;
 			sourceTree = "<group>";
@@ -3738,7 +3741,7 @@
 			isa = PBXGroup;
 			children = (
 				80B2D98E20E54999002F4149 /* UINavigationBarTransparent.swift */,
-				0D91D921224DA570003B3966 /* UINavigationItem.swift */,
+				0D91D921224DA570003B3966 /* UINavigationItemAccessibilityExtension.swift */,
 			);
 			path = UINavigationBar;
 			sourceTree = "<group>";
@@ -5118,7 +5121,7 @@
 				35E892C6201CDCBC00B4BE5A /* OAuthManager.swift in Sources */,
 				897083D51F8CF08100233561 /* TextFieldTableViewCell.swift in Sources */,
 				9928225F204DDC8C005D2067 /* EditProfileViewModel.swift in Sources */,
-				0D91D922224DA570003B3966 /* UINavigationItem.swift in Sources */,
+				0D91D922224DA570003B3966 /* UINavigationItemAccessibilityExtension.swift in Sources */,
 				802498EE1F7A8380005477EC /* MeRequest.swift in Sources */,
 				897083D71F8CF08100233561 /* FormTableViewCell.swift in Sources */,
 				412BCC8B1E55D4AA00F7F4EE /* UIColorCSSColorsExtension.swift in Sources */,
@@ -5336,6 +5339,7 @@
 				998E64982161ADE200E7C45A /* TextAttachmentCell.swift in Sources */,
 				419EB5BD215E69FF00E591BF /* ReactionsCell.swift in Sources */,
 				99BE4D822152D56E001A43E2 /* MessagesViewController.swift in Sources */,
+				0D1D8A60225F5FB7007CAF4B /* UIButtonAccessibilityExtension.swift in Sources */,
 				4151B4581E2D1D2E00F8AA1B /* MessageModelMapping.swift in Sources */,
 				41865AF21FC8B23400A5E48F /* WebViewControllerEmbedded.swift in Sources */,
 				414B3B25203E2F2C0078D3D9 /* MainSplitViewController.swift in Sources */,

--- a/Rocket.Chat.xcodeproj/project.pbxproj
+++ b/Rocket.Chat.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		0BC0E8612032DB20004BFAAF /* DrawingBrushColorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC0E8602032DB20004BFAAF /* DrawingBrushColorSpec.swift */; };
 		0BC0E8632032DD95004BFAAF /* DrawingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC0E8622032DD95004BFAAF /* DrawingViewModel.swift */; };
 		0BC0E8652032DF9B004BFAAF /* DrawingViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC0E8642032DF9B004BFAAF /* DrawingViewModelSpec.swift */; };
+		0D91D922224DA570003B3966 /* UINavigationItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D91D921224DA570003B3966 /* UINavigationItem.swift */; };
 		140A95DE202F1E6F003FD564 /* ChangeAppIconViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140A95DD202F1E6F003FD564 /* ChangeAppIconViewModelSpec.swift */; };
 		140A95E1202F526C003FD564 /* Drawing.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 140A95E0202F526C003FD564 /* Drawing.storyboard */; };
 		140A95E4202F536D003FD564 /* DrawingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140A95E3202F536D003FD564 /* DrawingViewController.swift */; };
@@ -985,6 +986,7 @@
 		0BC0E8602032DB20004BFAAF /* DrawingBrushColorSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingBrushColorSpec.swift; sourceTree = "<group>"; };
 		0BC0E8622032DD95004BFAAF /* DrawingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingViewModel.swift; sourceTree = "<group>"; };
 		0BC0E8642032DF9B004BFAAF /* DrawingViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingViewModelSpec.swift; sourceTree = "<group>"; };
+		0D91D921224DA570003B3966 /* UINavigationItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationItem.swift; sourceTree = "<group>"; };
 		0F5191CD6C53AEA006C82524 /* Pods_Rocket_Chat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rocket_Chat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		140A95DD202F1E6F003FD564 /* ChangeAppIconViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeAppIconViewModelSpec.swift; sourceTree = "<group>"; };
 		140A95E0202F526C003FD564 /* Drawing.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Drawing.storyboard; sourceTree = "<group>"; };
@@ -3736,6 +3738,7 @@
 			isa = PBXGroup;
 			children = (
 				80B2D98E20E54999002F4149 /* UINavigationBarTransparent.swift */,
+				0D91D921224DA570003B3966 /* UINavigationItem.swift */,
 			);
 			path = UINavigationBar;
 			sourceTree = "<group>";
@@ -5115,6 +5118,7 @@
 				35E892C6201CDCBC00B4BE5A /* OAuthManager.swift in Sources */,
 				897083D51F8CF08100233561 /* TextFieldTableViewCell.swift in Sources */,
 				9928225F204DDC8C005D2067 /* EditProfileViewModel.swift in Sources */,
+				0D91D922224DA570003B3966 /* UINavigationItem.swift in Sources */,
 				802498EE1F7A8380005477EC /* MeRequest.swift in Sources */,
 				897083D71F8CF08100233561 /* FormTableViewCell.swift in Sources */,
 				412BCC8B1E55D4AA00F7F4EE /* UIColorCSSColorsExtension.swift in Sources */,

--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -69,6 +69,7 @@ final class AuthTableViewController: BaseTableViewController {
         }
 
         collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
+        collapsibleAuthSeparatorRow.showMoreButton.applyShowMoreButtonAccessibility()
         collapsibleAuthSeparatorRow.showOrHideLoginServices = { [weak self] in
             self?.showOrHideLoginServices()
         }
@@ -257,12 +258,14 @@ final class AuthTableViewController: BaseTableViewController {
         if isLoginServicesCollapsed {
             UIView.animate(withDuration: 0.5) {
                 self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
+                self.collapsibleAuthSeparatorRow.showMoreButton.applyShowMoreButtonAccessibility()
             }
 
             tableView.deleteRows(at: extraLoginServiceIndexPaths, with: .automatic)
         } else {
             UIView.animate(withDuration: 0.5) {
                 self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi * 2)
+                self.collapsibleAuthSeparatorRow.showMoreButton.applyShowLessButtonAccessibility()
             }
 
             tableView.insertRows(at: extraLoginServiceIndexPaths, with: .automatic)

--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -126,6 +126,7 @@ final class AuthTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         title = serverURL?.host
+        navigationItem.moreButton()
         setupTableView()
 
         guard let settings = serverPublicSettings else { return }

--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -126,7 +126,7 @@ final class AuthTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         title = serverURL?.host
-        navigationItem.moreButton()
+        navigationItem.applyMoreButtonAccessibility()
         setupTableView()
 
         guard let settings = serverPublicSettings else { return }

--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -87,6 +87,7 @@ final class ConnectServerViewController: BaseViewController {
             navigationItem.leftBarButtonItem = nil
         } else {
             navigationItem.leftBarButtonItem = buttonClose
+            navigationItem.applyCloseButtonAccessibility()
         }
 
         selectedServer = DatabaseManager.selectedIndex

--- a/Rocket.Chat/Controllers/Auth/LegalTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LegalTableViewController.swift
@@ -26,6 +26,8 @@ class LegalTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        navigationItem.title = localized("auth.login.legal")
+
         if let nav = navigationController as? AuthNavigationController {
             nav.setGrayTheme()
         }

--- a/Rocket.Chat/Controllers/Auth/LegalTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LegalTableViewController.swift
@@ -27,6 +27,7 @@ class LegalTableViewController: UITableViewController {
         super.viewDidLoad()
 
         navigationItem.title = localized("auth.login.legal")
+        navigationItem.applyCloseButtonAccessibility()
 
         if let nav = navigationController as? AuthNavigationController {
             nav.setGrayTheme()

--- a/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
@@ -102,6 +102,7 @@ class LoginTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = serverURL?.host
+        navigationItem.rightBarButtonItem?.title = localized("auth.more")
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
@@ -102,7 +102,7 @@ class LoginTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = serverURL?.host
-        navigationItem.rightBarButtonItem?.title = localized("auth.more")
+        navigationItem.moreButton()
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
@@ -102,7 +102,7 @@ class LoginTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = serverURL?.host
-        navigationItem.moreButton()
+        navigationItem.applyMoreButtonAccessibility()
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/SignupCustomFieldsTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/SignupCustomFieldsTableViewController.swift
@@ -47,7 +47,7 @@ class SignupCustomFieldsTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = SocketManager.sharedInstance.serverURL?.host
-        navigationItem.moreButton()
+        navigationItem.applyMoreButtonAccessibility()
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/SignupCustomFieldsTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/SignupCustomFieldsTableViewController.swift
@@ -47,6 +47,7 @@ class SignupCustomFieldsTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = SocketManager.sharedInstance.serverURL?.host
+        navigationItem.rightBarButtonItem?.title = localized("auth.more")
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/SignupCustomFieldsTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/SignupCustomFieldsTableViewController.swift
@@ -47,7 +47,7 @@ class SignupCustomFieldsTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = SocketManager.sharedInstance.serverURL?.host
-        navigationItem.rightBarButtonItem?.title = localized("auth.more")
+        navigationItem.moreButton()
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/SignupTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/SignupTableViewController.swift
@@ -49,7 +49,7 @@ final class SignupTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = SocketManager.sharedInstance.serverURL?.host
-        navigationItem.rightBarButtonItem?.title = localized("auth.more")
+        navigationItem.moreButton()
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/SignupTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/SignupTableViewController.swift
@@ -49,6 +49,7 @@ final class SignupTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = SocketManager.sharedInstance.serverURL?.host
+        navigationItem.rightBarButtonItem?.title = localized("auth.more")
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/SignupTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/SignupTableViewController.swift
@@ -49,7 +49,7 @@ final class SignupTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = SocketManager.sharedInstance.serverURL?.host
-        navigationItem.moreButton()
+        navigationItem.applyMoreButtonAccessibility()
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/WelcomeViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/WelcomeViewController.swift
@@ -79,6 +79,7 @@ final class WelcomeViewController: BaseViewController {
             )
 
             joinCommunityButton.setAttributedTitle(combinedString, for: .normal)
+            joinCommunityButton.accessibilityLabel = "\(title.string), \(serverURL.string)"
         }
     }
 

--- a/Rocket.Chat/Controllers/Base/BaseTableViewController.swift
+++ b/Rocket.Chat/Controllers/Base/BaseTableViewController.swift
@@ -12,6 +12,8 @@ class BaseTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        self.navigationItem.rightBarButtonItem?.title = localized("auth.more")
+
         ThemeManager.addObserver(self)
 
         self.navigationItem.backBarButtonItem = UIBarButtonItem(

--- a/Rocket.Chat/Controllers/Base/BaseTableViewController.swift
+++ b/Rocket.Chat/Controllers/Base/BaseTableViewController.swift
@@ -12,8 +12,6 @@ class BaseTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.navigationItem.rightBarButtonItem?.title = localized("auth.more")
-
         ThemeManager.addObserver(self)
 
         self.navigationItem.backBarButtonItem = UIBarButtonItem(

--- a/Rocket.Chat/Extensions/UIButton/UIButtonAccessibilityExtension.swift
+++ b/Rocket.Chat/Extensions/UIButton/UIButtonAccessibilityExtension.swift
@@ -1,0 +1,19 @@
+//
+//  UIButtonAccessibilityExtension.swift
+//  Rocket.Chat
+//
+//  Created by Rudrank Riyam on 11/04/19.
+//  Copyright © 2019 Rocket.Chat. All rights reserved.
+//
+
+import UIKit
+
+extension UIButton {
+    func applyShowMoreButtonAccessibility() {
+        accessibilityLabel = VOLocalizedString("auth.show_more_options.label")
+    }
+
+    func applyShowLessButtonAccessibility() {
+        accessibilityLabel = VOLocalizedString("auth.show_less_options.label")
+    }
+}

--- a/Rocket.Chat/Extensions/UINavigationBar/UINavigationItem.swift
+++ b/Rocket.Chat/Extensions/UINavigationBar/UINavigationItem.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension UINavigationItem {
-    func moreButton() {
-        rightBarButtonItem?.accessibilityLabel = localized("auth.more")
+    func applyMoreButtonAccessibility() {
+        rightBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.more.label")
     }
 }

--- a/Rocket.Chat/Extensions/UINavigationBar/UINavigationItem.swift
+++ b/Rocket.Chat/Extensions/UINavigationBar/UINavigationItem.swift
@@ -12,4 +12,8 @@ extension UINavigationItem {
     func applyMoreButtonAccessibility() {
         rightBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.more.label")
     }
+
+    func applyCloseButtonAccessibility() {
+        leftBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.close.label")
+    }
 }

--- a/Rocket.Chat/Extensions/UINavigationBar/UINavigationItem.swift
+++ b/Rocket.Chat/Extensions/UINavigationBar/UINavigationItem.swift
@@ -1,0 +1,15 @@
+//
+//  UINavigationItem.swift
+//  Rocket.Chat
+//
+//  Created by Rudrank Riyam on 29/03/19.
+//  Copyright © 2019 Rocket.Chat. All rights reserved.
+//
+
+import UIKit
+
+extension UINavigationItem {
+    func moreButton() {
+        rightBarButtonItem?.accessibilityLabel = localized("auth.more")
+    }
+}

--- a/Rocket.Chat/Extensions/UINavigationBar/UINavigationItemAccessibilityExtension.swift
+++ b/Rocket.Chat/Extensions/UINavigationBar/UINavigationItemAccessibilityExtension.swift
@@ -1,5 +1,5 @@
 //
-//  UINavigationItem.swift
+//  UINavigationItemAccessibilityExtension.swift
 //  Rocket.Chat
 //
 //  Created by Rudrank Riyam on 29/03/19.

--- a/Rocket.Chat/Resources/cs.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/cs.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "e-mail"; // TODO
 "auth.login_service_prefix" = "Continue with "; // TODO
 
-"auth.more" = "More"; // TODO
-
 "auth.signup_title" = "Sign up"; // TODO
 "auth.signup.button_register" = "Register"; // TODO
 "auth.signup.button_next" = "Next"; // TODO

--- a/Rocket.Chat/Resources/cs.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/cs.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "e-mail"; // TODO
 "auth.login_service_prefix" = "Continue with "; // TODO
 
+"auth.more" = "More"; // TODO
+
 "auth.signup_title" = "Sign up"; // TODO
 "auth.signup.button_register" = "Register"; // TODO
 "auth.signup.button_next" = "Next"; // TODO
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "Forgot password";
 "auth.login.agree_label" = "By proceeding you are agreeing to our";
 "auth.login.agree_and" = "and";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Terms of Service";
 "auth.login.agree_privacypolicy" = "Privacy Policy";
 

--- a/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "Insert your server's URL here.";
 
 "auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
 
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";

--- a/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "Server URL";
 "auth.connect.urlfield.hint" = "Insert your server's URL here.";
 
+"auth.more.label" = "More"; // TODO
+
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";
 "auth.authentication.password.label" = "Password";

--- a/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "More"; // TODO
 "auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";

--- a/Rocket.Chat/Resources/de.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/de.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "E-Mail";
 "auth.login_service_prefix" = "Fortfahren mit ";
 
+"auth.more" = "More"; // TODO
+
 "auth.signup_title" = "Registrieren";
 "auth.signup.button_register" = "Registrieren";
 "auth.signup.button_next" = "Weiter";
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "Passwort vergessen";
 "auth.login.agree_label" = "Indem Sie fortfahren, erklären Sie sich einverstanden mit unseren";
 "auth.login.agree_and" = "und";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Allgemeinen Geschäftsbedingungen";
 "auth.login.agree_privacypolicy" = "Datenschutzerklärung";
 

--- a/Rocket.Chat/Resources/de.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/de.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "E-Mail";
 "auth.login_service_prefix" = "Fortfahren mit ";
 
-"auth.more" = "More"; // TODO
-
 "auth.signup_title" = "Registrieren";
 "auth.signup.button_register" = "Registrieren";
 "auth.signup.button_next" = "Weiter";

--- a/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "Geben Sie hier die URL Ihres Servers ein.";
 
 "auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
 
 "auth.authentication.emailorusername.label" = "E-Mail oder Benutzername";
 "auth.authentication.emailorusername.hint" = "Geben Sie hier Ihre E-Mail-Adresse oder Ihren Benutzernamen ein.";

--- a/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "Server URL";
 "auth.connect.urlfield.hint" = "Geben Sie hier die URL Ihres Servers ein.";
 
+"auth.more.label" = "More"; // TODO
+
 "auth.authentication.emailorusername.label" = "E-Mail oder Benutzername";
 "auth.authentication.emailorusername.hint" = "Geben Sie hier Ihre E-Mail-Adresse oder Ihren Benutzernamen ein.";
 "auth.authentication.password.label" = "Passwort";

--- a/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "More"; // TODO
 "auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "E-Mail oder Benutzername";
 "auth.authentication.emailorusername.hint" = "Geben Sie hier Ihre E-Mail-Adresse oder Ihren Benutzernamen ein.";

--- a/Rocket.Chat/Resources/el.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/el.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "e-mail"; // TODO
 "auth.login_service_prefix" = "Συνέχεια με ";
 
-"auth.more" = "More"; // TODO
-
 "auth.signup_title" = "Εγγραφή"; 
 "auth.signup.button_register" = "Εγγραφείτε"; 
 "auth.signup.button_next" = "Επόμενο"; 

--- a/Rocket.Chat/Resources/el.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/el.lproj/Localizable.strings
@@ -3,7 +3,7 @@
 "global.yes" = "Ναι";
 "global.no" = "Όχι";
 "global.cancel" = "Ακύρωση";
-"global.error" = "λάθος";
+"global.error" = "Λάθος";
 
 // Errors
 "error.socket.default_error.title" = "Ωπ!";
@@ -22,8 +22,8 @@
 "alert.connection.invalid_url.title" = "Ωπ!";
 "alert.connection.invalid_url.message" = "Το URL που εισάγατε είναι άκυρο. Παρακαλούμε ελέγξτε το και ξαναπροσπαθήστε!";
 
-"alert.connection.not_secured.title" = "Ωπ!"; 
-"alert.connection.not_secured.message" = "Δεν μπορέσαμε να εγκαθιδρύσουμε ασφαλή σύνεση με τον εξυπηρετητή. Παρακαλούμε επιβεβαιώστε ότι ο εξυπηρετητής υποστηρίζει SSL."; 
+"alert.connection.not_secured.title" = "Ωπ!";
+"alert.connection.not_secured.message" = "Δεν μπορέσαμε να εγκαθιδρύσουμε ασφαλή σύνεση με τον εξυπηρετητή. Παρακαλούμε επιβεβαιώστε ότι ο εξυπηρετητής υποστηρίζει SSL.";
 
 "alert.connection.socket_error.title" = "Ωπ!";
 "alert.connection.socket_error.message" = "Δεν είναι δυνατή η σύνδεση σε αυτόν τον εξυπηρετητή!";
@@ -50,7 +50,7 @@
 "alert.authorization_error.create_channel.description" = "Δεν μπορείτε να δημιουργήστετε κανάλια";
 
 "alert.unsupported_feature.title" = "Η λειτουργικότητα δεν υποστηρίζεται";
-"alert.unsupported_feature.message" = "Η έκδοση του εξυπηρετητή είναι: %@. Αητή η λειτουργικότητα υποστηρίζεται μονο σε εκδόσεις %@ και άνω.";
+"alert.unsupported_feature.message" = "Η έκδοση του εξυπηρετητή είναι: %@. Αυτή η λειτουργικότητα υποστηρίζεται μόνο σε εκδόσεις %@ και άνω.";
 
 "alert.upload_error.title" = "Σφάλμα στο ανέβασμα";
 "alert.upload_error.message" = "Συνέβη κάποιο σφάλμα ενώ ανεβάζατε το αρχείο σας. Παρακαλούμε ξαναπροσπαθήστε.";
@@ -63,27 +63,27 @@
 "alert.email_verification.title" = "Επαλήθευση Email";
 "alert.email_verification.message" = "Σας στείλαμε ένα email για να επιβεβαιώσουμε την εγγραφή σας. Αν δεν το λάβετε σύντομα, παρακαλούμε επιστρέψτε και ξαναπροσπαθήστε.";
 
-"alert.discarding_changes.title" = "Μη αποθηκευμένες αλλαγές"; 
-"alert.discarding_changes.message" = "Οι μη αποθηκευμένες αλλαγές σας έχουν απορριφθεί."; 
-"alert.load_profile_error.title" = "Απέτυχε η φόρτωση του λογαριασμού σας"; 
-"alert.load_profile_error.message" = "Συνέβη κάποιο σφάλμα καθώς φορτωνόταν το λογαριασμό σας. Παρακαλούμε ξαναπροσπαθήστε."; 
-"alert.password_mismatch_error.title" = "Το συνθηματικό σας δεν ταιριάζει"; 
-"alert.password_mismatch_error.message" = "Το πεδίο επιβεβαίωσης δεν ταιριάζει με το συνθηματικό που καταχωρίσατε. Παρακαλούμε ελέγξτε το και ξαναπροσπαθήστε."; 
-"alert.update_profile_error.title" = "Απέτυχε η ενημέρωση"; 
-"alert.update_profile_error.message" = "Συνέβη κάποιο σφάλμα όταν ενημερωνόταν το προφίλ σας. Παρακαλούμε ξαναπροσπαθήστε."; 
-"alert.update_password_error.title" = "Απέτυχε η τροποποίηση του συνθηματικού"; 
-"alert.update_password_error.message" = "Συνέβη κάποιο σφάλμα ενώ άλλαζε το συνθηματικό. Παρακαλούμε ξαναπροσπαθήστε."; 
-"alert.update_profile_empty_fields.title" = "Παρακαλούμε συμπληρώστε τα κενά πεδία"; 
-"alert.update_profile_empty_fields.message" = "Απαιτείται όλη η πληροφορία του λογαριασμού σας και δεν μπορεί να παραμείνει κενή"; 
-"alert.update_profile_invalid_email.title" = "Μή έγκυρο e-mail"; 
-"alert.update_profile_invalid_email.message" = "Φαίνεται ότι το e-mail που εισαγάγατε δεν είναι έγκυρο. Παρακαλούμε διορθώστε το και ξαναπροσπαθήστε."; 
-"alert.password_empty_fields.title" = "Παρακαλούμε συμπληρώστε τα κενά πεδία"; 
-"alert.password_empty_fields.message" = "Συμπληρώστε το συνθηματικό και τα πεδία επιβεβαίωσης ώστε να ενημερώσετε το συνθηματικό σας."; 
-"alert.update_profile_success.title" = "Ο Λογαριασμός ενημερώθηκε"; 
-"alert.update_password_success.title" = "Το συνθηματικό ενημερώθηκε"; 
+"alert.discarding_changes.title" = "Μη αποθηκευμένες αλλαγές";
+"alert.discarding_changes.message" = "Οι μη αποθηκευμένες αλλαγές σας έχουν απορριφθεί.";
+"alert.load_profile_error.title" = "Απέτυχε η φόρτωση του λογαριασμού σας";
+"alert.load_profile_error.message" = "Συνέβη κάποιο σφάλμα καθώς φορτωνόταν το λογαριασμό σας. Παρακαλούμε ξαναπροσπαθήστε.";
+"alert.password_mismatch_error.title" = "Το συνθηματικό σας δεν ταιριάζει";
+"alert.password_mismatch_error.message" = "Το πεδίο επιβεβαίωσης δεν ταιριάζει με το συνθηματικό που καταχωρίσατε. Παρακαλούμε ελέγξτε το και ξαναπροσπαθήστε.";
+"alert.update_profile_error.title" = "Απέτυχε η ενημέρωση";
+"alert.update_profile_error.message" = "Συνέβη κάποιο σφάλμα όταν ενημερωνόταν το προφίλ σας. Παρακαλούμε ξαναπροσπαθήστε.";
+"alert.update_password_error.title" = "Απέτυχε η τροποποίηση του συνθηματικού";
+"alert.update_password_error.message" = "Συνέβη κάποιο σφάλμα ενώ άλλαζε το συνθηματικό. Παρακαλούμε ξαναπροσπαθήστε.";
+"alert.update_profile_empty_fields.title" = "Παρακαλούμε συμπληρώστε τα κενά πεδία";
+"alert.update_profile_empty_fields.message" = "Απαιτείται όλη η πληροφορία του λογαριασμού σας και δεν μπορεί να παραμείνει κενή";
+"alert.update_profile_invalid_email.title" = "Μή έγκυρο e-mail";
+"alert.update_profile_invalid_email.message" = "Φαίνεται ότι το e-mail που εισαγάγατε δεν είναι έγκυρο. Παρακαλούμε διορθώστε το και ξαναπροσπαθήστε.";
+"alert.password_empty_fields.title" = "Παρακαλούμε συμπληρώστε τα κενά πεδία";
+"alert.password_empty_fields.message" = "Συμπληρώστε το συνθηματικό και τα πεδία επιβεβαίωσης ώστε να ενημερώσετε το συνθηματικό σας.";
+"alert.update_profile_success.title" = "Ο Λογαριασμός ενημερώθηκε";
+"alert.update_password_success.title" = "Το συνθηματικό ενημερώθηκε";
 
-"alert.logout.confirmation.title" = "Αποσύνδεση από αυτό τον εξυπηρετητή"; 
-"alert.logout.confirmation.message" = "Σίγουρα θέλετε να αποσυνδεθείτε από \"%@\"?"; 
+"alert.logout.confirmation.title" = "Αποσύνδεση από αυτό τον εξυπηρετητή";
+"alert.logout.confirmation.message" = "Σίγουρα θέλετε να αποσυνδεθείτε από \"%@\"?";
 "alert.logout.confirmation.confirm" = "Ναι, αποσυνδέστε με";
 
 // Connection Redirect
@@ -92,37 +92,37 @@
 "connection.server.redirect.alert.confirm" = "Ναι, αλλάξτε το URL";
 
 // Socket Connection
-"connection.title" = "Συνδεθείτε στον εξυπηρετητή σας"; 
+"connection.title" = "Συνδεθείτε στον εξυπηρετητή σας";
 "connection.button_connect" = "Σύνδεση";
-"connection.server_url.placeholder" = "your-company.rocket.chat"; // TODO
+"connection.server_url.placeholder" = "δική-σας-εταιρία.rocket.chat";
 "connection.offline.banner.message" = "Βρίσκεστε εκτός σύνδεσης, προσπαθήστε να συνδεθείτε ξανά";
 "connection.connecting.banner.message" = "Συνδεόμαστε...";
-"connection.waiting_for_network.banner.message" = "Περιμένετε για το δίκτυο"; 
+"connection.waiting_for_network.banner.message" = "Περιμένετε για το δίκτυο";
 
 // Onboarding
-"onboarding.label_welcome" = "Καλώς ορίσατε στο Rocket Chat"; 
-"onboarding.label_subtitle" = "Team Communication"; // TODO
-"onboarding.button_connect_server" = "Συνδεθείτε σε ένα εξυπηρετητή"; 
-"onboarding.button_create_server" = "Συνδεθείτε σε ένα Χώρο Εργασίας"; 
-"onboarding.button_join_community_prefix" = "Συνδεθείτε με την κοινότητα"; 
+"onboarding.label_welcome" = "Καλωσήρθατε στο Rocket Chat";
+"onboarding.label_subtitle" = "Επικοινωνία Ομάδας";
+"onboarding.button_connect_server" = "Συνδεθείτε σε ένα εξυπηρετητή";
+"onboarding.button_create_server" = "Συνδεθείτε σε ένα Χώρο Εργασίας";
+"onboarding.button_join_community_prefix" = "Συνδεθείτε με την κοινότητα";
 
 // Auth
 "auth.connect.button_connect" = "Σύνδεση";
 "auth.connect.ssl_required" = "Απαιτείται υποστήριξη SSL στον εξυπηρετητή";
 "auth.connect.connecting" = "Σύνδεση σε εξέλιξη. Περιμένετε παρακαλώ";
-"auth.email_auth_prefix" = "Σύνδεση με "; 
-"auth.email_auth" = "e-mail"; // TODO
+"auth.email_auth_prefix" = "Σύνδεση με ";
+"auth.email_auth" = "e-mail"; // TODO: maybe should not be translated
 "auth.login_service_prefix" = "Συνέχεια με ";
 
-"auth.signup_title" = "Εγγραφή"; 
-"auth.signup.button_register" = "Εγγραφείτε"; 
-"auth.signup.button_next" = "Επόμενο"; 
-"auth.signup.custom_fields_title" = "Ολοκληρώστε την εγγραφή σας"; 
+"auth.signup_title" = "Εγγραφή";
+"auth.signup.button_register" = "Εγγραφείτε";
+"auth.signup.button_next" = "Επόμενο";
+"auth.signup.custom_fields_title" = "Ολοκληρώστε την εγγραφή σας";
 
-"auth.login.login_title" = "Σύνδεση";  
-"auth.login.button_login_title" = "Σύνδεση"; 
-"auth.login.create_account_prefix" = "Δεν έχετε Λογαριασμό;"; 
-"auth.login.create_account" = "\nΔημιουργήστε ένα Λογαριασμό"; 
+"auth.login.login_title" = "Σύνδεση";
+"auth.login.button_login_title" = "Σύνδεση";
+"auth.login.create_account_prefix" = "Δεν έχετε Λογαριασμό;";
+"auth.login.create_account" = "\nΔημιουργήστε ένα Λογαριασμό";
 "auth.login.username.placeholder" = "Email ή όνομα χρήστη";
 "auth.login.password.placeholder" = "Συνθηματικό";
 "auth.login.buttonRegister" = "Δημιουργήστε νέο λογαριασμό";
@@ -153,11 +153,11 @@
 "subscriptions.list.no_message" = "Κανένα μήνυμα";
 "subscriptions.list.sent_an_attachment" = "στείλτε ένα συνημμένο";
 "subscriptions.list.date.yesterday" = "Εχθές";
-"subscriptions.list.actions.read" = "Read"; // TODO
-"subscriptions.list.actions.unread" = "Unread"; // TODO
-"subscriptions.list.actions.favorite" = "Favorite"; // TODO
-"subscriptions.list.actions.unfavorite" = "Unfavorite"; // TODO
-"subscriptions.list.actions.hide" = "Hide"; // TODO
+"subscriptions.list.actions.read" = "Αναγνωσμένο";
+"subscriptions.list.actions.unread" = "Αδιάβαστο";
+"subscriptions.list.actions.favorite" = "Αγαπημένο";
+"subscriptions.list.actions.unfavorite" = "Μη αγαπημένο";
+"subscriptions.list.actions.hide" = "Απόκρυψη";
 
 // Servers
 "servers.add_new_team" = "Προσθέστε νέα ομάδας";
@@ -183,7 +183,7 @@
 "new_room.cell.public_channel.description.public_only" = "Μπορείτε να δημιουργείτε μόνο δημόσια κανάλια";
 "new_room.cell.public_channel.description.private_only" = "Μπορείτε να δημιουργείτε μόνο ιδιωτικά κανάλια";
 "new_room.cell.read_only.title" = "Κανάλι μόνο ανάγνωσης";
-"new_room.cell.read_only.description" = "Μόνο εξουσιοδοτημένα μέλη μπορούν να γράψουν νέα μηνύματα"; 
+"new_room.cell.read_only.description" = "Μόνο εξουσιοδοτημένα μέλη μπορούν να γράψουν νέα μηνύματα";
 "new_room.group.channel.name" = "Όνομα Καναλιού";
 "new_room.cell.channel_name.title" = "Όνομα Καναλιού";
 "new_room.group.invite_users" = "Προσκαλέστε χρήστες";
@@ -201,11 +201,11 @@
 "chat.muted" = "Έχετε τεθεί σε σίγαση";
 "chat.loading_messages" = "Φόρτωση μηνυμάτων...";
 "chat.unread_separator" = "νέα μηνύματα";
-"chat.preview.actions.read" = "Mark as read"; // TODO
-"chat.preview.actions.unread" = "Mark as unread"; // TODO
-"chat.preview.actions.favorite" = "Favorite"; // TODO
-"chat.preview.actions.unfavorite" = "Unfavorite"; // TODO
-"chat.preview.actions.hide" = "Hide"; // TODO
+"chat.preview.actions.read" = "Σημαδέψτε σαν αναγνωσμένο";
+"chat.preview.actions.unread" = "Σημαδέψτε σαν μη αναγνωσμένο";
+"chat.preview.actions.favorite" = "Αγαπημένο";
+"chat.preview.actions.unfavorite" = "Μη αγαπημένο";
+"chat.preview.actions.hide" = "Κρυφό";
 
 // Read Receipts
 "chat.read_receipt_list.title" = "Διαβάστηκε από";
@@ -220,12 +220,12 @@
 "chat.message.actions.copy" = "Αντιγράψτε";
 "chat.message.actions.pin" = "Καρφιτσώστε μήνυμα";
 "chat.message.actions.unpin" = "Ξεκαρφιτσώστε μήνυμα";
-"chat.message.actions.star" = "Αστέρι"; 
-"chat.message.actions.unstar" = "Όχι-αστέρι"; 
+"chat.message.actions.star" = "Αστέρι";
+"chat.message.actions.unstar" = "Όχι-αστέρι";
 "chat.message.actions.quote" = "Επιδείξτε μήνυμα";
 "chat.message.actions.reply" = "Απαντήστε σε μήνυμα";
-"chat.message.actions.join_video_call" = "Join Video Call"; // TODO
-"chat.message.actions.permalink" = "Permalink"; //TODO
+"chat.message.actions.join_video_call" = "Συνδεση σε βιντεοκλήση";
+"chat.message.actions.permalink" = "Μόνιμος σύνδεσμος";
 "chat.message.actions.delete" = "Διαγράψτε μήνυμα";
 "chat.message.actions.delete.confirm.title" = "Να διαγράψουμε αυτό το μήνυμα;";
 "chat.message.actions.delete.confirm.message" = "Σίγουρα θέλετε να διαγράψετε αυτό το μήνυμα; Αυτή η διαδικασία δεν μπορεί να ακυρωθεί.";
@@ -268,10 +268,10 @@
 "chat.drawing.settings.color.others" = "Επιλλέξτε χρώμα:";
 
 // Chat Typing
-"chat.users_are_typing" = "%@ are typing..."; // TODO
-"chat.user_is_typing" = "%@ is typing..."; // TODO
-"chat.typing" = "typing..."; // TODO
-"chat.several_typing" = "several users are typing..."; // TODO
+"chat.users_are_typing" = "%@ πληκτρολογούν...";
+"chat.user_is_typing" = "%@ πληκτρολογεί...";
+"chat.typing" = "πληκτρολογεί...";
+"chat.several_typing" = "διαφοροι χρήστες πληκτρολογούν...";
 
 // Message Types
 "chat.message.type.room_name_changed" = "Το όνομα του δωματίου άλλαξε σε: %@ by %@";
@@ -288,12 +288,14 @@
 "chat.message.type.room_archived" = "Αυτό το δωμάτιο αρχειοθετήθηκε από %@";
 "chat.message.type.room_unarchived" = "Αυτό το δωμάτιο αποαρχειοθετήθηκε από %@";
 "chat.message.type.message_pinned" = "Καρφιτσώθηκε ένα μήνυμα:";
-"chat.message.type.message_snippeted" = "Created a snippet: \"%@\""; // TODO
-"chat.message.type.room_changed_privacy" = "Room privacy changed to \"%@\" by %@"; // TODO
-"chat.message.type.room_changed_topic" = "Room topic changed to \"%@\" by %@"; // TODO
-"chat.message.type.room_changed_announcement" = "Room annoucement changed to \"%@\" by %@"; // TODO
-"chat.message.type.room_changed_description" = "Room description changed to \"%@\" by %@"; // TODO
-"chat.message.type.video_call_started" = "Video call started by %@"; // TODO
+"chat.message.type.message_snippeted" = "Δημιουργήστε ένα απόσπασμα: \"%@\"";
+"chat.message.type.room_changed_privacy" = "H Ιδιωτικότητα(απόρρητο) του Δωματίου μεταβλήθηκε σε \"%@\" από %@";
+"chat.message.type.room_changed_topic" = "Το θέμα του δωματίου μεταβλήθηκε σε \"%@\" από %@";
+"chat.message.type.room_changed_announcement" = "Η αναγγελία του δωματίου μεταβλήθηκε σε \"%@\" από %@";
+"chat.message.type.room_changed_description" = "Η περιγραφή του Δωματίου μεταβλήθηκε σε \"%@\" από %@";
+"chat.message.type.video_call_started" = "Μια Βεντοκλήση ξεκίνησε από %@";
+"chat.message.type.discussion_created" = "Started a discussion:"; // TODO
+"chat.message.type.user_joined_conversation" = "Has joined the conversation"; // TODO
 
 // Chat Information
 "chat.info.title" = "Πληροφορία";
@@ -301,13 +303,13 @@
 "chat.info.item.no_topic" = "Όχι θέμα";
 "chat.info.item.description" = "Περιγραφή";
 "chat.info.item.no_description" = "Έλλειψη περιγραφής";
-"chat.info.item.announcement" = "Announcement"; // TODO
-"chat.info.item.no_announcement" = "No announcement"; // TODO
-"chat.info.item.notifications" = "Ειδοποιήσεις";
+"chat.info.item.announcement" = "Αναγγελία";
+"chat.info.item.no_announcement" = "Καμία αναγγελία";
+"chat.info.item.notifications" = "Γνωστοποιήσεις";
 "chat.info.item.members" = "Μέλη";
 "chat.info.item.pinned" = "Καρφιτσωμένα";
 "chat.info.item.starred" = "Αστερωμένα";
-"chat.info.item.mentions" = "Αναφέρθηκαν";
+"chat.info.item.mentions" = "Αναφορές";
 "chat.info.item.files" = "Αρχεία";
 "chat.info.item.share" = "Κοινή Χρήση";
 
@@ -315,18 +317,18 @@
 "chat.members.list.title" = "Μέλη";
 
 // Add Users
-"chat.add_users.title" = "Προσθήκη χρηστών"; 
-"chat.add_users.confirm.title" = "Θα προσθέσετε αυτό το χρήστη;"; 
-"chat.add_users.confirm.message" = "Σίγουρα θέλετε να προσθέσετε '%@' στο '%@'?"; 
+"chat.add_users.title" = "Προσθήκη χρηστών";
+"chat.add_users.confirm.title" = "Θα προσθέσετε αυτό το χρήστη;";
+"chat.add_users.confirm.message" = "Σίγουρα θέλετε να προσθέσετε '%@' στο '%@'?";
 
 // Messages List
 "chat.messages.list.title" = "Μηνύματα";
 "chat.messages.list.empty" = "Δεν βρέθηκαν μηνύματα";
-"chat.messages.list.search.placeholder" = "Αναζήτηση μηνυμάτων"; 
+"chat.messages.list.search.placeholder" = "Αναζήτηση μηνυμάτων";
 "chat.messages.pinned.list.title" = "Καρφιτσωμένα Μηνύματα";
 "chat.messages.starred.list.title" = "Αστερωμένα Μηνύματα";
-"chat.messages.mentions.list.title" = "Αναφέρθηκε"; 
-"chat.messages.files.list.title" = "Αρχεία"; 
+"chat.messages.mentions.list.title" = "Αναφορές";
+"chat.messages.files.list.title" = "Αρχεία";
 "chat.messages.files.list.empty" = "Δεν βρέθηκαν αρχεία";
 
 // Upload Banner
@@ -336,20 +338,20 @@
 
 // Settings
 "myaccount.settings.title" = "Ρυθμίσεις";
-"myaccount.settings.administration" = "Διαχείριση"; 
-"myaccount.settings.logout" = "Αποσύνδεση από %@"; 
+"myaccount.settings.administration" = "Διαχείριση";
+"myaccount.settings.logout" = "Αποσύνδεση από %@";
 "myaccount.settings.contactus" = "Επικοινωνήστε μαζί μας";
-"myaccount.settings.profile" = "Λογαριασμός"; 
+"myaccount.settings.profile" = "Λογαριασμός";
 "myaccount.settings.license" = "Άδεια";
-"myaccount.settings.language" = "Language";
-"myaccount.settings.review" = "Review this App"; // TODO
-"myaccount.settings.share" = "Share this App"; // TODO
+"myaccount.settings.language" = "Γλώσσα";
+"myaccount.settings.review" = "Αξιολογήστε την εφαρμογή";
+"myaccount.settings.share" = "Μοιραστείτε την εφαρμογή";
 "myaccount.settings.appicon" = "Εικονίδιο Εφαρμογής";
 "myaccount.settings.version" = "Έκδοση: %@ (%@)";
-"myaccount.settings.server_version" = "Έκδοση Εξυπηρετητή: %@"; 
-"myaccount.settings.web_browser" = "Πρόγραμμα Περιήγησης"; 
-"myaccount.settings.tracking.title" = "Αποστολή Αναφοράς Κατάρευσης"; 
-"myaccount.settings.tracking.footer" = "Δεν καταγράφουμε ποτέ το περιεχόμενο των συνομιλιών σας. Η αναφορά κατάρευσης πειλαμβάνει μόνο σχετική πληροφορία για μας ώστε να εντοπίσουμε προβλήματα και να τα διορθώσουμε."; 
+"myaccount.settings.server_version" = "Έκδοση Εξυπηρετητή: %@";
+"myaccount.settings.web_browser" = "Πρόγραμμα Περιήγησης";
+"myaccount.settings.tracking.title" = "Αποστολή Αναφοράς Κατάρευσης";
+"myaccount.settings.tracking.footer" = "Δεν καταγράφουμε ποτέ το περιεχόμενο των συνομιλιών σας. Η αναφορά κατάρρευσης περιλαμβάνει μόνο σχετική πληροφορία για μας ώστε να εντοπίσουμε προβλήματα και να τα διορθώσουμε.";
 
 // Change Application Icon
 "myaccount.settings.changeicon.title" = "Επιλέξτε Εικονίδιο";
@@ -363,113 +365,113 @@
 "myaccount.settings.language.message" = "Έχετε μεταβάλει τις ρυθμίσεις γλώσσας. Πρέπει να επανεκκινήσετε το Rocket.Chat ώστε να τεθούν σε εφαρμογή οι νέες ρυθμίσεις.";
 
 // Notifications preferences
-"myaccount.settings.notifications.title" = "Notification Preferences"; // TODO
-"myaccount.settings.notifications.save" = "Save"; // TODO
+"myaccount.settings.notifications.title" = "Προτιμήσεις Γνωστοποιήσεων";
+"myaccount.settings.notifications.save" = "Αποθήκευση";
 
-"myaccount.settings.notifications.receive.title" = "Receive Notifications"; // TODO
-"myaccount.settings.notifications.receive.footer" = "Receive notifications from %@"; // TODO
-"myaccount.settings.notifications.show.title" = "Show Unread Counter"; // TODO
-"myaccount.settings.notifications.show.footer" = "Unread counter is displayed as a badge on to the right of the channel, in the list."; // TODO
+"myaccount.settings.notifications.receive.title" = "Λήψη Γνωστοποιήσεων";
+"myaccount.settings.notifications.receive.footer" = "Λήψη Γνωστοποιήσεων από %@";
+"myaccount.settings.notifications.show.title" = "Εμφάνιση Μετρητή μη αναγνωσμένων";
+"myaccount.settings.notifications.show.footer" = "Ο μετρητής μη αναγνωσμένων εμφανίζεται σαν σήμα στα δεξιά του καναλιού, στη λίστα.";
 
-"myaccount.settings.notifications.inapp" = "In-app and Desktop"; // TODO
-"myaccount.settings.notifications.inapp.alerts" = "Alerts"; // TODO
-"myaccount.settings.notifications.inapp.footer" = "Displays a banner at the top of the screen when the app is open, and displays a notification on desktop."; // TODO
+"myaccount.settings.notifications.inapp" = "Εντός-Εφαρμογής και Επιφάνειας Εργασίας";
+"myaccount.settings.notifications.inapp.alerts" = "Συναγερμοί";
+"myaccount.settings.notifications.inapp.footer" = "Εμφανίζει ένα μπάνερ στην κορυφή της οθόνης όταν η εφαρμογή είναι ανοιχτή, και εμφανίζει μια γνωστοποίηση στην επιφάνεια εργασίας.";
 
-"myaccount.settings.notifications.mobile" = "Mobile"; // TODO
-"myaccount.settings.notifications.mobile.alerts" = "Alerts"; // TODO
-"myaccount.settings.notifications.mobile.footer" = "These notifications are delivered to your device when the app is not open."; // TODO
+"myaccount.settings.notifications.mobile" = "Κινητού";
+"myaccount.settings.notifications.mobile.alerts" = "Συναγερμοί";
+"myaccount.settings.notifications.mobile.footer" = "Αυτές οι γνωστοποιήσεις εμφανίζονται στη συσκευή σας όταν η εφαρμογή δεν είναι ενεργή.";
 
-"myaccount.settings.notifications.desktop" = "Desktop options"; // TODO
-"myaccount.settings.notifications.desktop.audio" = "Audio"; // TODO
-"myaccount.settings.notifications.desktop.sound" = "Sound"; // TODO
-"myaccount.settings.notifications.desktop.duration" = "Notification Duration"; // TODO
+"myaccount.settings.notifications.desktop" = "Επιλογές Επιφάνειας";
+"myaccount.settings.notifications.desktop.audio" = "Ακουστική";
+"myaccount.settings.notifications.desktop.sound" = "Ήχος";
+"myaccount.settings.notifications.desktop.duration" = "Διάρκεια Γνωστοποιήσεων";
 
-"myaccount.settings.notifications.mail" = "Email"; // TODO
-"myaccount.settings.notifications.email.alerts" = "Alerts"; // TODO
+"myaccount.settings.notifications.mail" = "Email"; // TODO: maybe should not be translated
+"myaccount.settings.notifications.email.alerts" = "Συναγερμοί";
 
-"myaccount.settings.notifications.duration.default" = "Default"; // TODO
-"myaccount.settings.notifications.duration.seconds" = "seconds"; // TODO
+"myaccount.settings.notifications.duration.default" = "Προεπιλογή";
+"myaccount.settings.notifications.duration.seconds" = "δευτερόλεπτα";
 
-"alert.update_notifications_preferences_success.title" = "Preferences saved"; // TODO
+"alert.update_notifications_preferences_success.title" = "Οι Προτιμήσεις αποθηκεύτηκαν";
 
-"alert.update_notifications_preferences_save_error.title" = "Failed to update notifications preferences"; // TODO:
-"alert.update_notifications_preferences_save_error.message" = "Something wrong happened while saving your notification preferences. Please, try again."; // TODO
+"alert.update_notifications_preferences_save_error.title" = "Απέτυχε η ενημέρωση των προτιμήσεων γνωστοποιήσεων";
+"alert.update_notifications_preferences_save_error.message" = "Κάποιο σφάλμα συνέβη κατά την αποθήκευση των προτιμήσεών σας για τις Γνωστοποιήσεις. Παρακαλούμε ξαναπροσπαθήστε.";
 
 // Enum SubscriptionNotificationsStatus
-"subscription.notifications.status.default" = "Default"; // TODO
-"subscription.notifications.status.nothing" = "Nothing"; // TODO
-"subscription.notifications.status.all" = "All"; // TODO
-"subscription.notifications.status.mentions" = "Mentions"; // TODO
+"subscription.notifications.status.default" = "Προεπιλογή";
+"subscription.notifications.status.nothing" = "Καμία";
+"subscription.notifications.status.all" = "Όλες";
+"subscription.notifications.status.mentions" = "Αναφορές";
 
 // Enum SubscriptionNotificationsAudioValue
-"subscription.notifications.audio.value.none" = "None"; // TODO
-"subscription.notifications.audio.value.default" = "Default"; // TODO
-"subscription.notifications.audio.value.beep" = "Beep"; // TODO
+"subscription.notifications.audio.value.none" = "Καμία";
+"subscription.notifications.audio.value.default" = "Προεπιλογή";
+"subscription.notifications.audio.value.beep" = "Μπίπ";
 "subscription.notifications.audio.value.chelle" = "Chelle"; // TODO
-"subscription.notifications.audio.value.ding" = "Ding"; // TODO
-"subscription.notifications.audio.value.droplet" = "Droplet"; // TODO
-"subscription.notifications.audio.value.highbell" = "Highbell"; // TODO
-"subscription.notifications.audio.value.seasons" = "Seasons"; // TODO
+"subscription.notifications.audio.value.ding" = "Κουδούνι";
+"subscription.notifications.audio.value.droplet" = "Σταγόνα";
+"subscription.notifications.audio.value.highbell" = "Καμπάνα";
+"subscription.notifications.audio.value.seasons" = "Εποχές";
 
 // Choose Web Browser
 "web_browser.safari.title" = "Safari";
-"web_browser.in_app_safari.title" = "Περιηγητής εντός-εφαρμογής"; 
+"web_browser.in_app_safari.title" = "Περιηγητής εντός-εφαρμογής";
 "web_browser.chrome.title" = "Chrome";
 "web_browser.opera.title" = "Opera Mini";
 "web_browser.firefox.title" = "Firefox";
-"myaccount.settings.web_browser.title" = "Πρόγραμμα Περιήγησης"; 
-"myaccount.settings.web_browser.footer" = "Αυτή η εφαρμογή θα χρησμοποιηθεί για να ανοίξει συνδέσμους στο Rocket Chat."; 
+"myaccount.settings.web_browser.title" = "Πρόγραμμα Περιήγησης";
+"myaccount.settings.web_browser.footer" = "Αυτή η εφαρμογή θα χρησιμοποιηθεί για να ανοίξει συνδέσμους στο Rocket Chat.";
 
 // Update Profile
-"myaccount.settings.profile.title" = "Λογαριασμός"; 
-"myaccount.settings.editing_profile.title" = "Επεξεργασία Λογαριασμού"; 
-"myaccount.settings.profile.actions.save" = "Αποθήκευση"; 
-"myaccount.settings.profile.actions.edit" = "Επεξεργασία"; 
-"myaccount.settings.profile.actions.change_password" = "Αλλάξτε το συνθηματικό σας"; 
-"myaccount.settings.profile.section.profile" = "Λογαριασμός"; 
-"myaccount.settings.profile.section.password" = "Συνθηματικό"; 
-"myaccount.settings.profile.name_placeholder" = "Όνομα"; 
-"myaccount.settings.profile.username_placeholder" = "Όνομα χρήστη"; 
-"myaccount.settings.profile.email_placeholder" = "E-mail"; 
-"myaccount.settings.profile.status.title" = "Κατάσταση"; 
-"myaccount.settings.profile.password_required.title" = "Εισάγετε το συνθηματικό σας"; 
-"myaccount.settings.profile.password_required.message" = "Το συνθηματικό σας είναι απαραίτητο όταν αλλάζετε το e-mail σας."; 
-"myaccount.settings.profile.password_required.placeholder" = "Συνθηματικό"; 
+"myaccount.settings.profile.title" = "Λογαριασμός";
+"myaccount.settings.editing_profile.title" = "Επεξεργασία Λογαριασμού";
+"myaccount.settings.profile.actions.save" = "Αποθήκευση";
+"myaccount.settings.profile.actions.edit" = "Επεξεργασία";
+"myaccount.settings.profile.actions.change_password" = "Αλλάξτε το συνθηματικό σας";
+"myaccount.settings.profile.section.profile" = "Λογαριασμός";
+"myaccount.settings.profile.section.password" = "Συνθηματικό";
+"myaccount.settings.profile.name_placeholder" = "Όνομα";
+"myaccount.settings.profile.username_placeholder" = "Όνομα χρήστη";
+"myaccount.settings.profile.email_placeholder" = "E-mail"; //TODO: maybe should not be translated
+"myaccount.settings.profile.status.title" = "Κατάσταση";
+"myaccount.settings.profile.password_required.title" = "Εισάγετε το συνθηματικό σας";
+"myaccount.settings.profile.password_required.message" = "Το συνθηματικό σας είναι απαραίτητο όταν αλλάζετε το e-mail σας.";
+"myaccount.settings.profile.password_required.placeholder" = "Συνθηματικό";
 
 // New Password
-"myaccount.settings.profile.new_password.title" = "Νέο συνθηματικό"; 
-"myaccount.settings.profile.new_password.section.password" = "Συνθηματικό"; 
-"myaccount.settings.profile.new_password.actions.save" = "Save"; 
-"myaccount.settings.profile.new_password.password_placeholder" = "Νέο συνθηματικό"; 
-"myaccount.settings.profile.new_password.password_confirmation_placeholder" = "Επιβεβαίωση Συνθηματικού"; 
-"myaccount.settings.profile.new_password.password_required.title" = "Εισάγετε το συνθηματικό σας"; 
+"myaccount.settings.profile.new_password.title" = "Νέο συνθηματικό";
+"myaccount.settings.profile.new_password.section.password" = "Συνθηματικό";
+"myaccount.settings.profile.new_password.actions.save" = "Αποθήκευση";
+"myaccount.settings.profile.new_password.password_placeholder" = "Νέο συνθηματικό";
+"myaccount.settings.profile.new_password.password_confirmation_placeholder" = "Επιβεβαίωση Συνθηματικού";
+"myaccount.settings.profile.new_password.password_required.title" = "Εισάγετε το συνθηματικό σας";
 "myaccount.settings.profile.new_password.password_required.message" = "Το τρέχον συνθηματικό είναι απαραίτητο όταν δημιουργείτε ένα νέο συνθηματικό.";
-"myaccount.settings.profile.new_password.password_required.placeholder" = "Συνθηματικό"; 
+"myaccount.settings.profile.new_password.password_required.placeholder" = "Συνθηματικό";
 
 // User Action Sheet
 "user_action_sheet.info" = "Πληροφορία";
-"user_action_sheet.remove" = "Αφαίρεση από το δωμάτιο"; 
-"user_action_sheet.remove_confirm.title" = "Αφαίρεση αυτού του χρήστη;"; 
+"user_action_sheet.remove" = "Αφαίρεση από το δωμάτιο";
+"user_action_sheet.remove_confirm.title" = "Αφαίρεση αυτού του χρήστη;";
 "user_action_sheet.remove_confirm.message" = "Σίγουρα θέλετε να αφαιρεθεί '%@' από το δωμάτιο;";
 
 // User Details
 "user_details.status" = "Κατάσταση";
 "user_details.role" = "Ρόλος";
 "user_details.roles" = "Ρόλοι";
-"user_details.email" = "Email"; // TODO
-"user_details.emails" = "Emails"; // TODO
+"user_details.email" = "Email"; // TODO: maybe should not be translated
+"user_details.emails" = "Emails"; // TODO: maybe should not be translated
 "user_details.timezone" = "Ζώνη ώρας";
 "user_details.message_button" = "Μήνυμα";
-"user_details.voice_call_button" = "Κλήση Ομιλίας";
-"user_details.video_call_button" = "Κλήση Βίντεο";
+"user_details.voice_call_button" = "Φωνητική κλήση";
+"user_details.video_call_button" = "Βιντεοκλήση";
 
 // Theme
-"theme.settings.title" = "Θέμα"; 
-"theme.settings.header" = "ΟΛΑ ΤΑ ΘΕΜΑΤΑ"; 
-"theme.settings.footer" = "Η ενεργοποίηση ενός θέματος θα μεταβάλει τον τρόπο εμφάνισης της μικροεφαρμογής."; 
-"theme.light" = "Φωτεινό"; 
-"theme.dark" = "Σκοτεινό"; 
-"theme.black" = "Μαύρο"; 
+"theme.settings.title" = "Θέμα";
+"theme.settings.header" = "ΟΛΑ ΤΑ ΘΕΜΑΤΑ";
+"theme.settings.footer" = "Η ενεργοποίηση ενός θέματος θα μεταβάλει τον τρόπο εμφάνισης της μικροεφαρμογής.";
+"theme.light" = "Φωτεινό";
+"theme.dark" = "Σκοτεινό";
+"theme.black" = "Μαύρο";
 
 // Sorting & Grouping Subscriptions
 "subscriptions.sorting.title.alphabetical" = "Ταξινόμηση κατά όνομα";
@@ -481,36 +483,41 @@
 "subscriptions.grouping.unread_top" = "Αδιάβαστα στην κορυφή";
 
 // Shortcuts
-"shortcuts.type_message" = "Type message"; //TODO
-"shortcuts.preferences" = "Preferences"; //TODO
-"shortcuts.room_search" = "Rooms search"; //TODO
-"shortcuts.room_selection" = "Room selection 1...9"; //TODO
-"shortcuts.next_room" = "Next room"; //TODO
-"shortcuts.previous_room" = "Previous room"; //TODO
-"shortcuts.new_room" = "New room"; //TODO
-"shortcuts.room_actions" = "Room actions"; //TODO
-"shortcuts.upload_room" = "Upload to room"; //TODO
-"shortcuts.search_messages" = "Search messages"; //TODO
-"shortcuts.scroll_messages" = "Scroll messages"; //TODO
-"shortcuts.reply_latest" = "Reply to latest"; //TODO
-"shortcuts.server_selection" = "Server selection"; //TODO
-"shortcuts.server_selection_numbers" = "Server selection 1...9"; //TODO
-"shortcuts.add_server" = "Add server"; //TODO
-"shortcuts.change_theme" = "Change theme"; //TODO
-"shortcuts.send" = "Send"; //TODO
-"shortcuts.new_line" = "New line"; //TODO
+"shortcuts.type_message" = "Γράψτε μήνυμα";
+"shortcuts.preferences" = "Προτιμήσεις";
+"shortcuts.room_search" = "Αναζήτηση δωματίου";
+"shortcuts.room_selection" = "Επιλογή δωματίου 1...9";
+"shortcuts.next_room" = "Επόμενο δωματιο";
+"shortcuts.previous_room" = "Προηγούμενο δωμάτιο";
+"shortcuts.new_room" = "Νέο δωμάτιο";
+"shortcuts.room_actions" = "Ενέργειες δωματίων";
+"shortcuts.upload_room" = "Μεταφόρτωση στο δωμάτιο";
+"shortcuts.search_messages" = "Αναζήτηση μηνυμάτων";
+"shortcuts.scroll_messages" = "Κοίληση μηνυμάτων";
+"shortcuts.reply_latest" = "Απάντηση στο πιο πρόσφατο";
+"shortcuts.server_selection" = "Επιλογή εξυπηρετητή";
+"shortcuts.server_selection_numbers" = "Επιλογή εξυπηρετητή 1...9";
+"shortcuts.add_server" = "Προσθήκη εξυπηρετητή";
+"shortcuts.change_theme" = "Αλλαγή θέματος";
+"shortcuts.send" = "Αποστολή";
+"shortcuts.new_line" = "Νέα γραμμή";
 
 // Chat Components
-"chat.components.quote.replied" = "Replied"; //TODO
-"chat.components.quote.pinned" = "Pinned"; //TODO
-"chat.components.text_attachment.no_title" = "No title"; //TODO
+"chat.components.quote.replied" = "Απαντήθηκε";
+"chat.components.quote.pinned" = "Καρφιτσώθηκε";
+"chat.components.text_attachment.no_title" = "Χωρίς Τίτλο";
 
 // Directory
-"directory.title" = "Directory"; // TODO
-"directory.filters.channels" = "Channels"; // TODO
-"directory.filters.users" = "Users"; // TODO
-"directory.filters.by" = "Search by"; // TODO
-"directory.filters.global.title" = "Search for global users"; // TODO
-"directory.filters.global.subtitle" = "If you turn-on, you can search for any user from others companies or servers. "; // TODO
-"directory.users.1_user" = "1 member"; // TODO
-"directory.users.x_users" = "%@ members"; // TODO
+"directory.title" = "Κατάλογος";
+"directory.filters.channels" = "Κανάλια";
+"directory.filters.users" = "Χρήστες";
+"directory.filters.by" = "Αναζήτηση με";
+"directory.filters.global.title" = "Αναζήτηση για χρήστες παντού";
+"directory.filters.global.subtitle" = "Αν το ενεργοποιήσετε, θα μπορείτε να αναζητήσετε για οποιοδήποτε χρήστη και από άλλες εταιρίες ή εξυπηρετητές. ";
+"directory.users.1_user" = "1 μέλος";
+"directory.users.x_users" = "%@ μέλη";
+
+// Discussions
+"discussion.no_messages" = "No messages yet"; // TODO
+"discussion.1_message" = "1 message"; // TODO
+"discussion.x_messages" = "%@ messages"; // TODO

--- a/Rocket.Chat/Resources/el.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/el.lproj/Localizable.strings
@@ -112,7 +112,9 @@
 "auth.connect.connecting" = "Σύνδεση σε εξέλιξη. Περιμένετε παρακαλώ";
 "auth.email_auth_prefix" = "Σύνδεση με "; 
 "auth.email_auth" = "e-mail"; // TODO
-"auth.login_service_prefix" = "Συνέχεια με "; 
+"auth.login_service_prefix" = "Συνέχεια με ";
+
+"auth.more" = "More"; // TODO
 
 "auth.signup_title" = "Εγγραφή"; 
 "auth.signup.button_register" = "Εγγραφείτε"; 
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "Ξέχασα το συνθηματικό";
 "auth.login.agree_label" = "Συνεχίζοντας συμφωνείτε με τους";
 "auth.login.agree_and" = "και";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Όρους Υπηρεσίας";
 "auth.login.agree_privacypolicy" = "Πολιτική Απορρήτου";
 

--- a/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "More"; // TODO
 "auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "Email ή Όνομα χρήστη";
 "auth.authentication.emailorusername.hint" = "Εισάγετε εδώ το email ή το Όνομα χρήστη σας.";

--- a/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "URL Εξυπηρετητή";
 "auth.connect.urlfield.hint" = "Εισάγετε εδώ το URL του εξυπηρετητή σας.";
 
+"auth.more.label" = "More"; // TODO
+
 "auth.authentication.emailorusername.label" = "Email ή Όνομα χρήστη";
 "auth.authentication.emailorusername.hint" = "Εισάγετε εδώ το email ή το Όνομα χρήστη σας.";
 "auth.authentication.password.label" = "Συνθηματικό";

--- a/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "Εισάγετε εδώ το URL του εξυπηρετητή σας.";
 
 "auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
 
 "auth.authentication.emailorusername.label" = "Email ή Όνομα χρήστη";
 "auth.authentication.emailorusername.hint" = "Εισάγετε εδώ το email ή το Όνομα χρήστη σας.";

--- a/Rocket.Chat/Resources/en.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/en.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Continue with ";
 
-"auth.more" = "More";
-
 "auth.signup_title" = "Sign up";
 "auth.signup.button_register" = "Register";
 "auth.signup.button_next" = "Next";

--- a/Rocket.Chat/Resources/en.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/en.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Continue with ";
 
+"auth.more" = "More";
+
 "auth.signup_title" = "Sign up";
 "auth.signup.button_register" = "Register";
 "auth.signup.button_next" = "Next";
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "Forgot password";
 "auth.login.agree_label" = "By proceeding you are agreeing to our";
 "auth.login.agree_and" = "and";
+"auth.login.legal" = "Legal";
 "auth.login.agree_termsofservice" = "Terms of Service";
 "auth.login.agree_privacypolicy" = "Privacy Policy";
 

--- a/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "More";
 "auth.close.label" = "Close";
+"auth.show_more_options.label" = "Show more options";
+"auth.show_less_options.label" = "Show less options";
 
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";

--- a/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "Insert your server's URL here.";
 
 "auth.more.label" = "More";
+"auth.close.label" = "Close";
 
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";

--- a/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "Server URL";
 "auth.connect.urlfield.hint" = "Insert your server's URL here.";
 
+"auth.more.label" = "More";
+
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";
 "auth.authentication.password.label" = "Password";

--- a/Rocket.Chat/Resources/es.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/es.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "e-mail"; // TODO
 "auth.login_service_prefix" = "Continue with "; // TODO
 
-"auth.more" = "More"; // TODO
-
 "auth.signup_title" = "Sign up"; // TODO
 "auth.signup.button_register" = "Register"; // TODO
 "auth.signup.button_next" = "Next"; // TODO

--- a/Rocket.Chat/Resources/es.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/es.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "e-mail"; // TODO
 "auth.login_service_prefix" = "Continue with "; // TODO
 
+"auth.more" = "More"; // TODO
+
 "auth.signup_title" = "Sign up"; // TODO
 "auth.signup.button_register" = "Register"; // TODO
 "auth.signup.button_next" = "Next"; // TODO
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "Forgot password";
 "auth.login.agree_label" = "By proceeding you are agreeing to our";
 "auth.login.agree_and" = "and";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Terms of Service";
 "auth.login.agree_privacypolicy" = "Privacy Policy";
 

--- a/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "URL del servidor";
 "auth.connect.urlfield.hint" = "Inserta la URL de tu servidor aquí.";
 
+"auth.more.label" = "More"; // TODO
+
 "auth.authentication.emailorusername.label" = "Correo electrónico o nombre de usuario";
 "auth.authentication.emailorusername.hint" = "Inserta tu correo electrónico o nombre de usuario aquí.";
 "auth.authentication.password.label" = "Contraseña";

--- a/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "More"; // TODO
 "auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "Correo electrónico o nombre de usuario";
 "auth.authentication.emailorusername.hint" = "Inserta tu correo electrónico o nombre de usuario aquí.";

--- a/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "Inserta la URL de tu servidor aquí.";
 
 "auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
 
 "auth.authentication.emailorusername.label" = "Correo electrónico o nombre de usuario";
 "auth.authentication.emailorusername.hint" = "Inserta tu correo electrónico o nombre de usuario aquí.";

--- a/Rocket.Chat/Resources/fr.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/fr.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Continuer avec ";
 
+"auth.more" = "Plus";
+
 "auth.signup_title" = "Créer un compte";
 "auth.signup.button_register" = "S'enregistrer";
 "auth.signup.button_next" = "Suivant";
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "Mot de passe oublié";
 "auth.login.agree_label" = "En continuant, vous acceptez notre";
 "auth.login.agree_and" = "et";
+"auth.login.legal" = "Légal";
 "auth.login.agree_termsofservice" = "Conditions de service";
 "auth.login.agree_privacypolicy" = "Politique de confidentialité";
 

--- a/Rocket.Chat/Resources/fr.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/fr.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Continuer avec ";
 
-"auth.more" = "Plus";
-
 "auth.signup_title" = "Créer un compte";
 "auth.signup.button_register" = "S'enregistrer";
 "auth.signup.button_next" = "Suivant";

--- a/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "Plus";
 "auth.close.label" = "Fermer";
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";

--- a/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "Server URL";
 "auth.connect.urlfield.hint" = "Insert your server's URL here.";
 
+"auth.more.label" = "Plus";
+
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";
 "auth.authentication.password.label" = "Password";

--- a/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "Insert your server's URL here.";
 
 "auth.more.label" = "Plus";
+"auth.close.label" = "Fermer";
 
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";

--- a/Rocket.Chat/Resources/it.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/it.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Continua con ";
 
+"auth.more" = "More"; // TODO
+
 "auth.signup_title" = "Iscrizione";
 "auth.signup.button_register" = "Registrati";
 "auth.signup.button_next" = "Avanti";
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "Password dimenticata";
 "auth.login.agree_label" = "Procedendo accetti i nostri";
 "auth.login.agree_and" = "e";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Termini di servizio";
 "auth.login.agree_privacypolicy" = "Politica sulla riservatezza";
 

--- a/Rocket.Chat/Resources/it.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/it.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Continua con ";
 
-"auth.more" = "More"; // TODO
-
 "auth.signup_title" = "Iscrizione";
 "auth.signup.button_register" = "Registrati";
 "auth.signup.button_next" = "Avanti";

--- a/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "Server URL";
 "auth.connect.urlfield.hint" = "Inserisci qui l'URL del tuo server.";
 
+"auth.more.label" = "More"; // TODO
+
 "auth.authentication.emailorusername.label" = "E-mail o nome utente";
 "auth.authentication.emailorusername.hint" = "Inserisci qui il tuo indirizzo e-mail o il tuo nome utente.";
 "auth.authentication.password.label" = "Password";

--- a/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "More"; // TODO
 "auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "E-mail o nome utente";
 "auth.authentication.emailorusername.hint" = "Inserisci qui il tuo indirizzo e-mail o il tuo nome utente.";

--- a/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "Inserisci qui l'URL del tuo server.";
 
 "auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
 
 "auth.authentication.emailorusername.label" = "E-mail o nome utente";
 "auth.authentication.emailorusername.hint" = "Inserisci qui il tuo indirizzo e-mail o il tuo nome utente.";

--- a/Rocket.Chat/Resources/ja.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/ja.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "ログイン";
 "auth.login_service_prefix" = "Continue with ";
 
+"auth.more" = "もっと";
+
 "auth.signup_title" = "サインアップ";
 "auth.signup.button_register" = "登録";
 "auth.signup.button_next" = "次";
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "パスワードをお忘れですか?";
 "auth.login.agree_label" = "続けることで、あなたは私達に同意します。";
 "auth.login.agree_and" = "と";
+"auth.login.legal" = "法的";
 "auth.login.agree_termsofservice" = "利用規約";
 "auth.login.agree_privacypolicy" = "個人情報保護方針";
 

--- a/Rocket.Chat/Resources/ja.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/ja.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "ログイン";
 "auth.login_service_prefix" = "Continue with ";
 
-"auth.more" = "もっと";
-
 "auth.signup_title" = "サインアップ";
 "auth.signup.button_register" = "登録";
 "auth.signup.button_next" = "次";

--- a/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "もっと";
 "auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "メールアドレスまたはユーザー名";
 "auth.authentication.emailorusername.hint" = "ここにメールアドレスまたはユーザー名を入力してください。";

--- a/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "サーバー URL";
 "auth.connect.urlfield.hint" = "ここにサーバーのURLを入力してください。";
 
+"auth.more.label" = "もっと";
+
 "auth.authentication.emailorusername.label" = "メールアドレスまたはユーザー名";
 "auth.authentication.emailorusername.hint" = "ここにメールアドレスまたはユーザー名を入力してください。";
 "auth.authentication.password.label" = "パスワード";

--- a/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "ここにサーバーのURLを入力してください。";
 
 "auth.more.label" = "もっと";
+"auth.close.label" = "Close"; // TODO
 
 "auth.authentication.emailorusername.label" = "メールアドレスまたはユーザー名";
 "auth.authentication.emailorusername.hint" = "ここにメールアドレスまたはユーザー名を入力してください。";

--- a/Rocket.Chat/Resources/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pl.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Kontynuuj z ";
 
+"auth.more" = "More"; // TODO
+
 "auth.signup_title" = "Zarejestruj się";
 "auth.signup.button_register" = "Rejestracja";
 "auth.signup.button_next" = "Dalej";
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "Zapomniałem hasła";
 "auth.login.agree_label" = "Kontynuując zgadzasz się na nasze";
 "auth.login.agree_and" = "i";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Warunku Usług";
 "auth.login.agree_privacypolicy" = "Politykę Prywatności";
 

--- a/Rocket.Chat/Resources/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pl.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Kontynuuj z ";
 
-"auth.more" = "More"; // TODO
-
 "auth.signup_title" = "Zarejestruj się";
 "auth.signup.button_register" = "Rejestracja";
 "auth.signup.button_next" = "Dalej";

--- a/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "Wpisz tutaj adres swojego serwera.";
 
 "auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
 
 "auth.authentication.emailorusername.label" = "E-mail lub nazwa użytkownika";
 "auth.authentication.emailorusername.hint" = "Wpisz tutaj swój e-mail lub nazwę użytkownika.";

--- a/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "Adres serwera";
 "auth.connect.urlfield.hint" = "Wpisz tutaj adres swojego serwera.";
 
+"auth.more.label" = "More"; // TODO
+
 "auth.authentication.emailorusername.label" = "E-mail lub nazwa użytkownika";
 "auth.authentication.emailorusername.hint" = "Wpisz tutaj swój e-mail lub nazwę użytkownika.";
 "auth.authentication.password.label" = "Hasło";

--- a/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "More"; // TODO
 "auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "E-mail lub nazwa użytkownika";
 "auth.authentication.emailorusername.hint" = "Wpisz tutaj swój e-mail lub nazwę użytkownika.";

--- a/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Continuar com ";
 
-"auth.more" = "More"; // TODO
-
 "auth.signup_title" = "Cadastre-se";
 "auth.signup.button_register" = "Cadastrar";
 "auth.signup.button_next" = "Próximo";

--- a/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Continuar com ";
 
+"auth.more" = "More"; // TODO
+
 "auth.signup_title" = "Cadastre-se";
 "auth.signup.button_register" = "Cadastrar";
 "auth.signup.button_next" = "Próximo";
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "Esqueci minha senha";
 "auth.login.agree_label" = "Ao proceder você está concordando com os";
 "auth.login.agree_and" = "e";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Termos de Serviço";
 "auth.login.agree_privacypolicy" = "Política de Privacidade";
 

--- a/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "Insira aqui a URL do servidor.";
 
 "auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
 
 "auth.authentication.emailorusername.label" = "Email ou nome de usuário";
 "auth.authentication.emailorusername.hint" = "Insira aqui o seu email ou nome de usuário.";

--- a/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "More"; // TODO
 "auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "Email ou nome de usuário";
 "auth.authentication.emailorusername.hint" = "Insira aqui o seu email ou nome de usuário.";

--- a/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "URL do servidor";
 "auth.connect.urlfield.hint" = "Insira aqui a URL do servidor.";
 
+"auth.more.label" = "More"; // TODO
+
 "auth.authentication.emailorusername.label" = "Email ou nome de usuário";
 "auth.authentication.emailorusername.hint" = "Insira aqui o seu email ou nome de usuário.";
 "auth.authentication.password.label" = "Senha";

--- a/Rocket.Chat/Resources/pt-PT.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Continuar com ";
 
+"auth.more" = "More"; // TODO
+
 "auth.signup_title" = "Registe-se";
 "auth.signup.button_register" = "Registar";
 "auth.signup.button_next" = "Próximo";
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "Esqueceu a palavra-passe";
 "auth.login.agree_label" = "Ao prosseguir você concorda com o nosso";
 "auth.login.agree_and" = "e";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Termos de Serviço";
 "auth.login.agree_privacypolicy" = "Política de Privacidade";
 

--- a/Rocket.Chat/Resources/pt-PT.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Continuar com ";
 
-"auth.more" = "More"; // TODO
-
 "auth.signup_title" = "Registe-se";
 "auth.signup.button_register" = "Registar";
 "auth.signup.button_next" = "Próximo";

--- a/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "Insira aqui a URL do servidor.";
 
 "auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
 
 "auth.authentication.emailorusername.label" = "Email ou nome de usuário";
 "auth.authentication.emailorusername.hint" = "Insira aqui o seu email ou nome de usuário.";

--- a/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "More"; // TODO
 "auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "Email ou nome de usuário";
 "auth.authentication.emailorusername.hint" = "Insira aqui o seu email ou nome de usuário.";

--- a/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "URL do servidor";
 "auth.connect.urlfield.hint" = "Insira aqui a URL do servidor.";
 
+"auth.more.label" = "More"; // TODO
+
 "auth.authentication.emailorusername.label" = "Email ou nome de usuário";
 "auth.authentication.emailorusername.hint" = "Insira aqui o seu email ou nome de usuário.";
 "auth.authentication.password.label" = "Senha";

--- a/Rocket.Chat/Resources/ru.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/ru.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Продолжить с ";
 
+"auth.more" = "More"; // TODO
+
 "auth.signup_title" = "Зарегистрироваться";
 "auth.signup.button_register" = "Регистрация";
 "auth.signup.button_next" = "Дальше";
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "Забыли пароль";
 "auth.login.agree_label" = "Продолжая, вы соглашаетесь с нашими";
 "auth.login.agree_and" = "и";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Условиями использования";
 "auth.login.agree_privacypolicy" = "Политикой конфиденциальности";
 

--- a/Rocket.Chat/Resources/ru.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/ru.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "e-mail";
 "auth.login_service_prefix" = "Продолжить с ";
 
-"auth.more" = "More"; // TODO
-
 "auth.signup_title" = "Зарегистрироваться";
 "auth.signup.button_register" = "Регистрация";
 "auth.signup.button_next" = "Дальше";

--- a/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "URL-адрес сервера";
 "auth.connect.urlfield.hint" = "Введите URL своего сервера здесь.";
 
+"auth.more.label" = "More"; // TODO
+
 "auth.authentication.emailorusername.label" = "Электронная почта или имя пользователя";
 "auth.authentication.emailorusername.hint" = "Вставьте свою электронную почту или имя пользователя здесь.";
 "auth.authentication.password.label" = "Пароль";

--- a/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "Введите URL своего сервера здесь.";
 
 "auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
 
 "auth.authentication.emailorusername.label" = "Электронная почта или имя пользователя";
 "auth.authentication.emailorusername.hint" = "Вставьте свою электронную почту или имя пользователя здесь.";

--- a/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "More"; // TODO
 "auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "Электронная почта или имя пользователя";
 "auth.authentication.emailorusername.hint" = "Вставьте свою электронную почту или имя пользователя здесь.";

--- a/Rocket.Chat/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/zh-Hans.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "邮箱";
 "auth.login_service_prefix" = "继续";
 
-"auth.more" = "More"; // TODO
-
 "auth.signup_title" = "登录";
 "auth.signup.button_register" = "注册";
 "auth.signup.button_next" = "下一步";

--- a/Rocket.Chat/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/zh-Hans.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "邮箱";
 "auth.login_service_prefix" = "继续";
 
+"auth.more" = "More"; // TODO
+
 "auth.signup_title" = "登录";
 "auth.signup.button_register" = "注册";
 "auth.signup.button_next" = "下一步";
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "忘记密码";
 "auth.login.agree_label" = "继续表示您同意我们的";
 "auth.login.agree_and" = "和";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "服务条款";
 "auth.login.agree_privacypolicy" = "隐私政策";
 

--- a/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "More"; // TODO
 "auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "邮箱地址或用户名";
 "auth.authentication.emailorusername.hint" = "添加邮箱地址或用户名";

--- a/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "服务器地址";
 "auth.connect.urlfield.hint" = "插入服务器地址";
 
+"auth.more.label" = "More"; // TODO
+
 "auth.authentication.emailorusername.label" = "邮箱地址或用户名";
 "auth.authentication.emailorusername.hint" = "添加邮箱地址或用户名";
 "auth.authentication.password.label" = "密码";

--- a/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "插入服务器地址";
 
 "auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
 
 "auth.authentication.emailorusername.label" = "邮箱地址或用户名";
 "auth.authentication.emailorusername.hint" = "添加邮箱地址或用户名";

--- a/Rocket.Chat/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/zh-Hant.lproj/Localizable.strings
@@ -114,8 +114,6 @@
 "auth.email_auth" = "電子郵件";
 "auth.login_service_prefix" = "使用";// TODO : need to add postfix in chinese
 
-"auth.more" = "More"; // TODO
-
 "auth.signup_title" = "登入";
 "auth.signup.button_register" = "註冊";
 "auth.signup.button_next" = "下一步";

--- a/Rocket.Chat/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/zh-Hant.lproj/Localizable.strings
@@ -114,6 +114,8 @@
 "auth.email_auth" = "電子郵件";
 "auth.login_service_prefix" = "使用";// TODO : need to add postfix in chinese
 
+"auth.more" = "More"; // TODO
+
 "auth.signup_title" = "登入";
 "auth.signup.button_register" = "註冊";
 "auth.signup.button_next" = "下一步";
@@ -129,6 +131,7 @@
 "auth.login.buttonResetPassword" = "忘記密碼";
 "auth.login.agree_label" = "繼續表示您同意我們的";
 "auth.login.agree_and" = "和";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "服務條款";
 "auth.login.agree_privacypolicy" = "隱私權政策";
 

--- a/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
@@ -11,6 +11,7 @@
 "auth.connect.urlfield.hint" = "新增伺服器地址";
 
 "auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
 
 "auth.authentication.emailorusername.label" = "電子信箱或用戶名稱";
 "auth.authentication.emailorusername.hint" = "新增電子信箱或用戶名稱";

--- a/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
@@ -12,6 +12,8 @@
 
 "auth.more.label" = "More"; // TODO
 "auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "電子信箱或用戶名稱";
 "auth.authentication.emailorusername.hint" = "新增電子信箱或用戶名稱";

--- a/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
@@ -10,6 +10,8 @@
 "auth.connect.urlfield.label" = "伺服器地址";
 "auth.connect.urlfield.hint" = "新增伺服器地址";
 
+"auth.more.label" = "More"; // TODO
+
 "auth.authentication.emailorusername.label" = "電子信箱或用戶名稱";
 "auth.authentication.emailorusername.hint" = "新增電子信箱或用戶名稱";
 "auth.authentication.password.label" = "密碼";


### PR DESCRIPTION
@RocketChat/ios

TODO - 

- [x] Adding a comma between the accessibility label of "Join the community" and communityServerURL sounds a bit better by creating a pause in VoiceOver dictation.

- [x] The "More" right bar button on Login / Sign up to open Legal terms was not accessible, so I added localised text.

- [x] The cross button is described in VoiceOver as “Stop” button, which needs to be named as “Close” button.

- [x] Localised "Legal" Heading

- [x] "Show more options button" in Login should be accessible. (On the iPhone)
