### PR TITLE
[NEW] Project02 - Changing and adding servers

### DIFF
--- a/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
+++ b/Rocket.Chat/Controllers/Subscriptions/SubscriptionsList/SubscriptionsViewController.swift
@@ -110,12 +110,16 @@ final class SubscriptionsViewController: BaseViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
+        serversView?.accessibilityViewIsModal = true
+        sortingView?.accessibilityViewIsModal = true
         serversView?.frame = frameForDropDownOverlay
         sortingView?.frame = frameForDropDownOverlay
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        UIAccessibility.post(notification: .screenChanged, argument: titleView?.labelMessages)
 
         // This method can stay here, since adding a new connection handler
         // will override the existing one if there's already one. This is here
@@ -237,6 +241,7 @@ final class SubscriptionsViewController: BaseViewController {
             self.titleView = titleView
 
             let tapGesture = UITapGestureRecognizer(target: self, action: #selector(recognizeTitleViewTapGesture(_:)))
+            titleView.isAccessibilityElement = true
             titleView.addGestureRecognizer(tapGesture)
         }
     }
@@ -362,6 +367,7 @@ extension SubscriptionsViewController: UISearchBarDelegate {
 
         titleView?.updateTitleImage(reverse: true)
         serversView = ServersListView.showIn(view, frame: frameForDropDownOverlay)
+        UIAccessibility.post(notification: .screenChanged, argument: serversView?.labelTitle)
         serversView?.delegate = self
     }
 

--- a/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/cs.lproj/VoiceOver.strings
@@ -28,7 +28,8 @@
 "subscriptions.main.userview.value" = "Server: %@. User: %@. Status: %@.";
 "subscriptions.main.userview.hint" = "Double tap to change status.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
-
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/de.lproj/VoiceOver.strings
@@ -28,6 +28,8 @@
 "subscriptions.main.userview.value" = "Server: %@. Benutzer: %@. Status: %@.";
 "subscriptions.main.userview.hint" = "Klicken Sie doppelt, um den Status zu ändern.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/el.lproj/VoiceOver.strings
@@ -28,6 +28,8 @@
 "subscriptions.main.userview.value" = "Εξυπηρετητής: %@. Χρήστης: %@. Κατάσταση: %@.";
 "subscriptions.main.userview.hint" = "Πατήστε δύο φορές για αλλαγή κατάστασης.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/en.lproj/VoiceOver.strings
@@ -27,7 +27,9 @@
 "subscriptions.main.userview.label" = "Session information";
 "subscriptions.main.userview.value" = "Server: %@. User: %@. Status: %@.";
 "subscriptions.main.userview.hint" = "Double tap to change status.";
-"subscriptions.main.channel.hint" = "Double tap to enter"; 
+"subscriptions.main.channel.hint" = "Double tap to enter";
+"subscriptions.server_button.hint" = "Double tap to add or change server";
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu";
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture";

--- a/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/es.lproj/VoiceOver.strings
@@ -28,6 +28,8 @@
 "subscriptions.main.userview.value" = "Servidor: %@. Usuario: %@. Estado: %@.";
 "subscriptions.main.userview.hint" = "Toca dos veces para cambiar el estado";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/fr.lproj/VoiceOver.strings
@@ -28,6 +28,8 @@
 "subscriptions.main.userview.value" = "Server: %@. User: %@. Status: %@.";
 "subscriptions.main.userview.hint" = "Double tap to change status.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/it.lproj/VoiceOver.strings
@@ -28,6 +28,8 @@
 "subscriptions.main.userview.value" = "Server: %@. Utente: %@. Stato: %@.";
 "subscriptions.main.userview.hint" = "Fare doppio clic per cambiare lo stato.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ja.lproj/VoiceOver.strings
@@ -28,6 +28,8 @@
 "subscriptions.main.userview.value" = "サーバー: %@. ユーザー: %@. ステータス: %@.";
 "subscriptions.main.userview.hint" = "ステータスを変更するにはダブルタップしてください。";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pl.lproj/VoiceOver.strings
@@ -28,6 +28,8 @@
 "subscriptions.main.userview.value" = "Serwer: %@. Użytkownik: %@. Status: %@.";
 "subscriptions.main.userview.hint" = "Dotknij dwukrotnie aby zmienić status.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-BR.lproj/VoiceOver.strings
@@ -28,6 +28,8 @@
 "subscriptions.main.userview.value" = "Servidor: %@. Usuário: %@. Status: %@.";
 "subscriptions.main.userview.hint" = "Toque duplo para mudar o status.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/pt-PT.lproj/VoiceOver.strings
@@ -28,6 +28,8 @@
 "subscriptions.main.userview.value" = "Servidor: %@. Usuário: %@. Status: %@.";
 "subscriptions.main.userview.hint" = "Toque duplo para mudar o status.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/ru.lproj/VoiceOver.strings
@@ -28,6 +28,8 @@
 "subscriptions.main.userview.value" = "Сервер: %@. Пользователь: %@. Статус: %@.";
 "subscriptions.main.userview.hint" = "Дважды нажмите, чтобы изменить статус.";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hans.lproj/VoiceOver.strings
@@ -28,6 +28,8 @@
 "subscriptions.main.userview.value" = "服务器: %@. 用户: %@. 状态: %@.";
 "subscriptions.main.userview.hint" = "双击变更状态";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
+++ b/Rocket.Chat/Resources/zh-Hant.lproj/VoiceOver.strings
@@ -28,6 +28,8 @@
 "subscriptions.main.userview.value" = "伺服器: %@. 訊息: %@. 狀態: %@.";
 "subscriptions.main.userview.hint" = "點擊兩下變更狀態";
 "subscriptions.main.channel.hint" = "Double tap to enter"; // TODO
+"subscriptions.server_button.hint" = "Double tap to add or change server"; // TODO
+"subscriptions.server_button.close.hint" = "Double tap to close the server menu"; // TODO
 
 // MARK: Preferences
 "preferences.profile.edit.label" = "Profile picture"; // TODO

--- a/Rocket.Chat/Views/Subscriptions/ServersListView.swift
+++ b/Rocket.Chat/Views/Subscriptions/ServersListView.swift
@@ -21,6 +21,7 @@ final class ServersListView: UIView {
     @IBOutlet weak var labelTitle: UILabel! {
         didSet {
             labelTitle.text = viewModel.title
+            labelTitle.accessibilityTraits = .header
         }
     }
 

--- a/Rocket.Chat/Views/Subscriptions/SubscriptionsTitleView.swift
+++ b/Rocket.Chat/Views/Subscriptions/SubscriptionsTitleView.swift
@@ -30,6 +30,9 @@ final class SubscriptionsTitleView: UIView {
             buttonServer.semanticContentAttribute = .forceRightToLeft
             buttonServer.layer.cornerRadius = 5
             buttonServer.layer.masksToBounds = true
+
+            buttonServer.isAccessibilityElement = true
+            buttonServer.accessibilityTraits = .button
         }
     }
 
@@ -47,8 +50,10 @@ final class SubscriptionsTitleView: UIView {
             if reverse, let cgImage = image.cgImage {
                 let rotatedImage = UIImage(cgImage: cgImage, scale: image.scale, orientation: .downMirrored)
                 buttonServer.setImage(rotatedImage, for: .normal)
+                buttonServer.accessibilityHint = VOLocalizedString("subscriptions.server_button.close.hint")
             } else {
                 buttonServer.setImage(image, for: .normal)
+                buttonServer.accessibilityHint = VOLocalizedString("subscriptions.server_button.hint")
             }
         }
     }


### PR DESCRIPTION
@RocketChat/ios

- [x] Adding a new server follows the same steps as from the main authentication screen, with the option of sign up and login. It has been covered in the previous project.

- [x] Servers can be added and changed using the ServersListView.
- [x] However, instead of tapping the current server, double tapping on Messages opens  and closes the ServersListView instead, which needs to be changed. 
- [x] Adding a comma between the accessibility label of Rocket.Chat and serverURL sounds a bit better by creating pause in VoiceOver dictation.
- [x] Accessibility notifications for screen and layout changes