### PR TITLE
[FIX] Navigation bar disappears after subscription search

### DIFF
--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
@@ -209,7 +209,7 @@ final class SubscriptionsViewController: BaseViewController {
     func setupSearchBar() {
         let searchController = UISearchController(searchResultsController: nil)
         searchController.dimsBackgroundDuringPresentation = false
-        searchController.hidesNavigationBarDuringPresentation = UIDevice.current.userInterfaceIdiom != .pad
+        searchController.hidesNavigationBarDuringPresentation = UIDevice.current.userInterfaceIdiom == .pad
 
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.largeTitleDisplayMode = .never

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
@@ -208,8 +208,8 @@ final class SubscriptionsViewController: BaseViewController {
 
     func setupSearchBar() {
         let searchController = UISearchController(searchResultsController: nil)
-        searchController.dimsBackgroundDuringPresentation = false
-        searchController.hidesNavigationBarDuringPresentation = UIDevice.current.userInterfaceIdiom == .pad
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.hidesNavigationBarDuringPresentation = false
 
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.largeTitleDisplayMode = .never


### PR DESCRIPTION
@RocketChat/ios

Closes #2631 

Tiny fix, but solved the navigation bar disappearing.

![NavigationBarAfter](https://user-images.githubusercontent.com/30552772/55535736-a521f680-56d5-11e9-9289-ca9382816757.gif)

But, while solving it, I found another bug. 

The "Type a message" Composer View is missing. 
Edit - It is a keyboard dismissal bug. Working on it.
