### PR TITLE
[FIX] "Join Channel" button overlapping home bar on iPhone X/Xr/Xs/Max 

### DIFF
--- a/Rocket.Chat/Controllers/Chat/MessagesViewControllerJoining.swift
+++ b/Rocket.Chat/Controllers/Chat/MessagesViewControllerJoining.swift
@@ -20,9 +20,9 @@ extension MessagesViewController {
             view.addSubview(previewView)
 
             NSLayoutConstraint.activate([
-                previewView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                previewView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                previewView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+                previewView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+                previewView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+                previewView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
             ])
 
             chatPreviewModeView = previewView


### PR DESCRIPTION

@RocketChat/ios

Tiny fix - Safe Layout Guide in ChatPreviewModeView.

![Simulator Screen Shot - iPhone XR - 2019-04-02 at 11 22 06](https://user-images.githubusercontent.com/30552772/55379529-06619280-553b-11e9-9470-ce373a9e36c5.png)

![Screenshot 2019-04-02 at 11 21 48 AM](https://user-images.githubusercontent.com/30552772/55379564-1d07e980-553b-11e9-9f91-87b1cd7b2b0d.png)


Closes #2628 
