### PR TITLE
[NEW] Preferences / editing profile VoiceOver accessible - Project 05

### DIFF
--- a/Rocket.Chat/Controllers/Preferences/PreferencesViewController.swift
+++ b/Rocket.Chat/Controllers/Preferences/PreferencesViewController.swift
@@ -149,6 +149,8 @@ final class PreferencesViewController: BaseTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = viewModel.title
+
+        navigationItem.leftBarButtonItem?.accessibilityLabel = VOLocalizedString("auth.close.label")
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Rocket.Chat/Controllers/Preferences/PreferencesViewController.swift
+++ b/Rocket.Chat/Controllers/Preferences/PreferencesViewController.swift
@@ -128,7 +128,7 @@ final class PreferencesViewController: BaseTableViewController {
         }
     }
 
-    @IBOutlet weak var switchTracking: UISwitch! {
+    var switchTracking: UISwitch! {
         didSet {
             switchTracking.isOn = viewModel.trackingValue
         }
@@ -156,6 +156,21 @@ final class PreferencesViewController: BaseTableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         updateUserInformation()
+        configureCells()
+    }
+
+    func configureCells() {
+        // Configuring the switch control for the crash report cell
+        // The switch is being added as an accessory view to enable
+        // control with VoiceOver.
+
+        if let trackingCell = tableView.cellForRow(at: IndexPath(row: 0, section: kSectionTracking)) {
+            switchTracking = UISwitch()
+            switchTracking.addTarget(self, action: #selector(crashReportSwitchDidChange(sender:)), for: .valueChanged)
+            switchTracking.accessibilityLabel = ""
+            trackingCell.accessoryView = switchTracking
+        }
+
     }
 
     @IBAction func buttonCloseDidPressed(_ sender: Any) {
@@ -344,7 +359,7 @@ final class PreferencesViewController: BaseTableViewController {
         }
     }
 
-    @IBAction func crashReportSwitchDidChange(sender: Any) {
+    @objc func crashReportSwitchDidChange(sender: Any) {
         AnalyticsCoordinator.toggleCrashReporting(disabled: !switchTracking.isOn)
     }
 

--- a/Rocket.Chat/Controllers/Preferences/PreferencesViewController.swift
+++ b/Rocket.Chat/Controllers/Preferences/PreferencesViewController.swift
@@ -140,6 +140,19 @@ final class PreferencesViewController: BaseTableViewController {
         }
     }
 
+    @IBOutlet weak var trackingCell: UITableViewCell! {
+        didSet {
+            // Configuring the switch control for the crash report cell
+            // The switch is being added as an accessory view to enable
+            // control with VoiceOver.
+
+            switchTracking = UISwitch()
+            switchTracking.addTarget(self, action: #selector(crashReportSwitchDidChange(sender:)), for: .valueChanged)
+            switchTracking.accessibilityLabel = ""
+            trackingCell.accessoryView = switchTracking
+        }
+    }
+
     override var navigationController: PreferencesNavigationController? {
         return super.navigationController as? PreferencesNavigationController
     }
@@ -156,21 +169,6 @@ final class PreferencesViewController: BaseTableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         updateUserInformation()
-        configureCells()
-    }
-
-    func configureCells() {
-        // Configuring the switch control for the crash report cell
-        // The switch is being added as an accessory view to enable
-        // control with VoiceOver.
-
-        if let trackingCell = tableView.cellForRow(at: IndexPath(row: 0, section: kSectionTracking)) {
-            switchTracking = UISwitch()
-            switchTracking.addTarget(self, action: #selector(crashReportSwitchDidChange(sender:)), for: .valueChanged)
-            switchTracking.accessibilityLabel = ""
-            trackingCell.accessoryView = switchTracking
-        }
-
     }
 
     @IBAction func buttonCloseDidPressed(_ sender: Any) {

--- a/Rocket.Chat/Controllers/Preferences/Profile/EditProfileTableViewController.swift
+++ b/Rocket.Chat/Controllers/Preferences/Profile/EditProfileTableViewController.swift
@@ -287,7 +287,6 @@ final class EditProfileTableViewController: BaseTableViewController, MediaPicker
     var avatarButtonAccessibilityLabel: String? = VOLocalizedString("preferences.profile.edit.label")
     var avatarEditingButtonAccessibilityLabel: String? = VOLocalizedString("preferences.profile.editing.label")
 
-
     // MARK: Actions
 
     @IBAction func saveProfile(_ sender: UIBarButtonItem) {

--- a/Rocket.Chat/Controllers/Preferences/Profile/EditProfileTableViewController.swift
+++ b/Rocket.Chat/Controllers/Preferences/Profile/EditProfileTableViewController.swift
@@ -46,7 +46,11 @@ final class EditProfileTableViewController: BaseTableViewController, MediaPicker
         }
     }
 
-    @IBOutlet weak var avatarButton: UIButton!
+    @IBOutlet weak var avatarButton: UIButton! {
+    didSet {
+        avatarButton.accessibilityLabel = avatarButtonAccessibilityLabel
+        }
+    }
 
     var avatarView: AvatarView = {
         let avatarView = AvatarView()
@@ -217,6 +221,7 @@ final class EditProfileTableViewController: BaseTableViewController, MediaPicker
 
         if authSettings?.isAllowedToEditAvatar ?? false {
             avatarButton.setImage(editingAvatarImage, for: .normal)
+            avatarButton.accessibilityLabel = avatarEditingButtonAccessibilityLabel
         }
 
         enableUserInteraction()
@@ -233,6 +238,7 @@ final class EditProfileTableViewController: BaseTableViewController, MediaPicker
 
         if authSettings?.isAllowedToEditAvatar ?? false {
             avatarButton.setImage(nil, for: .normal)
+            avatarButton.accessibilityLabel = avatarButtonAccessibilityLabel
         }
 
         disableUserInteraction()
@@ -275,6 +281,12 @@ final class EditProfileTableViewController: BaseTableViewController, MediaPicker
         username.isEnabled = false
         email.isEnabled = false
     }
+
+    // MARK: Accessibility
+
+    var avatarButtonAccessibilityLabel: String? = VOLocalizedString("preferences.profile.edit.label")
+    var avatarEditingButtonAccessibilityLabel: String? = VOLocalizedString("preferences.profile.editing.label")
+
 
     // MARK: Actions
 

--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
@@ -72,6 +72,8 @@ final class SubscriptionsViewController: BaseViewController {
 
         super.viewDidLoad()
 
+        navigationItem.leftBarButtonItem?.accessibilityLabel = VOLocalizedString("channel.preferences.label")
+
         // If the device is not using the SplitView, we want to show
         // the 3D Touch preview for the cells
         if splitViewController?.detailViewController as? BaseNavigationController == nil {

--- a/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
@@ -20,11 +20,15 @@
 "auth.authentication.password.label" = "Password";
 "auth.authentication.password.label" = "Insert your password here.";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "Session information";
 "subscriptions.main.userview.value" = "Server: %@. User: %@. Status: %@.";
 "subscriptions.main.userview.hint" = "Double tap to change status.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "Double tap to change status.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "Message from %@ at %@.";
 "message.hint" = "Reactions: %@";

--- a/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "Klicken Sie doppelt, um den Status zu ändern.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "Nachricht von %@ in %@.";
 "message.hint" = "Reaktionen: %@";

--- a/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "Passwort";
 "auth.authentication.password.label" = "Geben Sie hier Ihr Passwort ein.";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "Sitzungsinformationen";
 "subscriptions.main.userview.value" = "Server: %@. Benutzer: %@. Status: %@.";

--- a/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "Συνθηματικό";
 "auth.authentication.password.label" = "Εισάγετε εδώ το Συνθηματικό σας.";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "Πληροφορία Συνόδου";
 "subscriptions.main.userview.value" = "Εξυπηρετητής: %@. Χρήστης: %@. Κατάσταση: %@.";

--- a/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "Πατήστε δύο φορές για αλλαγή κατάστασης.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "Μήνυμα από %@ at %@.";
 "message.hint" = "Αντιδράσεις: %@";

--- a/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "Double tap to change status.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; 
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture";
+"preferences.profile.editing.label" = "Edit the profile picture";
+
 // MARK: Message
 "message.label" = "Message from %@ at %@.";
 "message.hint" = "Reactions: %@";

--- a/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "Password";
 "auth.authentication.password.label" = "Insert your password here.";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences";
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "Session information";
 "subscriptions.main.userview.value" = "Server: %@. User: %@. Status: %@.";

--- a/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "Contraseña";
 "auth.authentication.password.label" = "Inserta tu contraseña aquí";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "Información de la sesión";
 "subscriptions.main.userview.value" = "Servidor: %@. Usuario: %@. Estado: %@.";

--- a/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "Toca dos veces para cambiar el estado";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "Mensaje de %@ a %@.";
 "message.hint" = "Reacciones: %@";

--- a/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "Password";
 "auth.authentication.password.label" = "Insert your password here.";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "Session information";
 "subscriptions.main.userview.value" = "Server: %@. User: %@. Status: %@.";

--- a/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "Double tap to change status.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "Message from %@ at %@.";
 "message.hint" = "Reactions: %@";

--- a/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "Password";
 "auth.authentication.password.label" = "Inserisci qui la tua password.";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "Informazioni Sessione";
 "subscriptions.main.userview.value" = "Server: %@. Utente: %@. Stato: %@.";

--- a/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "Fare doppio clic per cambiare lo stato.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "Messaggio da %@ a %@.";
 "message.hint" = "Reazioni: %@";

--- a/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "ステータスを変更するにはダブルタップしてください。";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "%@ からのメッセージ %@";
 "message.hint" = "リアクション: %@";

--- a/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "パスワード";
 "auth.authentication.password.label" = "ここにパスワードを入力してください。";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "セッション情報";
 "subscriptions.main.userview.value" = "サーバー: %@. ユーザー: %@. ステータス: %@.";

--- a/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "Dotknij dwukrotnie aby zmienić status.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "Wiadomość od %@ o %@.";
 "message.hint" = "Reakcje: %@";

--- a/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "Hasło";
 "auth.authentication.password.label" = "Wpisz tutaj swoje hasło.";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "Informacje o sesji";
 "subscriptions.main.userview.value" = "Serwer: %@. Użytkownik: %@. Status: %@.";

--- a/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "Senha";
 "auth.authentication.password.label" = "Insira aqui a sua senha.";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "Informação da sessão";
 "subscriptions.main.userview.value" = "Servidor: %@. Usuário: %@. Status: %@.";

--- a/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "Toque duplo para mudar o status.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "Mensagem de %@ em %@.";
 "message.hint" = "Reações: %@";

--- a/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "Senha";
 "auth.authentication.password.label" = "Insira aqui a sua senha.";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "Informação da sessão";
 "subscriptions.main.userview.value" = "Servidor: %@. Usuário: %@. Status: %@.";

--- a/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "Toque duplo para mudar o status.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "Mensagem de %@ em %@.";
 "message.hint" = "Reações: %@";

--- a/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "Дважды нажмите, чтобы изменить статус.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "Сообщение от %@ в %@.";
 "message.hint" = "Реакции: %@";

--- a/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "Пароль";
 "auth.authentication.password.label" = "Введите свой пароль здесь.";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "Информация о сеансе";
 "subscriptions.main.userview.value" = "Сервер: %@. Пользователь: %@. Статус: %@.";

--- a/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "密码";
 "auth.authentication.password.label" = "添加密码";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "会话信息";
 "subscriptions.main.userview.value" = "服务器: %@. 用户: %@. 状态: %@.";

--- a/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "双击变更状态";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "来自 %@ at %@ 的信息";
 "message.hint" = "反馈: %@";

--- a/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
@@ -26,6 +26,10 @@
 "subscriptions.main.userview.hint" = "點擊兩下變更狀態";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
 
+// MARK: Preferences
+"preferences.profile.edit.label" = "Profile picture"; // TODO
+"preferences.profile.editing.label" = "Edit the profile picture"; // TODO
+
 // MARK: Message
 "message.label" = "來自 %@ at %@ 的訊息";
 "message.hint" = "回饋: %@";

--- a/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
@@ -20,6 +20,9 @@
 "auth.authentication.password.label" = "密碼";
 "auth.authentication.password.label" = "新增密碼";
 
+// MARK: Channels
+"channel.preferences.label" = "Preferences"; // TODO
+
 // MARK: Subscriptions
 "subscriptions.main.userview.label" = "聊天訊息";
 "subscriptions.main.userview.value" = "伺服器: %@. 訊息: %@. 狀態: %@.";

--- a/Rocket.Chat/Storyboards/Preferences.storyboard
+++ b/Rocket.Chat/Storyboards/Preferences.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="bDT-Aq-lo9">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="bDT-Aq-lo9">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -294,14 +294,8 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hm8-9Z-8cD">
-                                                    <rect key="frame" x="310" y="6.5" width="51" height="31"/>
-                                                    <connections>
-                                                        <action selector="crashReportSwitchDidChangeWithSender:" destination="pKS-7b-iHv" eventType="valueChanged" id="jbd-Lp-BV1"/>
-                                                    </connections>
-                                                </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Crash Report" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="evt-2t-Ueh">
-                                                    <rect key="frame" x="16" y="11.5" width="278" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="101.5" height="21"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -309,10 +303,7 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="evt-2t-Ueh" firstAttribute="centerY" secondItem="rNB-gF-HG7" secondAttribute="centerY" id="227-0q-tNE"/>
-                                                <constraint firstItem="Hm8-9Z-8cD" firstAttribute="leading" secondItem="evt-2t-Ueh" secondAttribute="trailing" constant="16" id="GMY-4g-b2z"/>
-                                                <constraint firstAttribute="trailing" secondItem="Hm8-9Z-8cD" secondAttribute="trailing" constant="16" id="SdP-IU-fIz"/>
                                                 <constraint firstItem="evt-2t-Ueh" firstAttribute="leading" secondItem="rNB-gF-HG7" secondAttribute="leading" constant="16" id="aJU-SD-SAK"/>
-                                                <constraint firstItem="Hm8-9Z-8cD" firstAttribute="centerY" secondItem="rNB-gF-HG7" secondAttribute="centerY" id="fMI-ro-sDw"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -394,7 +385,6 @@
                         <outlet property="labelTracking" destination="evt-2t-Ueh" id="EHK-gb-d8N"/>
                         <outlet property="labelVersion" destination="vOz-GO-Ifh" id="14X-a4-dRc"/>
                         <outlet property="labelWebBrowser" destination="jBR-jx-Kz9" id="vBB-bs-Sti"/>
-                        <outlet property="switchTracking" destination="Hm8-9Z-8cD" id="NwL-DE-zCj"/>
                         <segue destination="14p-5u-LKz" kind="show" identifier="AppIcon" id="5Rh-qB-fEf"/>
                         <segue destination="G2F-kh-af5" kind="show" identifier="Language" id="UkX-RM-9MT"/>
                     </connections>

--- a/Rocket.Chat/Storyboards/Preferences.storyboard
+++ b/Rocket.Chat/Storyboards/Preferences.storyboard
@@ -385,6 +385,7 @@
                         <outlet property="labelTracking" destination="evt-2t-Ueh" id="EHK-gb-d8N"/>
                         <outlet property="labelVersion" destination="vOz-GO-Ifh" id="14X-a4-dRc"/>
                         <outlet property="labelWebBrowser" destination="jBR-jx-Kz9" id="vBB-bs-Sti"/>
+                        <outlet property="trackingCell" destination="93i-3u-Cb2" id="dQf-ZV-XOZ"/>
                         <segue destination="14p-5u-LKz" kind="show" identifier="AppIcon" id="5Rh-qB-fEf"/>
                         <segue destination="G2F-kh-af5" kind="show" identifier="Language" id="UkX-RM-9MT"/>
                     </connections>


### PR DESCRIPTION
@RocketChat/ios

- [x] The “Preferences” button on the message Screen is not accessible and a label needs to be associated with it. 
- [x] The cross button is described in VoiceOver as “Stop” button, which need to be named as “Close” button. 
- [x] Send Crash Report text field and the switch toggle should be read as one.
- [x] The Name, username and email address are described in VoiceOver with the suffix Dimmed 
- [x] The profile picture is described in VoiceOver as “Dimmed button” which should have a label “Profile picture.” 
- [x] Editing the Profile picture is described in VoiceOver as “Button”, which should be “Edit the profile picture”. 
