### PR TITLE
[FIX] Update info request to use the /api/info endpoint

### DIFF
--- a/Rocket.Chat/API/Requests/General/InfoRequest.swift
+++ b/Rocket.Chat/API/Requests/General/InfoRequest.swift
@@ -12,11 +12,11 @@ import SwiftyJSON
 final class InfoRequest: APIRequest {
     typealias APIResourceType = InfoResource
 
-    let path = "/api/v1/info"
+    let path = "/api/info"
 }
 
 final class InfoResource: APIResource {
     var version: String? {
-        return raw?["info"]["version"].string
+        return raw?["version"].string
     }
 }

--- a/Rocket.ChatTests/API/Clients/InfoClientSpec.swift
+++ b/Rocket.ChatTests/API/Clients/InfoClientSpec.swift
@@ -18,9 +18,7 @@ class InfoClientSpec: XCTestCase {
         let client = InfoClient(api: api)
 
         api.nextResult = JSON([
-            "info": [
-                "version": "0.59.3"
-            ],
+            "version": "0.59.3",
             "success": "true"
         ])
 

--- a/Rocket.ChatTests/API/Requests/General/InfoRequestSpec.swift
+++ b/Rocket.ChatTests/API/Requests/General/InfoRequestSpec.swift
@@ -23,24 +23,8 @@ class InfoRequestSpec: APITestCase {
     func testProperties() {
         let jsonString = """
         {
-            "success": true,
-            "info": {
-                "version": "0.47.0-develop",
-                "build": {
-                    "nodeVersion": "v4.6.2",
-                    "arch": "x64",
-                    "platform": "linux",
-                    "cpus": 4
-                },
-                "commit": {
-                    "hash": "5901cc7270e3587101631ee222def950d705c611",
-                    "date": "Thu Dec 1 19:08:01 2016 -0200",
-                    "author": "Gabriel Engel",
-                    "subject": "Merge branch 'develop' into experimental",
-                    "tag": "0.46.0",
-                    "branch": "experimental"
-                }
-            }
+            "version": "1.2.3-develop",
+            "success": true
         }
         """
 
@@ -48,6 +32,6 @@ class InfoRequestSpec: APITestCase {
 
         let resource = InfoResource(raw: json)
 
-        XCTAssertEqual(resource.version, "0.47.0-develop")
+        XCTAssertEqual(resource.version, "1.2.3-develop")
     }
 }

--- a/Rocket.ChatTests/Managers/Requests/InfoRequestHandlerSpec.swift
+++ b/Rocket.ChatTests/Managers/Requests/InfoRequestHandlerSpec.swift
@@ -71,7 +71,7 @@ class InfoRequestHandlerSpec: XCTestCase {
     }
 
     func testValidateServerResponseSuccess() {
-        let result = InfoResource(raw: ["info": ["version": "0.54.0"]])
+        let result = InfoResource(raw: ["version": "0.54.0"])
         instance.validateServerResponse(result: result)
         XCTAssertTrue(controller.isServerValid, "server is valid after validation for valid result")
         XCTAssertTrue(controller.isURLValid, "url is valid after validation for valid result")


### PR DESCRIPTION
The info endpoint `/api/v1/info` had been deprecated, and now removed with v2.0.0 release of Rocket.Chat . 

This PR changes the request to use the `/api/info` endpoint, introduced in place of the old one. 

PR: https://github.com/RocketChat/Rocket.Chat/pull/15197
Doc: https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/info/