### PR TITLE
[NEW] Authentication screen VoiceOver accessible - Project 01

### DIFF
--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -69,7 +69,7 @@ final class AuthTableViewController: BaseTableViewController {
         }
 
         collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
-        collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = VOLocalizedString("auth.show_more_options.label")
+        collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = applyShowMoreButtonAccessibility()
         collapsibleAuthSeparatorRow.showOrHideLoginServices = { [weak self] in
             self?.showOrHideLoginServices()
         }
@@ -253,20 +253,28 @@ final class AuthTableViewController: BaseTableViewController {
         performSegue(withIdentifier: "Signup", sender: self)
     }
 
+    func applyShowMoreButtonAccessibility() -> String? {
+        if isLoginServicesCollapsed {
+            return VOLocalizedString("auth.show_more_options.label")
+        } else {
+            return VOLocalizedString("auth.show_less_options.label")
+        }
+    }
+
     func showOrHideLoginServices() {
         isLoginServicesCollapsed = !isLoginServicesCollapsed
 
         if isLoginServicesCollapsed {
             UIView.animate(withDuration: 0.5) {
                 self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
-                self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = VOLocalizedString("auth.show_more_options.label")
+                self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = self.applyShowMoreButtonAccessibility()
             }
 
             tableView.deleteRows(at: extraLoginServiceIndexPaths, with: .automatic)
         } else {
             UIView.animate(withDuration: 0.5) {
                 self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi * 2)
-                self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = VOLocalizedString("auth.show_less_options.label")
+                self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = self.applyShowMoreButtonAccessibility()
             }
             tableView.insertRows(at: extraLoginServiceIndexPaths, with: .automatic)
         }

--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -121,13 +121,10 @@ final class AuthTableViewController: BaseTableViewController {
         return extraLoginServiceIndexPaths
     }()
 
-    var showMoreButtonAccessibilityLabel: String? {
-        if isLoginServicesCollapsed {
-            return VOLocalizedString("auth.show_more_options.label")
-        } else {
-            return VOLocalizedString("auth.show_less_options.label")
-        }
-    }
+    // MARK: Accessibility
+
+    var showMoreButtonAccessibilityLabel: String? = VOLocalizedString("auth.show_more_options.label")
+    var showLessButtonAccessibilityLabel: String? = VOLocalizedString("auth.show_less_options.label")
 
     // MARK: Life Cycle
 
@@ -265,18 +262,16 @@ final class AuthTableViewController: BaseTableViewController {
         isLoginServicesCollapsed = !isLoginServicesCollapsed
 
         if isLoginServicesCollapsed {
+            collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = showMoreButtonAccessibilityLabel
             UIView.animate(withDuration: 0.5) {
                 self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: .pi)
-                self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel =
-                    self.showMoreButtonAccessibilityLabel
             }
 
             tableView.deleteRows(at: extraLoginServiceIndexPaths, with: .automatic)
         } else {
+            collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = showLessButtonAccessibilityLabel
             UIView.animate(withDuration: 0.5) {
                 self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: .pi * 2)
-                self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel =
-                    self.showMoreButtonAccessibilityLabel
             }
             tableView.insertRows(at: extraLoginServiceIndexPaths, with: .automatic)
         }

--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -254,7 +254,7 @@ final class AuthTableViewController: BaseTableViewController {
     }
 
     var showMoreButtonAccessibilityLabel: String {
-            if isLoginServicesCollapsed {
+        if isLoginServicesCollapsed {
             return VOLocalizedString("auth.show_more_options.label")
         } else {
             return VOLocalizedString("auth.show_less_options.label")

--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -253,8 +253,8 @@ final class AuthTableViewController: BaseTableViewController {
         performSegue(withIdentifier: "Signup", sender: self)
     }
 
-    func applyShowMoreButtonAccessibility() -> String? {
-        if isLoginServicesCollapsed {
+    var showMoreButtonAccessibilityLabel: String {
+            if isLoginServicesCollapsed {
             return VOLocalizedString("auth.show_more_options.label")
         } else {
             return VOLocalizedString("auth.show_less_options.label")
@@ -267,14 +267,16 @@ final class AuthTableViewController: BaseTableViewController {
         if isLoginServicesCollapsed {
             UIView.animate(withDuration: 0.5) {
                 self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
-                self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = self.applyShowMoreButtonAccessibility()
+                self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel =
+                    self.showMoreButtonAccessibilityLabel
             }
 
             tableView.deleteRows(at: extraLoginServiceIndexPaths, with: .automatic)
         } else {
             UIView.animate(withDuration: 0.5) {
-                self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi * 2)
-                self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = self.applyShowMoreButtonAccessibility()
+                self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: pi * 2)
+                self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel =
+                    self.showMoreButtonAccessibilityLabel
             }
             tableView.insertRows(at: extraLoginServiceIndexPaths, with: .automatic)
         }

--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -69,7 +69,7 @@ final class AuthTableViewController: BaseTableViewController {
         }
 
         collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
-        collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = applyShowMoreButtonAccessibility()
+        collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = showMoreButtonAccessibilityLabel
         collapsibleAuthSeparatorRow.showOrHideLoginServices = { [weak self] in
             self?.showOrHideLoginServices()
         }
@@ -253,7 +253,7 @@ final class AuthTableViewController: BaseTableViewController {
         performSegue(withIdentifier: "Signup", sender: self)
     }
 
-    var showMoreButtonAccessibilityLabel: String {
+    var showMoreButtonAccessibilityLabel: String? {
         if isLoginServicesCollapsed {
             return VOLocalizedString("auth.show_more_options.label")
         } else {
@@ -266,7 +266,7 @@ final class AuthTableViewController: BaseTableViewController {
 
         if isLoginServicesCollapsed {
             UIView.animate(withDuration: 0.5) {
-                self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
+                self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: .pi)
                 self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel =
                     self.showMoreButtonAccessibilityLabel
             }
@@ -274,7 +274,7 @@ final class AuthTableViewController: BaseTableViewController {
             tableView.deleteRows(at: extraLoginServiceIndexPaths, with: .automatic)
         } else {
             UIView.animate(withDuration: 0.5) {
-                self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: pi * 2)
+                self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: .pi * 2)
                 self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel =
                     self.showMoreButtonAccessibilityLabel
             }

--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -69,7 +69,7 @@ final class AuthTableViewController: BaseTableViewController {
         }
 
         collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
-        collapsibleAuthSeparatorRow.showMoreButton.applyShowMoreButtonAccessibility()
+        collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = VOLocalizedString("auth.show_more_options.label")
         collapsibleAuthSeparatorRow.showOrHideLoginServices = { [weak self] in
             self?.showOrHideLoginServices()
         }
@@ -127,7 +127,8 @@ final class AuthTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         title = serverURL?.host
-        navigationItem.applyMoreButtonAccessibility()
+        navigationItem.rightBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.more.label")
+
         setupTableView()
 
         guard let settings = serverPublicSettings else { return }
@@ -258,17 +259,15 @@ final class AuthTableViewController: BaseTableViewController {
         if isLoginServicesCollapsed {
             UIView.animate(withDuration: 0.5) {
                 self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
-                self.collapsibleAuthSeparatorRow.showMoreButton.applyShowMoreButtonAccessibility()
+                self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = VOLocalizedString("auth.show_more_options.label")
             }
 
             tableView.deleteRows(at: extraLoginServiceIndexPaths, with: .automatic)
         } else {
             UIView.animate(withDuration: 0.5) {
                 self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi * 2)
-                self.collapsibleAuthSeparatorRow.showMoreButton.applyShowLessButtonAccessibility()
+                self.collapsibleAuthSeparatorRow.showMoreButton.accessibilityLabel = VOLocalizedString("auth.show_less_options.label")
             }
-            
-
             tableView.insertRows(at: extraLoginServiceIndexPaths, with: .automatic)
         }
     }
@@ -361,14 +360,4 @@ extension AuthTableViewController {
 
 extension AuthTableViewController {
     override func applyTheme() { }
-}
-
-extension UIButton {
-    func applyShowMoreButtonAccessibility() {
-        accessibilityLabel = VOLocalizedString("auth.show_more_options.label")
-    }
-
-    func applyShowLessButtonAccessibility() {
-        accessibilityLabel = VOLocalizedString("auth.show_less_options.label")
-    }
 }

--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -69,6 +69,7 @@ final class AuthTableViewController: BaseTableViewController {
         }
 
         collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
+        collapsibleAuthSeparatorRow.showMoreButton.applyShowMoreButtonAccessibility()
         collapsibleAuthSeparatorRow.showOrHideLoginServices = { [weak self] in
             self?.showOrHideLoginServices()
         }
@@ -126,6 +127,7 @@ final class AuthTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         title = serverURL?.host
+        navigationItem.applyMoreButtonAccessibility()
         setupTableView()
 
         guard let settings = serverPublicSettings else { return }
@@ -256,13 +258,16 @@ final class AuthTableViewController: BaseTableViewController {
         if isLoginServicesCollapsed {
             UIView.animate(withDuration: 0.5) {
                 self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
+                self.collapsibleAuthSeparatorRow.showMoreButton.applyShowMoreButtonAccessibility()
             }
 
             tableView.deleteRows(at: extraLoginServiceIndexPaths, with: .automatic)
         } else {
             UIView.animate(withDuration: 0.5) {
                 self.collapsibleAuthSeparatorRow.showMoreButton.transform = CGAffineTransform(rotationAngle: CGFloat.pi * 2)
+                self.collapsibleAuthSeparatorRow.showMoreButton.applyShowLessButtonAccessibility()
             }
+            
 
             tableView.insertRows(at: extraLoginServiceIndexPaths, with: .automatic)
         }
@@ -356,4 +361,14 @@ extension AuthTableViewController {
 
 extension AuthTableViewController {
     override func applyTheme() { }
+}
+
+extension UIButton {
+    func applyShowMoreButtonAccessibility() {
+        accessibilityLabel = VOLocalizedString("auth.show_more_options.label")
+    }
+
+    func applyShowLessButtonAccessibility() {
+        accessibilityLabel = VOLocalizedString("auth.show_less_options.label")
+    }
 }

--- a/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/AuthTableViewController.swift
@@ -121,6 +121,14 @@ final class AuthTableViewController: BaseTableViewController {
         return extraLoginServiceIndexPaths
     }()
 
+    var showMoreButtonAccessibilityLabel: String? {
+        if isLoginServicesCollapsed {
+            return VOLocalizedString("auth.show_more_options.label")
+        } else {
+            return VOLocalizedString("auth.show_less_options.label")
+        }
+    }
+
     // MARK: Life Cycle
 
     override func viewDidLoad() {
@@ -251,14 +259,6 @@ final class AuthTableViewController: BaseTableViewController {
 
     @objc func showSignup() {
         performSegue(withIdentifier: "Signup", sender: self)
-    }
-
-    var showMoreButtonAccessibilityLabel: String? {
-        if isLoginServicesCollapsed {
-            return VOLocalizedString("auth.show_more_options.label")
-        } else {
-            return VOLocalizedString("auth.show_less_options.label")
-        }
     }
 
     func showOrHideLoginServices() {

--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -121,7 +121,7 @@ final class ConnectServerViewController: BaseViewController {
             navigationItem.leftBarButtonItem = nil
         } else {
             navigationItem.leftBarButtonItem = buttonClose
-            navigationItem.applyCloseButtonAccessibility()
+            navigationItem.leftBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.close.label")
         }
 
         selectedServer = DatabaseManager.selectedIndex

--- a/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/ConnectServerViewController.swift
@@ -121,6 +121,7 @@ final class ConnectServerViewController: BaseViewController {
             navigationItem.leftBarButtonItem = nil
         } else {
             navigationItem.leftBarButtonItem = buttonClose
+            navigationItem.applyCloseButtonAccessibility()
         }
 
         selectedServer = DatabaseManager.selectedIndex

--- a/Rocket.Chat/Controllers/Auth/LegalTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LegalTableViewController.swift
@@ -27,7 +27,7 @@ class LegalTableViewController: UITableViewController {
         super.viewDidLoad()
 
         navigationItem.title = localized("auth.login.legal")
-        navigationItem.applyCloseButtonAccessibility()
+        navigationItem.leftBarButtonItem.accessibilityLabel = VOLocalizedString("auth.close.label")
 
         if let nav = navigationController as? AuthNavigationController {
             nav.setGrayTheme()

--- a/Rocket.Chat/Controllers/Auth/LegalTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LegalTableViewController.swift
@@ -26,6 +26,9 @@ class LegalTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        navigationItem.title = localized("auth.login.legal")
+        navigationItem.applyCloseButtonAccessibility()
+
         if let nav = navigationController as? AuthNavigationController {
             nav.setGrayTheme()
         }

--- a/Rocket.Chat/Controllers/Auth/LegalTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LegalTableViewController.swift
@@ -27,7 +27,7 @@ class LegalTableViewController: UITableViewController {
         super.viewDidLoad()
 
         navigationItem.title = localized("auth.login.legal")
-        navigationItem.leftBarButtonItem.accessibilityLabel = VOLocalizedString("auth.close.label")
+        navigationItem.leftBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.close.label")
 
         if let nav = navigationController as? AuthNavigationController {
             nav.setGrayTheme()

--- a/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
@@ -102,6 +102,7 @@ class LoginTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = serverURL?.host
+        navigationItem.applyMoreButtonAccessibility()
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)
@@ -322,5 +323,15 @@ extension LoginTableViewController: UITextFieldDelegate {
 extension LoginTableViewController {
     override func applyTheme() {
         self.forgotPasswordButton.setTitleColor(UIColor.RCBlue(), for: .normal)
+    }
+}
+
+extension UINavigationItem {
+    func applyMoreButtonAccessibility() {
+        rightBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.more.label")
+    }
+
+    func applyCloseButtonAccessibility() {
+        leftBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.close.label")
     }
 }

--- a/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/LoginTableViewController.swift
@@ -102,7 +102,7 @@ class LoginTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = serverURL?.host
-        navigationItem.applyMoreButtonAccessibility()
+        navigationItem.rightBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.more.label")
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)
@@ -323,15 +323,5 @@ extension LoginTableViewController: UITextFieldDelegate {
 extension LoginTableViewController {
     override func applyTheme() {
         self.forgotPasswordButton.setTitleColor(UIColor.RCBlue(), for: .normal)
-    }
-}
-
-extension UINavigationItem {
-    func applyMoreButtonAccessibility() {
-        rightBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.more.label")
-    }
-
-    func applyCloseButtonAccessibility() {
-        leftBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.close.label")
     }
 }

--- a/Rocket.Chat/Controllers/Auth/SignupCustomFieldsTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/SignupCustomFieldsTableViewController.swift
@@ -47,6 +47,7 @@ class SignupCustomFieldsTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = SocketManager.sharedInstance.serverURL?.host
+        navigationItem.applyMoreButtonAccessibility()
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/SignupCustomFieldsTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/SignupCustomFieldsTableViewController.swift
@@ -47,7 +47,7 @@ class SignupCustomFieldsTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = SocketManager.sharedInstance.serverURL?.host
-        navigationItem.applyMoreButtonAccessibility()
+        navigationItem.rightBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.more.label")
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/SignupTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/SignupTableViewController.swift
@@ -49,7 +49,7 @@ final class SignupTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = SocketManager.sharedInstance.serverURL?.host
-        navigationItem.applyMoreButtonAccessibility()
+        navigationItem.rightBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.more.label")
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/SignupTableViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/SignupTableViewController.swift
@@ -49,6 +49,7 @@ final class SignupTableViewController: BaseTableViewController {
         super.viewDidLoad()
 
         navigationItem.title = SocketManager.sharedInstance.serverURL?.host
+        navigationItem.applyMoreButtonAccessibility()
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         view.addGestureRecognizer(tapGesture)

--- a/Rocket.Chat/Controllers/Auth/WelcomeViewController.swift
+++ b/Rocket.Chat/Controllers/Auth/WelcomeViewController.swift
@@ -79,6 +79,7 @@ final class WelcomeViewController: BaseViewController {
             )
 
             joinCommunityButton.setAttributedTitle(combinedString, for: .normal)
+            joinCommunityButton.accessibilityLabel = "\(title.string), \(serverURL.string)"
         }
     }
 

--- a/Rocket.Chat/Resources/cs.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/cs.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "Forgot password";
 "auth.login.agree_label" = "By proceeding you are agreeing to our";
 "auth.login.agree_and" = "and";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Terms of Service";
 "auth.login.agree_privacypolicy" = "Privacy Policy";
 

--- a/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
@@ -10,10 +10,10 @@
 "auth.connect.urlfield.label" = "Server URL";
 "auth.connect.urlfield.hint" = "Insert your server's URL here.";
 
-"auth.more.label" = "More";
-"auth.close.label" = "Close";
-"auth.show_more_options.label" = "Show more options";
-"auth.show_less_options.label" = "Show less options";
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
 
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";

--- a/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "Server URL";
 "auth.connect.urlfield.hint" = "Insert your server's URL here.";
 
+"auth.more.label" = "More";
+"auth.close.label" = "Close";
+"auth.show_more_options.label" = "Show more options";
+"auth.show_less_options.label" = "Show less options";
+
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";
 "auth.authentication.password.label" = "Password";

--- a/Rocket.Chat/Resources/de.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/de.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "Passwort vergessen";
 "auth.login.agree_label" = "Indem Sie fortfahren, erklären Sie sich einverstanden mit unseren";
 "auth.login.agree_and" = "und";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Allgemeinen Geschäftsbedingungen";
 "auth.login.agree_privacypolicy" = "Datenschutzerklärung";
 

--- a/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "Server URL";
 "auth.connect.urlfield.hint" = "Geben Sie hier die URL Ihres Servers ein.";
 
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
+
 "auth.authentication.emailorusername.label" = "E-Mail oder Benutzername";
 "auth.authentication.emailorusername.hint" = "Geben Sie hier Ihre E-Mail-Adresse oder Ihren Benutzernamen ein.";
 "auth.authentication.password.label" = "Passwort";

--- a/Rocket.Chat/Resources/el.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/el.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "Ξέχασα το συνθηματικό";
 "auth.login.agree_label" = "Συνεχίζοντας συμφωνείτε με τους";
 "auth.login.agree_and" = "και";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Όρους Υπηρεσίας";
 "auth.login.agree_privacypolicy" = "Πολιτική Απορρήτου";
 

--- a/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "URL Εξυπηρετητή";
 "auth.connect.urlfield.hint" = "Εισάγετε εδώ το URL του εξυπηρετητή σας.";
 
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
+
 "auth.authentication.emailorusername.label" = "Email ή Όνομα χρήστη";
 "auth.authentication.emailorusername.hint" = "Εισάγετε εδώ το email ή το Όνομα χρήστη σας.";
 "auth.authentication.password.label" = "Συνθηματικό";

--- a/Rocket.Chat/Resources/en.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/en.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "Forgot password";
 "auth.login.agree_label" = "By proceeding you are agreeing to our";
 "auth.login.agree_and" = "and";
+"auth.login.legal" = "Legal";
 "auth.login.agree_termsofservice" = "Terms of Service";
 "auth.login.agree_privacypolicy" = "Privacy Policy";
 

--- a/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "Server URL";
 "auth.connect.urlfield.hint" = "Insert your server's URL here.";
 
+"auth.more.label" = "More";
+"auth.close.label" = "Close";
+"auth.show_more_options.label" = "Show more options";
+"auth.show_less_options.label" = "Show less options";
+
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";
 "auth.authentication.password.label" = "Password";

--- a/Rocket.Chat/Resources/es.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/es.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "Forgot password";
 "auth.login.agree_label" = "By proceeding you are agreeing to our";
 "auth.login.agree_and" = "and";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Terms of Service";
 "auth.login.agree_privacypolicy" = "Privacy Policy";
 

--- a/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "URL del servidor";
 "auth.connect.urlfield.hint" = "Inserta la URL de tu servidor aquí.";
 
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
+
 "auth.authentication.emailorusername.label" = "Correo electrónico o nombre de usuario";
 "auth.authentication.emailorusername.hint" = "Inserta tu correo electrónico o nombre de usuario aquí.";
 "auth.authentication.password.label" = "Contraseña";

--- a/Rocket.Chat/Resources/fr.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/fr.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "Mot de passe oublié";
 "auth.login.agree_label" = "En continuant, vous acceptez notre";
 "auth.login.agree_and" = "et";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Conditions de service";
 "auth.login.agree_privacypolicy" = "Politique de confidentialité";
 

--- a/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "Server URL";
 "auth.connect.urlfield.hint" = "Insert your server's URL here.";
 
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
+
 "auth.authentication.emailorusername.label" = "Email or Username";
 "auth.authentication.emailorusername.hint" = "Insert your email or username here.";
 "auth.authentication.password.label" = "Password";

--- a/Rocket.Chat/Resources/it.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/it.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "Password dimenticata";
 "auth.login.agree_label" = "Procedendo accetti i nostri";
 "auth.login.agree_and" = "e";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Termini di servizio";
 "auth.login.agree_privacypolicy" = "Politica sulla riservatezza";
 

--- a/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "Server URL";
 "auth.connect.urlfield.hint" = "Inserisci qui l'URL del tuo server.";
 
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
+
 "auth.authentication.emailorusername.label" = "E-mail o nome utente";
 "auth.authentication.emailorusername.hint" = "Inserisci qui il tuo indirizzo e-mail o il tuo nome utente.";
 "auth.authentication.password.label" = "Password";

--- a/Rocket.Chat/Resources/ja.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/ja.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "パスワードをお忘れですか?";
 "auth.login.agree_label" = "続けることで、あなたは私達に同意します。";
 "auth.login.agree_and" = "と";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "利用規約";
 "auth.login.agree_privacypolicy" = "個人情報保護方針";
 

--- a/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "サーバー URL";
 "auth.connect.urlfield.hint" = "ここにサーバーのURLを入力してください。";
 
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
+
 "auth.authentication.emailorusername.label" = "メールアドレスまたはユーザー名";
 "auth.authentication.emailorusername.hint" = "ここにメールアドレスまたはユーザー名を入力してください。";
 "auth.authentication.password.label" = "パスワード";

--- a/Rocket.Chat/Resources/pl.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pl.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "Zapomniałem hasła";
 "auth.login.agree_label" = "Kontynuując zgadzasz się na nasze";
 "auth.login.agree_and" = "i";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Warunku Usług";
 "auth.login.agree_privacypolicy" = "Politykę Prywatności";
 

--- a/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "Adres serwera";
 "auth.connect.urlfield.hint" = "Wpisz tutaj adres swojego serwera.";
 
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
+
 "auth.authentication.emailorusername.label" = "E-mail lub nazwa użytkownika";
 "auth.authentication.emailorusername.hint" = "Wpisz tutaj swój e-mail lub nazwę użytkownika.";
 "auth.authentication.password.label" = "Hasło";

--- a/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "Esqueci minha senha";
 "auth.login.agree_label" = "Ao proceder você está concordando com os";
 "auth.login.agree_and" = "e";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Termos de Serviço";
 "auth.login.agree_privacypolicy" = "Política de Privacidade";
 

--- a/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "URL do servidor";
 "auth.connect.urlfield.hint" = "Insira aqui a URL do servidor.";
 
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
+
 "auth.authentication.emailorusername.label" = "Email ou nome de usuário";
 "auth.authentication.emailorusername.hint" = "Insira aqui o seu email ou nome de usuário.";
 "auth.authentication.password.label" = "Senha";

--- a/Rocket.Chat/Resources/pt-PT.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "Esqueceu a palavra-passe";
 "auth.login.agree_label" = "Ao prosseguir você concorda com o nosso";
 "auth.login.agree_and" = "e";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Termos de Serviço";
 "auth.login.agree_privacypolicy" = "Política de Privacidade";
 

--- a/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "URL do servidor";
 "auth.connect.urlfield.hint" = "Insira aqui a URL do servidor.";
 
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
+
 "auth.authentication.emailorusername.label" = "Email ou nome de usuário";
 "auth.authentication.emailorusername.hint" = "Insira aqui o seu email ou nome de usuário.";
 "auth.authentication.password.label" = "Senha";

--- a/Rocket.Chat/Resources/ru.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/ru.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "Забыли пароль";
 "auth.login.agree_label" = "Продолжая, вы соглашаетесь с нашими";
 "auth.login.agree_and" = "и";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "Условиями использования";
 "auth.login.agree_privacypolicy" = "Политикой конфиденциальности";
 

--- a/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "URL-адрес сервера";
 "auth.connect.urlfield.hint" = "Введите URL своего сервера здесь.";
 
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
+
 "auth.authentication.emailorusername.label" = "Электронная почта или имя пользователя";
 "auth.authentication.emailorusername.hint" = "Вставьте свою электронную почту или имя пользователя здесь.";
 "auth.authentication.password.label" = "Пароль";

--- a/Rocket.Chat/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/zh-Hans.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "忘记密码";
 "auth.login.agree_label" = "继续表示您同意我们的";
 "auth.login.agree_and" = "和";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "服务条款";
 "auth.login.agree_privacypolicy" = "隐私政策";
 

--- a/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "服务器地址";
 "auth.connect.urlfield.hint" = "插入服务器地址";
 
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
+
 "auth.authentication.emailorusername.label" = "邮箱地址或用户名";
 "auth.authentication.emailorusername.hint" = "添加邮箱地址或用户名";
 "auth.authentication.password.label" = "密码";

--- a/Rocket.Chat/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Rocket.Chat/Resources/zh-Hant.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "auth.login.buttonResetPassword" = "忘記密碼";
 "auth.login.agree_label" = "繼續表示您同意我們的";
 "auth.login.agree_and" = "和";
+"auth.login.legal" = "Legal"; // TODO
 "auth.login.agree_termsofservice" = "服務條款";
 "auth.login.agree_privacypolicy" = "隱私權政策";
 

--- a/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
@@ -10,6 +10,11 @@
 "auth.connect.urlfield.label" = "伺服器地址";
 "auth.connect.urlfield.hint" = "新增伺服器地址";
 
+"auth.more.label" = "More"; // TODO
+"auth.close.label" = "Close"; // TODO
+"auth.show_more_options.label" = "Show more options"; // TODO
+"auth.show_less_options.label" = "Show less options"; // TODO
+
 "auth.authentication.emailorusername.label" = "電子信箱或用戶名稱";
 "auth.authentication.emailorusername.hint" = "新增電子信箱或用戶名稱";
 "auth.authentication.password.label" = "密碼";

--- a/Rocket.ChatTests/External/RCEmojiKit/EmojioneSpec.swift
+++ b/Rocket.ChatTests/External/RCEmojiKit/EmojioneSpec.swift
@@ -66,7 +66,7 @@ class EmojioneSpec: XCTestCase {
             XCTAssert(Emojione.transform(string: string) == ":supercalifragilisticexpialidocious,:pneumonoultramicroscopicsilicovolcanoconiosis😃a")
             expect.fulfill()
         }
-        waitForExpectations(timeout: 5) { (error) in
+        waitForExpectations(timeout: 10) { (error) in
             if error != nil {
                 XCTFail("The regex parsing took too long, it may have gone through a catastrophic backtracking")
             }


### PR DESCRIPTION
@RocketChat/ios

TODO - 

- [x] Adding a comma between the accessibility label of "Join the community" and communityServerURL sounds a bit better by creating a pause in VoiceOver dictation.

- [x] The "More" right bar button on Login / Sign up to open Legal terms was not accessible, so I added localised text.

- [x] The cross button is described in VoiceOver as “Stop” button, which needs to be named as “Close” button.

- [x] Localised "Legal" Heading

- [x] "Show more options button" in Login should be accessible. (On the iPhone)
