### PR TITLE
[IMPROVEMENT] Swipe to read messages with uniform colour

### DIFF
--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
@@ -585,6 +585,10 @@ extension SubscriptionsViewController: SwipeTableViewCellDelegate {
         var options = SwipeOptions()
         options.expansionStyle = .selection
         options.transitionStyle = .border
+
+        if orientation == .left {
+            options.backgroundColor = view.theme?.tintColor ?? #colorLiteral(red: 0.2392156869, green: 0.6745098233, blue: 0.9686274529, alpha: 1)
+        }
         return options
     }
 }


### PR DESCRIPTION
@RocketChat/ios

Tiny fix to make the background colour in long swipe gesture same.

![Simulator Screen Shot - iPhone SE - 2019-04-12 at 23 45 25](https://user-images.githubusercontent.com/30552772/56057693-1704da80-5d7d-11e9-92ce-c5f9f559f481.png)

Closes #2230
